### PR TITLE
Consolidate `MapController` options

### DIFF
--- a/src/components/GeoExporter/GeoExporter.js
+++ b/src/components/GeoExporter/GeoExporter.js
@@ -2,6 +2,7 @@ import React, { PropTypes, Component } from 'react';
 import { DropdownButton, MenuItem, ButtonGroup, Button, Modal } from 'react-bootstrap';
 
 import g from '../../core/geo';
+import ModalMixin from '../ModalMixin';
 
 
 var exportPolygon = function(area, format) {
@@ -37,26 +38,9 @@ export { GeoExporterDropdown as Dropdown };
 
 var GeoExporterModal = React.createClass({
 
+  mixins: [ModalMixin],
   propTypes: {
     area: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      showModal: false
-    };
-  },
-
-  close() {
-    this.setState({
-      showModal: false
-    });
-  },
-
-  open() {
-    this.setState({
-      showModal: true
-    });
   },
 
   render() {

--- a/src/components/GeoExporter/GeoExporter.js
+++ b/src/components/GeoExporter/GeoExporter.js
@@ -1,5 +1,5 @@
 import React, { PropTypes, Component } from 'react';
-import { DropdownButton, MenuItem, ButtonGroup, Button, Modal } from 'react-bootstrap';
+import { DropdownButton, MenuItem, ButtonGroup, Button, Glyphicon, Modal } from 'react-bootstrap';
 
 import g from '../../core/geo';
 import ModalMixin from '../ModalMixin';
@@ -47,14 +47,12 @@ var GeoExporterModal = React.createClass({
     return (
       <div>
 
-        <Button onClick={this.open}>
-          Export Polygon
-        </Button>
+        <Button onClick={this.open}><Glyphicon glyph="save-file" /></Button>
 
         <Modal show={this.state.showModal} onHide={this.close}>
 
           <Modal.Header closeButton>
-            <Modal.Title>Select Format</Modal.Title>
+            <Modal.Title>Export Polygon by Type</Modal.Title>
           </Modal.Header>
 
           <Modal.Body>

--- a/src/components/GeoExporter/GeoExporter.js
+++ b/src/components/GeoExporter/GeoExporter.js
@@ -47,7 +47,7 @@ var GeoExporterModal = React.createClass({
     return (
       <div>
 
-        <Button onClick={this.open}><Glyphicon glyph="save-file" /></Button>
+        <Button onClick={this.open} title={this.props.title}><Glyphicon glyph="save-file" /></Button>
 
         <Modal show={this.state.showModal} onHide={this.close}>
 

--- a/src/components/GeoLoader/GeoLoader.js
+++ b/src/components/GeoLoader/GeoLoader.js
@@ -1,5 +1,5 @@
 import React, { PropTypes, Component } from 'react';
-import { Input, Button, Modal } from 'react-bootstrap';
+import { Input, Button, Glyphicon, Modal } from 'react-bootstrap';
 
 import g from '../../core/geo';
 import ModalMixin from '../ModalMixin';
@@ -28,9 +28,7 @@ var GeoLoader = React.createClass({
     return (
       <div>
 
-        <Button onClick={this.open}>
-          Import Polygon
-        </Button>
+        <Button onClick={this.open}><Glyphicon glyph="open-file" /></Button>
 
         <Modal show={this.state.showModal} onHide={this.close}>
 

--- a/src/components/GeoLoader/GeoLoader.js
+++ b/src/components/GeoLoader/GeoLoader.js
@@ -2,6 +2,7 @@ import React, { PropTypes, Component } from 'react';
 import { Input, Button, Modal } from 'react-bootstrap';
 
 import g from '../../core/geo';
+import ModalMixin from '../ModalMixin';
 
 /*
 
@@ -13,26 +14,9 @@ Calls callback with resulting geojson
 
 var GeoLoader = React.createClass({
 
+  mixins: [ModalMixin],
   propTypes: {
     onLoadArea: React.PropTypes.func.isRequired,
-  },
-
-  getInitialState() {
-    return {
-      showModal: false
-    };
-  },
-
-  close() {
-    this.setState({
-      showModal: false
-    });
-  },
-
-  open() {
-    this.setState({
-      showModal: true
-    });
   },
 
   importPolygon: function(file) {

--- a/src/components/GeoLoader/GeoLoader.js
+++ b/src/components/GeoLoader/GeoLoader.js
@@ -28,7 +28,7 @@ var GeoLoader = React.createClass({
     return (
       <div>
 
-        <Button onClick={this.open}><Glyphicon glyph="open-file" /></Button>
+        <Button onClick={this.open} title={this.props.title}><Glyphicon glyph="open-file" /></Button>
 
         <Modal show={this.state.showModal} onHide={this.close}>
 

--- a/src/components/MapController/MapController.css
+++ b/src/components/MapController/MapController.css
@@ -7,7 +7,6 @@
 
 .controls {
     position: absolute;
-    top: 0;
-    left: 75px;
-    right: 30px;
+    top: 5px;
+    right: 5px;
 }

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -155,7 +155,7 @@ var MapController = React.createClass({
           </Col>
         </Row>
 
-        <Modal show={this.state.showModal} onHide={this.close} animation="false" >
+        <Modal show={this.state.showModal} onHide={this.close} >
 
           <Modal.Header closeButton>
             <Modal.Title>Map Options</Modal.Title>

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -157,10 +157,17 @@ var MapController = React.createClass({
           </Modal.Header>
 
           <Modal.Body>
-            <TimeOfYearSelector onChange={this.updateTime} />
-            <Selector label={"Dataset"} onChange={this.updateDataset} items={ids} />
-            <Selector label={"Color pallette"} onChange={this.updateSelection.bind(this, 'styles')} items={pallettes} />
-            <Selector label={"Color scale"} onChange={this.updateSelection.bind(this, 'logscale')} items={color_scales} />
+            <TimeOfYearSelector onChange={this.updateTime}
+                                value={this.state.timeidx} />
+            <Selector label={"Dataset"} onChange={this.updateDataset}
+                      items={ids} value={this.state.dataset} />
+            <Selector label={"Color pallette"}
+                      onChange={this.updateSelection.bind(this, 'styles')}
+                      items={pallettes} value={this.state.styles} />
+            <Selector label={"Color scale"}
+                      onChange={this.updateSelection.bind(this, 'logscale')}
+                      items={color_scales} value={this.state.logscale} />
+
             <GeoExporter.Modal area={this.state.area} />
             <GeoLoader onLoadArea={this.handleSetArea} />
           </Modal.Body>

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -145,9 +145,9 @@ var MapController = React.createClass({
 
               <div className={styles.controls} class="btn-group-vertical" role="group">
                 <ButtonGroup vertical>
-                  <Button onClick={this.open}><Glyphicon glyph="menu-hamburger" /></Button>
-                  <GeoExporter.Modal area={this.state.area} />
-                  <GeoLoader onLoadArea={this.handleSetArea} />
+                  <Button onClick={this.open} title="Map settings"><Glyphicon glyph="menu-hamburger" /></Button>
+                  <GeoExporter.Modal area={this.state.area} title="Export polygon" />
+                  <GeoLoader onLoadArea={this.handleSetArea} title="Import polygon" />
                 </ButtonGroup>
               </div>
               </CanadaMap>

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -1,5 +1,5 @@
 import React, { PropTypes, Component } from 'react';
-import { Row, Col } from 'react-bootstrap';
+import { Row, Col, Button, Glyphicon, Modal } from 'react-bootstrap';
 import _ from 'underscore';
 import urljoin from 'url-join';
 import saveAs from 'filesaver.js';
@@ -13,11 +13,13 @@ import TimeOfYearSelector from '../Selector/TimeOfYearSelector';
 import GeoExporter from '../GeoExporter';
 import GeoLoader from '../GeoLoader';
 import g from '../../core/geo';
+import ModalMixin from '../ModalMixin';
 
 import styles from './MapController.css';
 
 var MapController = React.createClass({
 
+  mixins: [ModalMixin],
   propTypes: {
     variable: React.PropTypes.string,
     meta: React.PropTypes.array,
@@ -140,32 +142,35 @@ var MapController = React.createClass({
               variable={this.state.variable}
               onSetArea={this.handleSetArea}
               area={this.state.area}>
+
               <div className={styles.controls}>
-                <Row>
-                  <Col lg={4} md={4}>
-                    <TimeOfYearSelector onChange={this.updateTime} />
-                  </Col>
-                  <Col lg={4} md={4}>
-                    <Selector label={"Dataset"} onChange={this.updateDataset} items={ids} />
-                  </Col>
-                  <Col lg={4} md={4}>
-                    <GeoExporter.Modal area={this.state.area} />
-                    <GeoLoader onLoadArea={this.handleSetArea} />
-                  </Col>
-                </Row>
-                <Row>
-                  <Col lg={4} md={4}>
-                    <Selector label={"Color pallette"} onChange={this.updateSelection.bind(this, 'styles')} items={pallettes} />
-                  </Col>
-                  <Col lg={4} md={4}>
-                    <Selector label={"Color scale"} onChange={this.updateSelection.bind(this, 'logscale')} items={color_scales} />
-                  </Col>
-                </Row>
+                <Button onClick={this.open}><Glyphicon glyph="menu-hamburger" /></Button>
               </div>
               </CanadaMap>
             </div>
           </Col>
         </Row>
+        <Modal show={this.state.showModal} onHide={this.close}>
+
+          <Modal.Header closeButton>
+            <Modal.Title>Map Options</Modal.Title>
+          </Modal.Header>
+
+          <Modal.Body>
+            <TimeOfYearSelector onChange={this.updateTime} />
+            <Selector label={"Dataset"} onChange={this.updateDataset} items={ids} />
+            <Selector label={"Color pallette"} onChange={this.updateSelection.bind(this, 'styles')} items={pallettes} />
+            <Selector label={"Color scale"} onChange={this.updateSelection.bind(this, 'logscale')} items={color_scales} />
+            <GeoExporter.Modal area={this.state.area} />
+            <GeoLoader onLoadArea={this.handleSetArea} />
+          </Modal.Body>
+
+          <Modal.Footer>
+            <Button onClick={this.close}>Close</Button>
+          </Modal.Footer>
+
+        </Modal>
+
       </div>
     )
   }

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -1,5 +1,5 @@
 import React, { PropTypes, Component } from 'react';
-import { Row, Col, Button, Glyphicon, Modal } from 'react-bootstrap';
+import { Row, Col, Button, ButtonGroup, Glyphicon, Modal } from 'react-bootstrap';
 import _ from 'underscore';
 import urljoin from 'url-join';
 import saveAs from 'filesaver.js';
@@ -143,14 +143,19 @@ var MapController = React.createClass({
               onSetArea={this.handleSetArea}
               area={this.state.area}>
 
-              <div className={styles.controls}>
-                <Button onClick={this.open}><Glyphicon glyph="menu-hamburger" /></Button>
+              <div className={styles.controls} class="btn-group-vertical" role="group">
+                <ButtonGroup vertical>
+                  <Button onClick={this.open}><Glyphicon glyph="menu-hamburger" /></Button>
+                  <GeoExporter.Modal area={this.state.area} />
+                  <GeoLoader onLoadArea={this.handleSetArea} />
+                </ButtonGroup>
               </div>
               </CanadaMap>
             </div>
           </Col>
         </Row>
-        <Modal show={this.state.showModal} onHide={this.close}>
+
+        <Modal show={this.state.showModal} onHide={this.close} animation="false" >
 
           <Modal.Header closeButton>
             <Modal.Title>Map Options</Modal.Title>
@@ -168,8 +173,6 @@ var MapController = React.createClass({
                       onChange={this.updateSelection.bind(this, 'logscale')}
                       items={color_scales} value={this.state.logscale} />
 
-            <GeoExporter.Modal area={this.state.area} />
-            <GeoLoader onLoadArea={this.handleSetArea} />
           </Modal.Body>
 
           <Modal.Footer>

--- a/src/components/ModalMixin/ModalMixin.js
+++ b/src/components/ModalMixin/ModalMixin.js
@@ -1,0 +1,23 @@
+var ModalMixin = {
+
+  getInitialState() {
+    return {
+      showModal: false
+    };
+  },
+
+  close() {
+    this.setState({
+      showModal: false
+    });
+  },
+
+  open() {
+    this.setState({
+      showModal: true
+    });
+  },
+
+};
+
+export default ModalMixin;

--- a/src/components/ModalMixin/package.json
+++ b/src/components/ModalMixin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ModalMixin",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./ModalMixin.js"
+}

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -5,7 +5,8 @@ var Selector = React.createClass({
   getDefaultProps: function() {
     return {
       label: "Selection",
-      items: []
+      items: [],
+      value: "",
     };
   },
 
@@ -15,7 +16,7 @@ var Selector = React.createClass({
 
   render: function() {
     return (
-      <Input type="select" label={this.props.label} onChange={this.handleChange}>
+      <Input type="select" label={this.props.label} onChange={this.handleChange} value={this.props.value}>
       {
         this.props.items.map(function(item) {
           return Array.isArray(item) ? <option value={item[0]} key={item[0]}>{item[1]}</option> : <option value={item} key={item}>{item}</option>;

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -16,7 +16,7 @@ var Selector = React.createClass({
 
   render: function() {
     return (
-      <Input type="select" label={this.props.label} onChange={this.handleChange} value={this.props.value}>
+      <Input type="select" label={this.props.label} onChange={this.handleChange} value={this.props.value ? this.props.value : undefined}>
       {
         this.props.items.map(function(item) {
           return Array.isArray(item) ? <option value={item[0]} key={item[0]}>{item[1]}</option> : <option value={item} key={item}>{item}</option>;

--- a/src/components/Selector/TimeOfYearSelector.js
+++ b/src/components/Selector/TimeOfYearSelector.js
@@ -9,7 +9,7 @@ var timesofyear = [[0, 'January'], [1, 'February'], [2, 'March'],
 
 var TimeOfYearSelector = React.createClass({
   render: function() {
-    return (<Selector label="Time of year" onChange={this.props.onChange} items={timesofyear} />);
+    return (<Selector label="Time of year" onChange={this.props.onChange} items={timesofyear} value={this.props.value} />);
   }
 });
 


### PR DESCRIPTION
This PR takes all of the configuration options (four different selectors) and the input/export buttons and puts them into modals. This gets uncommonly used options out of the way and clears up real estate on the map. Fixes #19 