### PR TITLE
Add ncWMSAutoscaleControl and add it to the map

### DIFF
--- a/src/components/Map/CanadaMap.js
+++ b/src/components/Map/CanadaMap.js
@@ -5,6 +5,7 @@ import { saveAs } from 'filesaver.js';
 
 import utils from './utils';
 import NcWMSColorbarControl from '../../core/leaflet-ncwms-colorbar';
+import NcWMSAutoscaleControl from '../../core/leaflet-ncwms-autoset-colorscale';
 
 import styles from './map.css';
 
@@ -222,6 +223,7 @@ var CanadaMap = React.createClass({
     map.addControl(new PrintControl());
 
     map.addControl(new NcWMSColorbarControl(this.ncwmsLayer));
+    map.addControl(new NcWMSAutoscaleControl(this.ncwmsLayer));
   },
 
   componentWillUnmount: function () {

--- a/src/components/Map/CanadaMap.js
+++ b/src/components/Map/CanadaMap.js
@@ -223,7 +223,9 @@ var CanadaMap = React.createClass({
     map.addControl(new PrintControl());
 
     map.addControl(new NcWMSColorbarControl(this.ncwmsLayer));
-    map.addControl(new NcWMSAutoscaleControl(this.ncwmsLayer));
+    map.addControl(new NcWMSAutoscaleControl(this.ncwmsLayer, {
+      position: 'bottomright',
+    }));
   },
 
   componentWillUnmount: function () {

--- a/src/core/leaflet-ncwms-autoset-colorscale.js
+++ b/src/core/leaflet-ncwms-autoset-colorscale.js
@@ -22,6 +22,7 @@ var ncWMSAutoscaleControl = L.Control.extend({
 
     this.button = L.DomUtil.create('a', '', this.container);
     this.button.innerHTML = 'AS';
+    this.button.style.fontWeight = 'bold';
 
     // Set up event handling
     L.DomEvent

--- a/src/core/leaflet-ncwms-autoset-colorscale.js
+++ b/src/core/leaflet-ncwms-autoset-colorscale.js
@@ -1,0 +1,59 @@
+/*
+ * Relies upon global Leaflet variable 'L'
+ * Compatible with any ncWMS server which fulfills the `minmax`
+ * `GetMetadata` requests.
+*/
+
+var ncWMSAutoscaleControl = L.Control.extend({
+  options: {
+    position: 'topleft',
+  },
+
+  initialize: function (layer, options) {
+    this.layer = layer;
+    L.Util.setOptions(this, options);
+  },
+
+  onAdd: function () {
+    // Container element
+    this.container = L.DomUtil.create('div', 'leaflet-control leaflet-bar');
+    this.container.title = 'Autoscale map color scale to current view';
+    this.container.style.cursor = 'pointer';
+
+    this.button = L.DomUtil.create('a', '', this.container);
+    this.button.innerHTML = 'AS';
+
+    // Set up event handling
+    L.DomEvent
+      .addListener(this.container, 'click', L.DomEvent.stopPropagation)
+      .addListener(this.container, 'click', L.DomEvent.preventDefault)
+      .addListener(this.container, 'click', this.autoscale, this);
+
+    return this.container;
+  },
+
+  autoscale: function () {
+    /*
+    Get min/max for current view then update layer params
+    */
+
+    $.ajax(this.layer._url, {
+      context: this,
+      crossDomain: true,
+      data: {
+        request: 'GetMetadata',
+        item: 'minmax',
+        layers: this.layer.wmsParams.layers,
+        bbox: this.layer._map.getBounds().toBBoxString(),
+        time: this.layer.wmsParams.time,
+        srs: this.layer.wmsParams.srs,
+        width: 100,
+        height: 100,
+      },
+    }).done(function (data) {
+      this.layer.setParams({ colorscalerange: data.min + ',' + data.max });
+    });
+  },
+});
+
+export default ncWMSAutoscaleControl;


### PR DESCRIPTION
Adds a Leaflet control to automatically set an ncWMS layer colorscalerange WMS parameter to the min/max of the current map view.

(Partially) Fixes #33.