### PR TITLE
Use timeres to interpret timestamp. Fix #85

### DIFF
--- a/src/core/__tests__/util-test.js
+++ b/src/core/__tests__/util-test.js
@@ -189,19 +189,20 @@ var mockAPI = require('./sample-API-results');
   });
 
   describe('timestampToTimeOfYear', function () {
-    it('converts customary timestamps into monthly values', function () {
-      expect(util.timestampToTimeOfYear("1977-07-15T00:00:00Z", false)).toBe("July");
-      expect(util.timestampToTimeOfYear("1977-04-15T00:00:00Z", false)).toBe("April");
+    it('converts timestamps into monthly values', function () {
+      expect(util.timestampToTimeOfYear("1977-07-15T00:00:00Z", "monthly", false)).toBe("July");
+      expect(util.timestampToTimeOfYear("1977-04-15T00:00:00Z", "monthly", false)).toBe("April");
     });
-    it('converts customary timestamps into seasonal values', function () {
-      expect(util.timestampToTimeOfYear("1977-07-16T00:00:00Z", false)).toBe("Summer-JJA");
-      expect(util.timestampToTimeOfYear("1977-04-16T00:00:00Z", false)).toBe("Spring-MAM");
+    it('converts timestamps into seasonal values', function () {
+      expect(util.timestampToTimeOfYear("1977-07-15T00:00:00Z", "seasonal", false)).toBe("Summer-JJA");
+      expect(util.timestampToTimeOfYear("1977-04-15T00:00:00Z", "seasonal", false)).toBe("Spring-MAM");
     });
-    it('converts customary timestamps into annual values', function () {
-      expect(util.timestampToTimeOfYear("1977-07-02T00:00:00Z", true)).toBe("Annual 1977");
+    it('converts timestamps into annual values', function () {
+      expect(util.timestampToTimeOfYear("1977-07-15T00:00:00Z", "yearly", true)).toBe("Annual 1977");
+      expect(util.timestampToTimeOfYear("1977-04-15T00:00:00Z", "yearly", true)).toBe("Annual 1977");
     });
-    it('does not convert unrecognized timestamps', function () {
-      expect(util.timestampToTimeOfYear("1977-07-05T00:00:00Z")).toBe("1977-07-05T00:00:00Z");
+    it('does not convert unrecognized resolutions', function () {
+      expect(util.timestampToTimeOfYear("1977-07-05T00:00:00Z", "daily", true)).toBe("1977-07-05T00:00:00Z");
     });
   });
 

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -180,30 +180,46 @@ var extendedDateToBasicDate = function(timestamp) {
 };
 
 /*
- * Infers the time index and time resolution represented by a particular
- * timestamp and returns a human-friendly string. Used by map controllers, 
- * as the WMS API doesn't provide any useful time metadata.
- * Assumes that data for a particular resolution is associated with the median
- * day of that time period: the 15th day of each month for monthly resolutions,
- * July 2 for yearly resolutions, and the 16th day of the central month for 
- * seasonal resolutions. 
+ * Produces a human-readable string describing the time of year of displayed data.
+ * Used by MapController, since ncWMS doesn't provide any human-friendly time info.
  */
-var timestampToTimeOfYear = function(timestamp, disambiguateYear = true) {
-  var month = moment(timestamp, moment.ISO_8601).utc().format('MMMM');
-  var day = moment(timestamp, moment.ISO_8601).utc().format('D');
+var timestampToTimeOfYear = function (timestamp, resolution="monthly", disambiguateYear = true) {
   var year = disambiguateYear ? moment(timestamp, moment.ISO_8601).utc().format(' YYYY') : "";
+  var month = moment(timestamp, moment.ISO_8601).utc().format('MMMM');
   
-  if(day == 15) {
-    return `${month}${year}`;
-  }
-  if(day == 16) {
-    return `${{"January": "Winter-DJF", "April": "Spring-MAM",
-            "July": "Summer-JJA", "October": "Fall-SON"}[month]}${year}`;
-  }
-  else if ((day == 2 || day == 1) && month == "July") { //some datasets use July 1 for annual data.
+  if(resolution == "yearly") {
     return `Annual${year}`;
   }
-  return timestamp;
+  else if(resolution == "monthly") {
+    return `${month}${year}`;
+  }
+  else if(resolution == "seasonal") {
+    switch(month) {
+      case "December":
+      case "January":
+      case "February":
+        return `Winter-DJF${year}`;
+        break;
+      case "March":
+      case "April":
+      case "May":
+        return `Spring-MAM${year}`;
+        break;
+      case "June":
+      case "July":
+      case "August":
+        return `Summer-JJA${year}`;
+        break;
+      case "September":
+      case "October":
+      case "December":
+        return `Winter-SON${year}`;
+        break;
+    }
+  }
+  else {
+    return timestamp;
+  }
 };
 
 /*


### PR DESCRIPTION
This PR, along with the [previous one](https://github.com/pacificclimate/climate-explorer-frontend/pull/84), should result in reasonable time strings on the map footer and in the map modal menu for all data sets.

[Test docker for this branch with the climdex datasets](http://docker2.pcic.uvic.ca:8602/climo).