### PR TITLE
Map usability fixes

### DIFF
--- a/src/components/Map/CanadaMap.js
+++ b/src/components/Map/CanadaMap.js
@@ -206,6 +206,11 @@ var CanadaMap = React.createClass({
     }).getLayers()[0]);
   },
 
+  //Map should only rerender when something has changed
+  shouldComponentUpdate: function (nextProps, nextState) {
+    return !(_.isEqual(nextState, this.state) && _.isEqual(nextProps, this.props));
+  },
+
   //initializes the map, loads data, and generates controls
   //NOTE: the buttons that open the "Map Settings" menu are
   //actually provided by MapController, not this component.
@@ -403,6 +408,12 @@ var CanadaMap = React.createClass({
   },
 
   componentWillReceiveProps: function (newProps) {
+    //MapController has a modal menu, and has to rerender itself (and CanadaMap)
+    //when the modal opens or closes, but the map itself doesn't need to be
+    //redrawn unless something has actually changed.
+    if(_.isEqual(this.props, newProps)) {
+      return;
+    }
     
     // FIXME: This isn't ideal. Leaflet doesn't support /removing/
     // wmsParameters yet - https://github.com/Leaflet/Leaflet/issues/3441

--- a/src/components/Map/CanadaMap.js
+++ b/src/components/Map/CanadaMap.js
@@ -377,6 +377,11 @@ var CanadaMap = React.createClass({
       map.addControl(rasterBar);
       map.addControl(autoscale);
     }
+
+    //Set and display an area if one was received
+    if(this.props.area && !this.state.area) {
+      this.handleNewArea(this.props.area);
+    }
   },
   
   //returns an array of two controls registered to the layer:


### PR DESCRIPTION
- Fixes a bug that caused the map to refresh (losing any user changes like autoscaling) every time the map settings menu was opened ( #80 )

- Fixes a bug that caused inconsistent transparency handling of map layers, resulting in the raster layer sometimes rendered opaquely, so that a user couldn't see the context underneath. ( #91 )

- If the map is initialized while the "area" parameter was already set, the area wasn't being drawn or indicated in any way, which has now been corrected. ( #93 )