### PR TITLE
Draw map only if dataset has been set

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-bootstrap": "^0.27.3",
     "react-dom": "^0.14.2",
     "react-hot-loader": "^1.3.0",
+    "react-loader": "^2.2.0",
     "react-tabs": "^0.5.1",
     "shp-write": "^0.2.5",
     "shpjs": "^3.3.1",

--- a/src/components/Map/CanadaMap.js
+++ b/src/components/Map/CanadaMap.js
@@ -94,7 +94,6 @@ var CanadaMap = React.createClass({
         });
 
         var datalayerName = "Climate raster";
-        //FIXME - Problem: ncWMS layer 404s if we don't provide a dataset/variable. Solution: conditionally add layer to map
         var ncwmsLayer =  this.ncwmsLayer = new L.tileLayer.wms(NCWMS_URL, this.getWMSParams()).addTo(map);
 
         var drawnItems = this.drawnItems = new L.FeatureGroup();

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -3,6 +3,7 @@ import { Row, Col, Button, ButtonGroup, Glyphicon, Modal } from 'react-bootstrap
 import _ from 'underscore';
 import urljoin from 'url-join';
 import saveAs from 'filesaver.js';
+import Loader from 'react-loader';
 
 import classNames from 'classnames';
 
@@ -129,21 +130,27 @@ var MapController = React.createClass({
       return a[1] > b[1] ? 1 : -1;
     });
 
-    return (
-      <div>
-        <Row>
-          <Col lg={12}>
-            <div className={styles.map}>
-
-              <CanadaMap
+    var map
+    if (this.state.dataset) {
+      map = <CanadaMap
               logscale={this.state.logscale}
               styles={this.state.styles}
               time={this.state.wmstime}
               dataset={this.state.dataset}
               variable={this.state.variable}
               onSetArea={this.handleSetArea}
-              area={this.state.area}>
-              </CanadaMap>
+              area={this.state.area} />
+    } else {
+      map = <Loader />
+    }
+
+    return (
+      <div>
+        <Row>
+          <Col lg={12}>
+            <div className={styles.map}>
+
+              {map}
 
               <div className={styles.controls}>
                 <ButtonGroup vertical>


### PR DESCRIPTION
This has bugged me for a while. Stops leaflet from looking for 'undefined' datasets and variables.