### PR TITLE
Error message when no data available. Fix #63

### DIFF
--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -38,11 +38,26 @@ var ModalMixin = {
 
 
   componentWillReceiveProps: function (nextProps) {
-    this.setState({
-      timeSeriesDatasetId: nextProps.meta[0].unique_id,
-    });
-    if (this.verifyParams(nextProps)) {
+    if (this.verifyParams(nextProps) && nextProps.meta.length > 0) {
+      this.setState({
+        timeSeriesDatasetId: nextProps.meta[0].unique_id,
+      });
       this.getData(nextProps);
+    }
+    else { //Didn't receive any valid data.
+      //Most likely cause in production would be the user selecting
+      //parameters (rcp, model, variable) for which no datasets have been
+      //added to the database yet.
+      //In development, could be API or ensemble misconfiguration, database down.
+      //Display an error message on each viewer in use by this datacontroller.
+      var text = "No data matching selected parameters available";
+      var viewers = ["StatsTable", "ClimoSeries", "TimeSeries"];
+      _.each(viewers, function(viewer) {
+        var viewerFunction = `set${viewer}NoDataMessage`;
+        if(typeof this[viewerFunction] == 'function'){
+          this[viewerFunction](text);
+        }
+      }, this);
     }
   },
 

--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -51,13 +51,14 @@ var ModalMixin = {
       //In development, could be API or ensemble misconfiguration, database down.
       //Display an error message on each viewer in use by this datacontroller.
       var text = "No data matching selected parameters available";
-      var viewers = ["StatsTable", "ClimoSeries", "TimeSeries"];
-      _.each(viewers, function(viewer) {
-        var viewerFunction = `set${viewer}NoDataMessage`;
-        if(typeof this[viewerFunction] == 'function'){
-          this[viewerFunction](text);
+      var viewerMessageDisplays = [this.setStatsTableNoDataMessage,
+                                   this.setClimoSeriesNoDataMessage,
+                                   this.setTimeSeriesNoDataMessage];
+      _.each(viewerMessageDisplays, function(display) {
+        if(typeof display == 'function') {
+          display(text);
         }
-      }, this);
+      });
     }
   },
 

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -138,7 +138,19 @@ var MapController = React.createClass({
       sPalette = 'x-Occam';
     }
     
-    this.loadMap(nextProps, defaultDataset, sPalette, cPalette);   
+    if(nextProps.meta.length > 0) {
+      this.loadMap(nextProps, defaultDataset, sPalette, cPalette);
+    }
+    else {
+      //haven't received any displayable data. Probably means user has selected
+      //parameters for a dataset that isn't in the database.
+      //Clear the map to prevent the previously-generated map causing confusion
+      //if the user doesn't notice the footer.
+      this.setState({
+        times: undefined,
+        timeidx: undefined
+      });
+    }
   },
   
   //update state with all the information needed to display


### PR DESCRIPTION
Clears maps and graphs when user selects a model/variables/emission scenario combination that is not present in the database. Before this update, the previously selected valid data would continue to be displayed, possibly causing confusion.

[Test docker for this PR](http://docker2.pcic.uvic.ca:8604/climo). Changing either the model or the emissions scenario away from starting values demonstrates the new behaviour.