### PR TITLE
Disable dropdown parameters that do not describe any dataset

### DIFF
--- a/src/components/AppController/AppController.js
+++ b/src/components/AppController/AppController.js
@@ -34,17 +34,24 @@ var App = React.createClass({
   },
 
   render: function () {
+    //hierarchical selection: model, then variable, then experiment
+    var modOptions = this.getMetadataItems('model_id');
+    var varOptions = this.markDisabledMetadataItems(this.getVariableIdNameArray(),
+        this.getFilteredMetadataItems('variable_id', {model_id: this.state.model_id}));
+    var expOptions = this.markDisabledMetadataItems(this.getMetadataItems('experiment'),
+        this.getFilteredMetadataItems('experiment', {model_id: this.state.model_id, variable_id: this.state.variable_id}));
+
     return (
       <Grid fluid>
         <Row>
           <Col lg={4} md={4}>
-            <Selector label={"Model Selection"} onChange={this.updateSelection.bind(this, 'model_id')} items={this.getMetadataItems('model_id')} value={this.state.model_id}/>
+            <Selector label={"Model Selection"} onChange={this.updateSelection.bind(this, 'model_id')} items={modOptions} value={this.state.model_id}/>
           </Col>
           <Col lg={4} md={4}>
-            <Selector label={"Variable Selection"} onChange={this.updateSelection.bind(this, 'variable_id')} items={this.getVariableIdNameArray()} value={this.state.variable_id}/>
+            <Selector label={"Variable Selection"} onChange={this.updateSelection.bind(this, 'variable_id')} items={varOptions} value={this.state.variable_id}/>
           </Col>
           <Col lg={4} md={4}>
-            <Selector label={"Emission Scenario Selection"} onChange={this.updateSelection.bind(this, 'experiment')} items={this.getMetadataItems('experiment')} value={this.state.experiment}/>
+            <Selector label={"Emission Scenario Selection"} onChange={this.updateSelection.bind(this, 'experiment')} items={expOptions} value={this.state.experiment}/>
           </Col>
         </Row>
         <Row>

--- a/src/components/DualController/DualController.js
+++ b/src/components/DualController/DualController.js
@@ -56,20 +56,27 @@ var App = React.createClass({
   },
 
   render: function () {
+    //hierarchical data selection: model, then experiment, then variable(s)
+    var modOptions = this.getMetadataItems('model_id');
+    var expOptions = this.markDisabledMetadataItems(this.getMetadataItems('experiment'),
+        this.getFilteredMetadataItems('experiment', {model_id: this.state.model_id}));
+    var varOptions = this.markDisabledMetadataItems(this.getVariableIdNameArray(),
+        this.getFilteredMetadataItems('variable_id', {model_id: this.state.model_id, experiment: this.state.experiment}));
+ 
     return (
       <Grid fluid>
         <Row>
           <Col lg={3} md={3}>
-            <Selector label={"Model Selection"} onChange={this.updateSelection.bind(this, 'model_id')} items={this.getMetadataItems('model_id')} value={this.state.model_id}/>
+            <Selector label={"Model Selection"} onChange={this.updateSelection.bind(this, 'model_id')} items={modOptions} value={this.state.model_id}/>
           </Col>
             <Col lg={3} md={3}>
-            <Selector label={"Emission Scenario Selection"} onChange={this.updateSelection.bind(this, 'experiment')} items={this.getMetadataItems('experiment')} value={this.state.experiment}/>
+            <Selector label={"Emission Scenario Selection"} onChange={this.updateSelection.bind(this, 'experiment')} items={expOptions} value={this.state.experiment}/>
           </Col>
           <Col lg={3} md={3}>
-            <Selector label={"Variable #1 (Colour blocks)"} onChange={this.updateSelection.bind(this, 'variable_id')} items={this.getVariableIdNameArray()} value={this.state.variable_id}/>
+            <Selector label={"Variable #1 (Colour blocks)"} onChange={this.updateSelection.bind(this, 'variable_id')} items={varOptions} value={this.state.variable_id}/>
           </Col>
           <Col lg={3} md={3}>
-            <Selector label={"Variable #2 (Isolines)"} onChange={this.updateSelection.bind(this, 'comparand_id')} items={this.getVariableIdNameArray()} value={this.state.comparand_id ? this.state.comparand_id : this.state.variable_id}/>
+            <Selector label={"Variable #2 (Isolines)"} onChange={this.updateSelection.bind(this, 'comparand_id')} items={varOptions} value={this.state.comparand_id ? this.state.comparand_id : this.state.variable_id}/>
           </Col>
         </Row>
         <Row>

--- a/src/components/MotiController/MotiController.js
+++ b/src/components/MotiController/MotiController.js
@@ -24,14 +24,20 @@ var App = React.createClass({
   },
 
   render: function () {
+    //hierarchical selections: model (implicit), then variable, then emission
+    var varOptions = this.markDisabledMetadataItems(this.getVariableIdNameArray(),
+        this.getFilteredMetadataItems('variable_id', {model_id: this.state.model_id}));
+    var expOptions = this.markDisabledMetadataItems(this.getMetadataItems('experiment'),
+        this.getFilteredMetadataItems('experiment', {model_id: this.state.model_id, variable_id: this.state.variable_id}));
+
     return (
       <Grid fluid>
         <Row>
           <Col lg={4} md={4}>
-            <Selector label={"Variable Selection"} onChange={this.updateSelection.bind(this, 'variable_id')} items={this.getVariableIdNameArray()} value={this.state.variable_id}/>
+            <Selector label={"Variable Selection"} onChange={this.updateSelection.bind(this, 'variable_id')} items={varOptions} value={this.state.variable_id}/>
           </Col>
           <Col lg={4} md={4}>
-            <Selector label={"Emission Scenario Selection"} onChange={this.updateSelection.bind(this, 'experiment')} items={this.getMetadataItems('experiment')} value={this.state.experiment}/>
+            <Selector label={"Emission Scenario Selection"} onChange={this.updateSelection.bind(this, 'experiment')} items={expOptions} value={this.state.experiment}/>
           </Col>
           <Col lg={4} md={4} />
         </Row>

--- a/src/components/Selector/Selector.css
+++ b/src/components/Selector/Selector.css
@@ -1,0 +1,24 @@
+.selectorlabel {
+	display: block;
+	}
+
+.selectortitle {
+	text-align: left;
+	
+}
+
+/*leaflet controls have z index 1000, need the menu to be above them.*/
+.selectormenu {
+	z-index: 1001;
+}
+
+.selectoritem {
+	color: WhiteSmoke;
+}
+
+.selectorframe {
+	padding-top: 5px;
+	padding-right: 5px;
+	padding-bottom: 5px;
+	padding-left: 5px;
+}

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -9,13 +9,18 @@
  *   items - the array of possible choices. Can be either:
  *             * an array of strings - the string user picks is sent to
  *               callback
- *             * a array of tuples: the 1st item in the tuple will be
+ *             * an array of pairs: the 1st item in the tuple will be
  *               the string displayed the users, the 0th is what is sent
  *               to the callback if the displayed string is selected.
+ *             * an array of triples: the 0th item is the callback string,
+ *               the 1st is the choice label, the 2nd is a boolean for
+ *               whether this choice is disabled
  **********************************************************************/
 
 import React from 'react';
-import { Input } from 'react-bootstrap';
+import { DropdownButton, Input, ControlLabel, MenuItem, Dropdown} from 'react-bootstrap';
+import _ from 'underscore';
+import styles from './Selector.css';
 
 var Selector = React.createClass({
 
@@ -36,26 +41,61 @@ var Selector = React.createClass({
     };
   },
 
+  componentWillReceiveProps: function (newProps) {
+    this.updateDisplayValue(newProps.value, newProps.items);
+  },
+
+  //store the display string for the already-selected value
+  updateDisplayValue: function (value, items=this.props.items) {
+    if(_.indexOf(items, value) != -1) {
+      //display string is the same as value string.
+      this.displayString = value;
+    }
+    else { //display the associated user string,
+      //if associated user string cannot be found,
+      //just display the original string, on the assumption
+      //it's something like "Select a Choice"
+      var item = _.findWhere(items, {0: value});
+      this.displayString = item ? item[1] : value;
+    }
+  },
+
   handleChange: function (event) {
-    this.props.onChange(event.target.value);
+    this.props.onChange(event);
+  },
+
+  //renders an item into a react.bootstrap MenuItem
+  //if item is an atom, it is used for both user text and event key
+  //otherwise, the 0th item is event key, the 1st user text, and the 2rd,
+  //if present, whether the item is disabled.
+  createMenuItem: function (item) {
+    var choice = _.isArray(item) ? item[1] : item;
+    var eventKey = _.isArray(item) ? item[0] : item;
+    var disabled = _.isArray(item) && item.length > 2 ? item[2] : false;
+
+    return (
+      <MenuItem eventKey={eventKey} disabled={disabled} block className={styles.selectoritem}>
+        {choice}
+      </MenuItem>
+    );
   },
 
   render: function () {
     return (
-      <Input
-        type='select'
-        label={this.props.label}
-        onChange={this.handleChange}
-        value={this.props.value ? this.props.value : undefined}
-        disabled={this.props.disabled}
-      >
-        {
-          this.props.items.map(function (item) {
-            return Array.isArray(item) ? <option value={item[0]} key={item[0]}>{item[1]}</option> : <option value={item} key={item}>{item}</option>;
-          })
-        }
-      </Input>
-      );
+        <div className={styles.selectorframe}>
+          <div>
+            <ControlLabel className={styles.selectorlabel}>{this.props.label}</ControlLabel>
+          </div>
+          <Dropdown block vertical disabled={this.props.disabled} onSelect={this.handleChange}>
+            <Dropdown.Toggle className={styles.selectortitle}>
+              {this.displayString}
+            </Dropdown.Toggle>
+            <Dropdown.Menu block className={styles.selectormenu}>
+              {this.props.items.map(this.createMenuItem)}
+            </Dropdown.Menu>
+          </Dropdown>
+        </div>
+    );
   },
 });
 

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -86,7 +86,7 @@ var Selector = React.createClass({
           <div>
             <ControlLabel className={styles.selectorlabel}>{this.props.label}</ControlLabel>
           </div>
-          <Dropdown block vertical disabled={this.props.disabled} onSelect={this.handleChange}>
+          <Dropdown block vertical disabled={this.props.disabled} onSelect={this.handleChange} id={this.props.label}>
             <Dropdown.Toggle className={styles.selectortitle}>
               {this.displayString}
             </Dropdown.Toggle>

--- a/src/components/Selector/__tests__/Selector-test.js
+++ b/src/components/Selector/__tests__/Selector-test.js
@@ -16,44 +16,55 @@ describe('Selector', function () {
     expect(labelNode.textContent).toEqual('New Label');
   });
 
-  it('sets passed items', function () {
+  it('can handle passed items', function () {
     var selector = TestUtils.renderIntoDocument(
       <Selector items={['apple', 'banana', 'carrot']} />
     );
 
-    var optionNodes = TestUtils.scryRenderedDOMComponentsWithTag(selector, 'option');
-    var content = optionNodes.map(function (obj) {
+    var itemNodes = TestUtils.scryRenderedDOMComponentsWithTag(selector, 'li');
+    var content = itemNodes.map(function (obj) {
       return obj.textContent;
     });
     expect(content).toEqual(['apple', 'banana', 'carrot']);
   });
 
-  it('can handle "tuples"', function () {
+  it('can handle [key, label] pairs', function () {
     var selector = TestUtils.renderIntoDocument(
       <Selector items={[['apple_value', 'Apple label'], ['banana_value', 'Banana label']]} />
     );
-    var optionNodes = TestUtils.scryRenderedDOMComponentsWithTag(selector, 'option');
+    var itemNodes = TestUtils.scryRenderedDOMComponentsWithTag(selector, 'li');
 
-    var content = optionNodes.map(function (obj) {
+    var content = itemNodes.map(function (obj) {
       return obj.textContent;
     });
     expect(content).toEqual(['Apple label', 'Banana label']);
+  });
 
-    var keys = optionNodes.map(function (obj) {
-      return obj.value;
-    });
-    expect(keys).toEqual(['apple_value', 'banana_value']);
+  it('can handle [key, label, disabled] triples', function() {
+    var selector = TestUtils.renderIntoDocument(
+        <Selector items={[['apple_value', 'Apple label', true],['banana_value', 'Banana label', false]]} />
+    );
+    var itemNodes = TestUtils.scryRenderedDOMComponentsWithTag(selector, 'a');
+    //This is a very low-level way to test this, and very dependant on
+    //exact implementation in a way we normally don't have to care about. 
+    //This test would likely be broken by a react or react-bootstrap upgrade. There is
+    //probably a more semantic and less fragile way to test whether an element is
+    //disabled, but I have been unable to determine it.
+    expect(itemNodes[0].style[0]).toBe("pointer-events");
+    expect(itemNodes[1].style[0]).toBe(undefined);
   });
 
   it('calls the callback', function () {
     var dummyCallback = jest.genMockFunction();
     var selector = TestUtils.renderIntoDocument(
-      <Selector onChange={dummyCallback} />
+      <Selector onChange={dummyCallback} items={[["one", "first"], ["two", "second"]]}/>
     );
 
-    var selectorNode = TestUtils.findRenderedDOMComponentWithTag(selector, 'select');
-    TestUtils.Simulate.change(selectorNode, { target: { value: 'new value' } });
+    var dropdownButton = TestUtils.findRenderedDOMComponentWithTag(selector, 'button');
+    TestUtils.Simulate.click(dropdownButton);
+    var option = TestUtils.scryRenderedDOMComponentsWithTag(selector, 'a')[1];
+    TestUtils.Simulate.click(option);
 
-    expect(dummyCallback).toBeCalled();
+    expect(dummyCallback).toBeCalledWith("two");
   });
 });


### PR DESCRIPTION
This change treats the parameter selectors (Model, Scenario, Year) as a left to right hierarchy, and disables any unavailable options based on selections higher in the hierarchy. The user can freely select any model. Any variables not present in that model will be disabled in the `Variable Selection` dropdown. Any emissions scenario unavailable for both the selected variable and model will be disabled in the `Emissions Scenario` dropdown.

It's still possible to specify nonexistent data parameters. For example if the user is looking at a variable and then switches models to one that doesn't have that variable, they'd get the usual error message (`No data matching selected parameters available`). But the visual cues should make it a lot easier to find data.

The selectors are a little less pretty now.