### PR TITLE
Add logarithmic scales to map viewer. Fixes #64

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "PCIC Climate Explorer front end application",
   "main": "index.js",
   "scripts": {
+    "prestart": "if [ ! -f ./variable-options.yaml ]; then touch ./variable-options.yaml; fi",
     "start": "webpack-dev-server --host 0.0.0.0",
     "build": "webpack --progress --colors",
     "test": "jest --verbose --runInBand",
@@ -14,10 +15,12 @@
   "license": "GPL-3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pacificclimate/climate-explorer"
+    "url": "https://github.com/pacificclimate/climate-explorer-frontend"
   },
+  "bugs": "https://github.com/pacificclimate/climate-explorer-frontend/issues",
   "//": [
-    "fbjs mocked due to https://github.com/facebook/jest/issues/554"
+    "fbjs mocked due to https://github.com/facebook/jest/issues/554",
+    "config file variable-options.yaml created by prestart if not present"
   ],
   "jest": {
     "rootDir": "./src",
@@ -82,6 +85,7 @@
     "underscore": "^1.8.3",
     "url-join": "0.0.1",
     "url-loader": "^0.5.6",
+    "yml-loader": ">=2.0",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.1",
     "wellknown": "^0.4.1"

--- a/src/components/Map/CanadaMap.js
+++ b/src/components/Map/CanadaMap.js
@@ -96,8 +96,8 @@ var CanadaMap = React.createClass({
         var min = Math.max(this.layerRange.raster.min, Number.EPSILON);
         var max = Math.max(this.layerRange.raster.max, Number.EPSILON * 2);
         params.colorscalerange = `${min},${max}`;
-        params.abovemaxcolor="0x000000";
-        params.belowmincolor="0x000000";
+        params.abovemaxcolor="transparent";
+        params.belowmincolor="transparent";
       }
     }
     else if (layer == "isoline") {
@@ -110,8 +110,8 @@ var CanadaMap = React.createClass({
         var min = Math.max(this.layerRange.isoline.min, Number.EPSILON);
         var max = Math.max(this.layerRange.isoline.max, Number.EPSILON * 2);
         params.colorscalerange = `${min},${max}`;
-        params.abovemaxcolor="0x000000";
-        params.belowmincolor="0x000000";
+        params.abovemaxcolor="transparent";
+        params.belowmincolor="transparent";
       }
     }
     return params;    
@@ -192,7 +192,7 @@ var CanadaMap = React.createClass({
 
   //initializes the map, loads data, and generates controls
   //NOTE: the buttons that open the "Map Settings" menu are
-  //actually provided by MapController, *not* this component.
+  //actually provided by MapController, not this component.
   //CanadaMap draws colourbars, the autoscale button, and the
   //area drawing and manipulation controls.
   componentDidMount: function () {

--- a/src/components/Map/CanadaMap.js
+++ b/src/components/Map/CanadaMap.js
@@ -37,10 +37,10 @@ var CanadaMap = React.createClass({
 
   propTypes: {
     rasterPalette: React.PropTypes.string,
-    rasterLogscale: React.PropTypes.bool,
+    rasterLogscale: React.PropTypes.string,
     isolinePalette: React.PropTypes.string,
     numberOfContours: React.PropTypes.number,
-    isolineLogscale: React.PropTypes.bool,
+    isolineLogscale: React.PropTypes.string,
     rasterDataset: React.PropTypes.string,
     isolineDataset: React.PropTypes.string,
     rasterVariable: React.PropTypes.string,

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -126,8 +126,11 @@ var MapController = React.createClass({
   componentWillReceiveProps: function (nextProps) {
     var newVariableId = nextProps.meta[0].variable_id;
     var oldVariableId = this.props.meta.length > 0 ? this.props.meta[0].variable_id : undefined;
-    var newComparandId = nextProps.comparandMeta.length > 0 ? nextProps.comparandMeta[0].variable_id : undefined;
-    var oldComparandId = this.props.comparandMeta.length > 0 ? this.props.comparandMeta[0].variable_id : undefined;
+    var hasComparand = nextProps.comparandMeta && nextProps.comparandMeta.length > 0;
+    if(hasComparand){
+      var newComparandId = nextProps.comparandMeta.length > 0 ? nextProps.comparandMeta[0].variable_id : undefined;
+      var oldComparandId = this.props.comparandMeta.length > 0 ? this.props.comparandMeta[0].variable_id : undefined;
+    }
     var defaultDataset = nextProps.meta[0];
     this.layerRange = {};
     
@@ -137,9 +140,9 @@ var MapController = React.createClass({
     });
 
     //check to see whether the variables displayed have been switched.
-    //if so, unset logarithmic display.
+    //if so, unset logarithmic display; default is linear.
     var switchVariable = !_.isEqual(newVariableId, oldVariableId);
-    var switchComparand = !_.isEqual(newComparandId, oldComparandId);
+    var switchComparand = hasComparand && !_.isEqual(newComparandId, oldComparandId);
 
     //set display colours. In order of preference:
     //1. colours received by prop

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -123,22 +123,33 @@ var MapController = React.createClass({
   //same data, though a user can choose to view different data with 
   //each viewer if they like.
   componentWillReceiveProps: function (nextProps) {
+    var variableOptions = require('../../../variable-options.yaml');
+    var newVariableId = nextProps.meta[0].variable_id;
+    var oldVariableId = this.props.meta.length > 0 ? this.props.meta[0].variable_id : undefined;
     var defaultDataset = nextProps.meta[0];
     this.layerRange = {};
     
     //set display colours. In order of preference:
     //1. colours received by prop
     //2. colours from state (set by the user or this function previously)
-    //3. defaults (raster rainbow if a single dataset, 
+    //3. colours specified in variables.yaml, if applicable (raster only)
+    //4. defaults (raster rainbow if a single dataset,
     //             raster greyscale and isolines rainbow for 2)
     var sPalette, cPalette;
     if(nextProps.rasterPalette) {
       sPalette = nextProps.rasterPalette;
       cPalette = nextProps.isolinePalette;
     }
-    else if(this.state.rasterPalette) {
+    else if(this.state.rasterPalette && _.isEqual(newVariableId, oldVariableId)) {
       sPalette = this.state.rasterPalette;
       cPalette = this.state.isolinePalette;
+    }
+    else if (nestedAttributeIsDefined(variableOptions, newVariableId, "defaultRasterPalette"))
+    {
+      sPalette = variableOptions[newVariableId].defaultRasterPalette;
+      if(nextProps.comparandMeta) {
+        cPalette = 'x-Occam';
+      }
     }
     else if(nextProps.comparandMeta){
       sPalette = 'seq-Greys';

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -30,7 +30,8 @@ import GeoLoader from '../GeoLoader';
 import g from '../../core/geo';
 import ModalMixin from '../ModalMixin';
 import { timestampToTimeOfYear,
-         nestedAttributeIsDefined } from '../../core/util';
+         nestedAttributeIsDefined,
+         getVariableOptions} from '../../core/util';
 
 import styles from './MapController.css';
 
@@ -123,7 +124,6 @@ var MapController = React.createClass({
   //same data, though a user can choose to view different data with 
   //each viewer if they like.
   componentWillReceiveProps: function (nextProps) {
-    var variableOptions = require('../../../variable-options.yaml');
     var newVariableId = nextProps.meta[0].variable_id;
     var oldVariableId = this.props.meta.length > 0 ? this.props.meta[0].variable_id : undefined;
     var defaultDataset = nextProps.meta[0];
@@ -144,9 +144,9 @@ var MapController = React.createClass({
       sPalette = this.state.rasterPalette;
       cPalette = this.state.isolinePalette;
     }
-    else if (nestedAttributeIsDefined(variableOptions, newVariableId, "defaultRasterPalette"))
+    else if (!_.isUndefined(getVariableOptions(newVariableId, "defaultRasterPalette")))
     {
-      sPalette = variableOptions[newVariableId].defaultRasterPalette;
+      sPalette = getVariableOptions(newVariableId, "defaultRasterPalette");
       if(nextProps.comparandMeta) {
         cPalette = 'x-Occam';
       }
@@ -261,7 +261,6 @@ var MapController = React.createClass({
     }
 
     var override = false;
-    var variableOptions = require('../../../variable-options.yaml');
     var variableName;
 
     if(layer == "raster"){
@@ -271,9 +270,7 @@ var MapController = React.createClass({
       variableName = this.props.comparandMeta[0].variable_id;
     }
 
-    var override = nestedAttributeIsDefined(variableOptions, variableName,
-                                           "overrideLogarithmicScale")
-                   && variableOptions[variableName].overrideLogarithmicScale;
+    var override = getVariableOptions(variableName, "overrideLogarithmicScale");
     var min = -1;
 
     if(nestedAttributeIsDefined(this.layerRange, layer, "min")) {

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -1,3 +1,19 @@
+/**********************************************************************
+ * Selector.js - a dropdown menu component for users to make a choice
+ *
+ * Props:
+ *   onChange - callback function to ping when user selects something
+ *   disabled - if true, selector will be greyed out and noninteractive
+ *   value - the "already selected" value to be displayed initially
+ *   label - title that will be printed above the dropdown
+ *   items - the array of possible choices. Can be either:
+ *             * an array of strings - the string user picks is sent to
+ *               callback
+ *             * a array of tuples: the 1st item in the tuple will be
+ *               the string displayed the users, the 0th is what is sent
+ *               to the callback if the displayed string is selected.
+ **********************************************************************/
+
 import React from 'react';
 import { Input } from 'react-bootstrap';
 
@@ -8,6 +24,7 @@ var Selector = React.createClass({
     label: React.PropTypes.string,
     items: React.PropTypes.array,
     value: React.PropTypes.node,
+    disabled: React.PropTypes.bool
   },
 
   getDefaultProps: function () {
@@ -15,6 +32,7 @@ var Selector = React.createClass({
       label: 'Selection',
       items: [],
       value: '',
+      disabled: false,
     };
   },
 
@@ -29,6 +47,7 @@ var Selector = React.createClass({
         label={this.props.label}
         onChange={this.handleChange}
         value={this.props.value ? this.props.value : undefined}
+        disabled={this.props.disabled}
       >
         {
           this.props.items.map(function (item) {

--- a/src/core/__tests__/chart-test.js
+++ b/src/core/__tests__/chart-test.js
@@ -45,9 +45,9 @@ describe('fixedPrecision', function () {
 });
 
 describe('makePrecisionBySeries', function () {
-  //this test fails because it relies on an external .yaml config file
-  //that isn't easily available during jest testing. In non-test usage
-  //the file is transformed and made available by webpack.
+  //this test fails and is skipped because it relies on an external 
+  //.yaml config file that isn't easily available during jest testing. 
+  //In non-test usage the file is transformed and made available by webpack.
   xit('reads the config file and applies its settings', function() {
     var precision = chart.makePrecisionBySeries({"testseries": "tasmin"});
     expect(precision(4.777, "testseries")).toEqual(4.8);

--- a/src/core/__tests__/chart-test.js
+++ b/src/core/__tests__/chart-test.js
@@ -30,7 +30,7 @@ describe ('formatYAxis', function () {
 });
 
 describe('fixedPrecision', function () {
-  it('formats a positive decimal number for user display', function () {
+  it('formats a positive number for user display', function () {
     var formatted = chart.fixedPrecision(6.22222);
     expect(formatted).toEqual(6.22);
   });
@@ -41,6 +41,20 @@ describe('fixedPrecision', function () {
   it('rounds a number for user display', function () {
     var formatted = chart.fixedPrecision(6.9999);
     expect(formatted).toEqual(7);
+  });
+});
+
+describe('makePrecisionBySeries', function () {
+  //this test fails because it relies on an external .yaml config file
+  //that isn't easily available during jest testing. In non-test usage
+  //the file is transformed and made available by webpack.
+  xit('reads the config file and applies its settings', function() {
+    var precision = chart.makePrecisionBySeries({"testseries": "tasmin"});
+    expect(precision(4.777, "testseries")).toEqual(4.8);
+  });
+  it('uses a default precision for unspecified variables', function () {
+    var precision = chart.makePrecisionBySeries({"testseries": "tasmin"});
+    expect(precision(4.777, "testseries")).toEqual(4.78);
   });
 });
 

--- a/src/core/__tests__/export-test.js
+++ b/src/core/__tests__/export-test.js
@@ -93,8 +93,8 @@ describe('generateDataCellsFromC3Graph', function () {
     expect(cells[1][0]).toBe("Monthly Mean");
     //spot check representative values
     expect(cells[1][13]).toBe("degC");
-    expect(cells[1][1]).toBe(-20.599000150601793);
-    expect(cells[1][12]).toBe(-16.96361296358877);
+    expect(cells[1][1]).toBe('-20.60');
+    expect(cells[1][12]).toBe('-16.96');
     //make sure nothing is undefined
     expect(validate.allDefinedArray(cells)).toBe(true);
   });
@@ -108,9 +108,9 @@ describe('generateDataCellsFromC3Graph', function () {
     expect(cells[2][0]).toBe("Seasonal Mean");
     expect(cells[3][0]).toBe("Yearly Mean");
     //spot check a couple representative values
-    expect(cells[3][6]).toBe(-2.671051067797724);
-    expect(cells[2][10]).toBe(-1.3596123480139706);
-    expect(cells[1][3]).toBe( -13.699929389799847);
+    expect(cells[3][6]).toBe('-2.67');
+    expect(cells[2][10]).toBe('-1.36');
+    expect(cells[1][3]).toBe('-13.70');
     //make sure nothing is undefined
     expect(validate.allDefinedArray(cells)).toBe(true);
   });
@@ -118,7 +118,7 @@ describe('generateDataCellsFromC3Graph', function () {
     var toExport = chart.dataToProjectedChangeGraph([mockAPI.tasmaxData]);
     var cells = exportdata.generateDataCellsFromC3Graph(toExport, "Run");
     expect(validate.isRectangularArray(cells, 2, 8)).toBe(true);
-    expect(cells[1][2]).toBe(-17.825752320828578);
+    expect(cells[1][2]).toBe('-17.83');
     expect(cells[1][7]).toBe('degC');
     expect(validate.allDefinedArray(cells)).toBe(true);
   });

--- a/src/core/__tests__/util-test.js
+++ b/src/core/__tests__/util-test.js
@@ -177,7 +177,20 @@ var mockAPI = require('./sample-API-results');
   });
 
   describe('timestampToTimeOfYear', function () {
-    
+    it('converts customary timestamps into monthly values', function () {
+      expect(util.timestampToTimeOfYear("1977-07-15T00:00:00Z")).toBe("July");
+      expect(util.timestampToTimeOfYear("1977-04-15T00:00:00Z")).toBe("April");
+    });
+    it('converts customary timestamps into seasonal values', function () {
+      expect(util.timestampToTimeOfYear("1977-07-16T00:00:00Z")).toBe("Summer-JJA");
+      expect(util.timestampToTimeOfYear("1977-04-16T00:00:00Z")).toBe("Spring-MAM");
+    });
+    it('converts customary timestamps into annual values', function () {
+      expect(util.timestampToTimeOfYear("1977-07-02T00:00:00Z")).toBe("Annual");
+    });
+    it('does not convert unrecognized timestamps', function () {
+      expect(util.timestampToTimeOfYear("1977-07-01T00:00:00Z")).toBe("1977-07-01T00:00:00Z");
+    });
   });
 
   describe('capitalizeWords', function () {
@@ -185,5 +198,17 @@ var mockAPI = require('./sample-API-results');
       expect(util.capitalizeWords("initial lowercase string")).toBe("Initial Lowercase String");
       expect(util.capitalizeWords("Initial uppercase")).toBe("Initial Uppercase");
       expect(util.capitalizeWords("string number the 3rd")).toBe("String Number The 3rd");
+    });
+  });
+
+  describe('nestedAttributeIsDefined', function () {
+    it('returns true when an attribute is defined', function () {
+      expect(util.nestedAttributeIsDefined({attribute: 0}, "attribute")).toBe(true);
+      expect(util.nestedAttributeIsDefined({attribute: {nested: 0}}, "attribute", "nested")).toBe(true);
+    });
+    it('returns false when an attribute is undefined', function () {
+      expect(util.nestedAttributeIsDefined({}, "missing")).toBe(false);
+      expect(util.nestedAttributeIsDefined({attribute: 0}, "missing")).toBe(false);
+      expect(util.nestedAttributeIsDefined({attribute: {nested: 0}}, "attribute", "missing")).toBe(false);
     });
   });

--- a/src/core/__tests__/util-test.js
+++ b/src/core/__tests__/util-test.js
@@ -150,6 +150,18 @@ var mockAPI = require('./sample-API-results');
       expect(util.validateAnnualCycleData({data: mockAPI.annualTasmaxTimeseries})).toEqual({data: mockAPI.annualTasmaxTimeseries});
     });
   });
+  
+  //Depends on an external .yml file, variable-options.yaml. 
+  //Under normal circumstances, webpack transforms the file and makes it
+  //accessible. It is theoretically possible to have jest run similar 
+  //transforms for testing, but I haven't gotten that working yet.
+  //Info about configuring jest to test webpack-dependent functionality:
+  //https://facebook.github.io/jest/docs/en/webpack.html
+  describe('getVariableOptions', function() {
+    xit('returns undefined for nonexistant variables', function () {});
+    xit('returns undefined for nonexistent options', function () {});
+    xit('returns the requested option', function () {});
+  });
 
   describe('timeIndexToTimeOfYear', function() {
     it('converts a time index into human-readable string', function () {

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -18,7 +18,8 @@ import _ from 'underscore';
 import moment from 'moment';
 import {PRECISION,
         extendedDateToBasicDate,
-        capitalizeWords} from './util';
+        capitalizeWords,
+        nestedAttributeIsDefined} from './util';
 
 /*****************************************************
  * 0. Helper functions used by both graph generators *
@@ -38,8 +39,30 @@ var formatYAxis = function (label) {
   };
 };
 
-//Simple formatting function for numbers to be displayed on the graph.
-var fixedPrecision = function (n) { return +n.toFixed(PRECISION);};
+/*
+ * Simple formatting function for numbers to be displayed on the graph.
+ * Used as a default when a more specialized formatting function isn't
+ * available; ignores all its inputs except the number to be formatted.
+ */
+var fixedPrecision = function (n, ...rest) { return +n.toFixed(PRECISION);};
+
+/*
+ * Accepts a object with seriesname:variable pairs.
+ * Returns a function that accepts a number and a series name, and formats
+ * the number according to precision set in the variable-options.yaml config
+ * file for the associated variable, or a default precision with
+ * util.PRECISION for variables with no precision options in the file.
+ */
+var makePrecisionBySeries = function (series) {
+  const variableOptions = require('../../variable-options.yaml');
+  var dictionary = {};
+  for(var s in series) {
+    var inConfig = nestedAttributeIsDefined(variableOptions, series[s], "decimalPrecision");
+    dictionary[s] = inConfig ? variableOptions[series[s]].decimalPrecision : PRECISION;
+  }
+
+  return function(n, series) {return +n.toFixed(dictionary[series])};
+};
 
 /*
  * This function returns a number-formatting function for use by the C3
@@ -51,17 +74,24 @@ var fixedPrecision = function (n) { return +n.toFixed(PRECISION);};
  * This function extracts unit names for each data series from the axis
  * labels, then returns a function that uses the series id passed by 
  * C3 to append a units string to each value.
+ *
+ * It optionally accepts a precisionFunction for more exact formatting of
+ * numbers. precisionFunction will be passed the number to format and the
+ * series id it belongs to.
  */
-var makeTooltipDisplayNumbersWithUnits = function(axes, axis) {
+var makeTooltipDisplayNumbersWithUnits = function(axes, axis, precisionFunction) {
   var unitsDictionary = {};
+  if(_.isUndefined(precisionFunction)) { //use a default.
+    precisionFunction = fixedPrecision;
+  }
   
   //build a dictionary between timeseries names and units
   for(var series in axes) {
     unitsDictionary[series] = axis[axes[series]].label.text;
   }
- 
+
   return function(value, ratio, id, index) {
-    return `${fixedPrecision(value)} ${unitsDictionary[id]}`;
+    return `${precisionFunction(value, id)} ${unitsDictionary[id]}`;
   };
 };
 
@@ -106,6 +136,7 @@ var timeseriesToAnnualCycleGraph = function(metadata, ...data) {
 
   var yUnits = "";
   var y2Units = "";
+  var seriesVariables = {};
   
   var getTimeseriesName = shortestUniqueTimeseriesNamingFunction(metadata, data);
   
@@ -116,6 +147,7 @@ var timeseriesToAnnualCycleGraph = function(metadata, ...data) {
     var timeseries = data[i];
     var timeseriesMetadata = _.find(metadata, function(m) {return m.unique_id === timeseries.id;});  
     var timeseriesName = getTimeseriesName(timeseriesMetadata);
+    seriesVariables[timeseriesName] = timeseriesMetadata.variable_id;
        
     //add the actual data to the graph
     c3Data.columns.push([timeseriesName].concat(getMonthlyData(timeseries.data, timeseriesMetadata.timescale)));
@@ -152,10 +184,11 @@ var timeseriesToAnnualCycleGraph = function(metadata, ...data) {
   if(y2Units) { 
     c3Axis.y2 = formatYAxis(y2Units);
     }
-    
+
+  var precision = makePrecisionBySeries(seriesVariables);
   var c3Tooltip = {format: {}};
   c3Tooltip.grouped = "true";
-  c3Tooltip.format.value = makeTooltipDisplayNumbersWithUnits(c3Data.axes, c3Axis);
+  c3Tooltip.format.value = makeTooltipDisplayNumbersWithUnits(c3Data.axes, c3Axis, precision);
   
   return {
     data: c3Data,
@@ -330,6 +363,7 @@ var dataToProjectedChangeGraph = function(data, contexts = []){
   var yUnits = "";
   var y2Units = "";
   
+  var seriesVariables = {};
   var nameSeries;
   
   if(data.length == 1) {
@@ -357,6 +391,7 @@ var dataToProjectedChangeGraph = function(data, contexts = []){
     //add each individual dataset from the API to the chart
     for(let run in call) {
       var runName = nameSeries(run, context);
+      seriesVariables[runName] = _.isEmpty(context) ? undefined : context.variable_id;
       var series = [runName];
       
       //if a given timestamp is present in some, but not all
@@ -397,10 +432,14 @@ var dataToProjectedChangeGraph = function(data, contexts = []){
   if(y2Units) { 
     c3Axis.y2 = formatYAxis(y2Units);
     }
-    
+
+  //Note: if context is empty (dataToProjectedChangeGraph was called with only
+  //one time series), variable-determined precision will not be available and
+  //numbers will be formatted with default precision.
+  var precision = makePrecisionBySeries(seriesVariables);
   var c3Tooltip = {format: {}};
   c3Tooltip.grouped = "true";
-  c3Tooltip.format.value = makeTooltipDisplayNumbersWithUnits(c3Data.axes, c3Axis);
+  c3Tooltip.format.value = makeTooltipDisplayNumbersWithUnits(c3Data.axes, c3Axis, precision);
   
   return {
     data: c3Data,

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -533,6 +533,6 @@ var timeseriesXAxis = {
 
 module.exports = { timeseriesToAnnualCycleGraph, dataToProjectedChangeGraph,
     //exported only for testing purposes:
-    formatYAxis, fixedPrecision, makeTooltipDisplayNumbersWithUnits,
+    formatYAxis, fixedPrecision, makePrecisionBySeries, makeTooltipDisplayNumbersWithUnits,
     getMonthlyData, shortestUniqueTimeseriesNamingFunction,
     getAllTimestamps, nameAPICallParametersFunction};

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -19,7 +19,8 @@ import moment from 'moment';
 import {PRECISION,
         extendedDateToBasicDate,
         capitalizeWords,
-        nestedAttributeIsDefined} from './util';
+        nestedAttributeIsDefined,
+        getVariableOptions} from './util';
 
 /*****************************************************
  * 0. Helper functions used by both graph generators *
@@ -54,11 +55,10 @@ var fixedPrecision = function (n, ...rest) { return +n.toFixed(PRECISION);};
  * util.PRECISION for variables with no precision options in the file.
  */
 var makePrecisionBySeries = function (series) {
-  const variableOptions = require('../../variable-options.yaml');
   var dictionary = {};
   for(var s in series) {
-    var inConfig = nestedAttributeIsDefined(variableOptions, series[s], "decimalPrecision");
-    dictionary[s] = inConfig ? variableOptions[series[s]].decimalPrecision : PRECISION;
+    var fromConfig = getVariableOptions(series[s], "decimalPrecision");
+    dictionary[s] = _.isUndefined(fromConfig) ? PRECISION : fromConfig;
   }
 
   return function(n, series) {return +n.toFixed(dictionary[series])};

--- a/src/core/leaflet-ncwms-colorbar.js
+++ b/src/core/leaflet-ncwms-colorbar.js
@@ -4,7 +4,7 @@
  * `layerDetails` `GetMetadata` requests.
 */
 import axios from 'axios';
-import {nestedAttributeIsDefined, PRECISION} from './util';
+import {getVariableOptions, PRECISION} from './util';
 
 var round = function (number, places) {
   return Math.round(number * Math.pow(10, places)) / Math.pow(10, places);
@@ -157,11 +157,10 @@ var ncWMSColorbarControl = L.Control.extend({
   //config file to determine decimal precision. Defaults to util.PRECISION
   getDecimalPrecision: function (layer = this.layer) {
     var places = PRECISION;
-    var variableOptions = require('../../variable-options.yaml');
     var variableName = layer.wmsParams.layers.split("/")[1];
 
-    if (nestedAttributeIsDefined(variableOptions, variableName, "decimalPrecision")) {
-      places = variableOptions[variableName].decimalPrecision;
+    if (getVariableOptions(variableName, "decimalPrecision") !== undefined) {
+      places = getVariableOptions(variableName, "decimalPrecision");
     }
     return places;
   },

--- a/src/core/leaflet-ncwms-colorbar.js
+++ b/src/core/leaflet-ncwms-colorbar.js
@@ -26,7 +26,6 @@ var ncWMSColorbarControl = L.Control.extend({
   initialize: function (layer, options) {
     this.layer = layer;
     options.decimalPlaces = this.getDecimalPrecision(layer);
-
     L.Util.setOptions(this, options);
   },
 

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -110,6 +110,30 @@ var validateAnnualCycleData = function(response) {
   return response;
 };
 
+/*
+ * Get an option defined in the variable-options.yaml config file.
+ * This file is used to set formatting options (default map colours,
+ * decimal precision, logarithmic scales, etc) at an individual
+ * variable level. 
+ * variable-options.yaml is guarenteed to exist as a file; webpack 
+ * is configured to creates it during pre-startip if it doesn't 
+ * already exist, but if webpack creates it, it will be blank.
+ * Returns the option value, or "undefined" if the variable or option
+ * is not listed. 
+ * NOTE: A variable option can legitimately have a value of "false", 
+ * so callers of this function need to distinguish between "false" 
+ * and "undefined" when acting on its results.
+ */
+var getVariableOptions = function(variable, option) {
+  var vOptions = require('../../variable-options.yaml');
+  if(nestedAttributeIsDefined(vOptions, variable, option)){
+    return vOptions[variable][option];
+  }
+  else {
+    return undefined;
+  }
+};
+
 /************************************************************
  * Date and calendar helper functions
  ************************************************************/
@@ -217,7 +241,7 @@ var nestedAttributeIsDefined = function (o, ...attributes) {
 }
 
 module.exports = { PRECISION, parseBootstrapTableData, validateProjectedChangeData, 
-    validateStatsData, validateAnnualCycleData,
+    validateStatsData, validateAnnualCycleData, getVariableOptions,
     timeIndexToTimeOfYear, timeResolutionIndexToTimeOfYear, extendedDateToBasicDate, 
     timestampToTimeOfYear,
     capitalizeWords,

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -172,7 +172,7 @@ var timestampToTimeOfYear = function(timestamp) {
     return month;
   }
   if(day == 16) {
-    return {"January": "Winter-DJF", "April": "Sping-MAM",
+    return {"January": "Winter-DJF", "April": "Spring-MAM",
             "July": "Summer-JJA", "October": "Fall-SON"}[month];
   }
   else if (day == 2 && month == "July") {
@@ -194,8 +194,31 @@ var capitalizeWords = function(s) {
   return s.replace(/\b\w/g, c => c.toUpperCase());
 };
 
+
+/**********************************************************
+ * Object-related helper function
+ **********************************************************/
+
+/*
+ * Given an object and any number of arguments arg1, arg2, arg3,
+ * et cetera, returns true if object.arg1.arg2.arg3 is defined
+ */
+var nestedAttributeIsDefined = function (o, ...attributes) {
+  if (_.isUndefined(o)) {
+    return false;
+  }
+  for(var i = 0; i < attributes.length; i++) {
+    if(_.isUndefined(o[attributes[i]])) {
+      return false
+    }
+    o = o[attributes[i]];
+  }
+  return true;
+}
+
 module.exports = { PRECISION, parseBootstrapTableData, validateProjectedChangeData, 
     validateStatsData, validateAnnualCycleData,
     timeIndexToTimeOfYear, timeResolutionIndexToTimeOfYear, extendedDateToBasicDate, 
     timestampToTimeOfYear,
-    capitalizeWords};
+    capitalizeWords,
+    nestedAttributeIsDefined};

--- a/variable-options.yaml
+++ b/variable-options.yaml
@@ -29,6 +29,8 @@ tasmax:
   decimalPrecision: 1
 
 pr:
-  decimalPrecision: 0
   overrideLogarithmicScale: true
   defaultScalarPalette: seq-Greens
+  #decimalPrecision: 0
+  #Note: in an ideal universe, pr would be measured in millimeters with 0
+  #decimal places, but right now our pr data is in kg m-2 d-1 instead.

--- a/variable-options.yaml
+++ b/variable-options.yaml
@@ -31,3 +31,4 @@ tasmax:
 pr:
   decimalPrecision: 0
   overrideLogarithmicScale: true
+  defaultScalarPalette: seq-Greens

--- a/variable-options.yaml
+++ b/variable-options.yaml
@@ -1,0 +1,33 @@
+################################################################
+# variable-options.yaml - variable-specific configuration file
+#
+# This file supplies default display options about climate
+# variables. Each variable is referred to using the name that 
+# appears in the netcdf variables listing.
+#
+# Available options are:
+#   - decimalPrecision
+#        INTEGER
+#        number of digits after the decimal point to display on
+#        graphs and map legends (default: 2)
+#   - overrideLogarithmicScale 
+#        BOOLEAN
+#        if true, allows clipping this variable to a positive 
+#        range and displaying with a logarithmic scale on map 
+#        views, even when the range of the variable contains 
+#        negative values (default: false)
+#   - defaultScalarPalette
+#        NCWMS PALETTE (see options here: http://goo.gl/J4Q5PD )
+#        the default colour scheme used to show this variable
+#        on a map. (default: seq-Greys)
+################################################################
+
+tasmin:
+  decimalPrecision: 1
+  
+tasmax:
+  decimalPrecision: 1
+
+pr:
+  decimalPrecision: 0
+  overrideLogarithmicScale: true

--- a/variable-options.yaml
+++ b/variable-options.yaml
@@ -16,7 +16,7 @@
 #        range and displaying with a logarithmic scale on map 
 #        views, even when the range of the variable contains 
 #        negative values (default: false)
-#   - defaultScalarPalette
+#   - defaultRasterPalette
 #        NCWMS PALETTE (see options here: http://goo.gl/J4Q5PD )
 #        the default colour scheme used to show this variable
 #        on a map. (default: seq-Greys)
@@ -30,7 +30,7 @@ tasmax:
 
 pr:
   overrideLogarithmicScale: true
-  defaultScalarPalette: seq-Greens
+  defaultRasterPalette: seq-Greens
   #decimalPrecision: 0
   #Note: in an ideal universe, pr would be measured in millimeters with 0
   #decimal places, but right now our pr data is in kg m-2 d-1 instead.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,9 @@ module.exports = {
         }, {
           test : /\.woff$/,
           loader : 'file-loader?name=fonts/[name].[ext]',
+        }, {
+          test : /\.(yaml|yml)$/,
+          loader : 'yml'
         }, ],
   },
 


### PR DESCRIPTION
Enables logarithmic colour scaling on the map for variables where either:

- All values of the variable are > 0 for the timeslice currently being displayed
- The variable is listed in` variable-options.yaml` with an `overrideLogarithmicScale` value of `true`, in which case, this particular variable _always_ has the option to be clipped to > 0 and displayed with logarithmic colouring

Also adds a couple other low-hanging items mentioned by Trevor during the isolines demo to `variable-options.yaml`:
 - specify a default colour scheme to display a variable on the map
- specify a default precision for a variable, which is used in both graphs and maps. 

[Test docker for this branch](http://docker2.pcic.uvic.ca:8605/compare). Precipitation has a default colour scheme and logarithmic override enabled. Tasmin and tasmax have a decimal precision (1) specified.