### PR TITLE
Resolves #60

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --host 0.0.0.0",
     "build": "webpack --progress --colors",
-    "test": "jest --verbose",
+    "test": "jest --verbose --runInBand",
     "lint": "eslint .",
     "lint:glob": "eslint"
   },


### PR DESCRIPTION
Requires jest to run tests serially instead of parallelizing them. Hopefully resolves the ongoing issue with intermittent CI test failures.