### PR TITLE
Add application-wide routing to multiple ensembles

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head lang="en">
   <meta charset="UTF-8">
   <title>PCIC Climate Explorer</title>
-  <link type="text/css" rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">
-  <link type="text/css" rel="stylesheet" href="node_modules/leaflet/dist/leaflet.css">
-  <link type="text/css" rel="stylesheet" href="node_modules/leaflet-draw/dist/leaflet.draw.css">
-  <link type="text/css" rel="stylesheet" href="node_modules/bootstrap-slider/dist/css/bootstrap-slider.min.css">
-  <link type="text/css" rel="stylesheet" href="node_modules/perfect-scrollbar/dist/css/perfect-scrollbar.min.css">
-  <link type="text/css" rel="stylesheet" href="node_modules/c3/c3.min.css">
-  <link rel="stylesheet" href="node_modules/react-bootstrap-table/css/react-bootstrap-table-all.min.css">
-  <link type="text/css" rel="stylesheet" href="style.css">
+  <link type="text/css" rel="stylesheet" href="/node_modules/bootstrap/dist/css/bootstrap.min.css">
+  <link type="text/css" rel="stylesheet" href="/node_modules/leaflet/dist/leaflet.css">
+  <link type="text/css" rel="stylesheet" href="/node_modules/leaflet-draw/dist/leaflet.draw.css">
+  <link type="text/css" rel="stylesheet" href="/node_modules/bootstrap-slider/dist/css/bootstrap-slider.min.css">
+  <link type="text/css" rel="stylesheet" href="/node_modules/perfect-scrollbar/dist/css/perfect-scrollbar.min.css">
+  <link type="text/css" rel="stylesheet" href="/node_modules/c3/c3.min.css">
+  <link rel="stylesheet" href="/node_modules/react-bootstrap-table/css/react-bootstrap-table-all.min.css">
+  <link type="text/css" rel="stylesheet" href="/style.css">
 </head>
 
 <body>
@@ -18,13 +18,13 @@
     <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
   <![endif]-->
   <div id="wrapper"></div>
-  <script type="text/javascript" src="node_modules/proj4/dist/proj4.js"></script>
+  <script type="text/javascript" src="/node_modules/proj4/dist/proj4.js"></script>
   <!--  leaflet canvas required for leaflet.image  -->
   <script>L_PREFER_CANVAS = true;</script>
-  <script type="text/javascript" src="node_modules/leaflet/dist/leaflet.js"></script>
-  <script type="text/javascript" src="node_modules/proj4leaflet/src/proj4leaflet.js"></script>
-  <script type="text/javascript" src="node_modules/leaflet-draw/dist/leaflet.draw.js"></script>
-  <script type="text/javascript" src="bundle.js"></script>
+  <script type="text/javascript" src="/node_modules/leaflet/dist/leaflet.js"></script>
+  <script type="text/javascript" src="/node_modules/proj4leaflet/src/proj4leaflet.js"></script>
+  <script type="text/javascript" src="/node_modules/leaflet-draw/dist/leaflet.draw.js"></script>
+  <script type="text/javascript" src="/bundle.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head lang="en">
   <meta charset="UTF-8">
   <title>PCIC Climate Explorer</title>
-  <link type="text/css" rel="stylesheet" href="/node_modules/bootstrap/dist/css/bootstrap.min.css">
-  <link type="text/css" rel="stylesheet" href="/node_modules/leaflet/dist/leaflet.css">
-  <link type="text/css" rel="stylesheet" href="/node_modules/leaflet-draw/dist/leaflet.draw.css">
-  <link type="text/css" rel="stylesheet" href="/node_modules/bootstrap-slider/dist/css/bootstrap-slider.min.css">
-  <link type="text/css" rel="stylesheet" href="/node_modules/perfect-scrollbar/dist/css/perfect-scrollbar.min.css">
-  <link type="text/css" rel="stylesheet" href="/node_modules/c3/c3.min.css">
-  <link rel="stylesheet" href="/node_modules/react-bootstrap-table/css/react-bootstrap-table-all.min.css">
-  <link type="text/css" rel="stylesheet" href="/style.css">
+  <link type="text/css" rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">
+  <link type="text/css" rel="stylesheet" href="node_modules/leaflet/dist/leaflet.css">
+  <link type="text/css" rel="stylesheet" href="node_modules/leaflet-draw/dist/leaflet.draw.css">
+  <link type="text/css" rel="stylesheet" href="node_modules/bootstrap-slider/dist/css/bootstrap-slider.min.css">
+  <link type="text/css" rel="stylesheet" href="node_modules/perfect-scrollbar/dist/css/perfect-scrollbar.min.css">
+  <link type="text/css" rel="stylesheet" href="node_modules/c3/c3.min.css">
+  <link rel="stylesheet" href="node_modules/react-bootstrap-table/css/react-bootstrap-table-all.min.css">
+  <link type="text/css" rel="stylesheet" href="style.css">
 </head>
 
 <body>
@@ -18,13 +18,13 @@
     <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
   <![endif]-->
   <div id="wrapper"></div>
-  <script type="text/javascript" src="/node_modules/proj4/dist/proj4.js"></script>
+  <script type="text/javascript" src="node_modules/proj4/dist/proj4.js"></script>
   <!--  leaflet canvas required for leaflet.image  -->
   <script>L_PREFER_CANVAS = true;</script>
-  <script type="text/javascript" src="/node_modules/leaflet/dist/leaflet.js"></script>
-  <script type="text/javascript" src="/node_modules/proj4leaflet/src/proj4leaflet.js"></script>
-  <script type="text/javascript" src="/node_modules/leaflet-draw/dist/leaflet.draw.js"></script>
-  <script type="text/javascript" src="/bundle.js"></script>
+  <script type="text/javascript" src="node_modules/leaflet/dist/leaflet.js"></script>
+  <script type="text/javascript" src="node_modules/proj4leaflet/src/proj4leaflet.js"></script>
+  <script type="text/javascript" src="node_modules/leaflet-draw/dist/leaflet.draw.js"></script>
+  <script type="text/javascript" src="bundle.js"></script>
 
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prestart": "if [ ! -f ./variable-options.yaml ]; then touch ./variable-options.yaml; fi",
-    "start": "webpack-dev-server --host 0.0.0.0",
+    "start": "webpack-dev-server --host 0.0.0.0 --history-api-fallback",
     "build": "webpack --progress --colors",
     "test": "jest --verbose --runInBand",
     "lint": "eslint .",

--- a/src/components/AppController/AppController.js
+++ b/src/components/AppController/AppController.js
@@ -24,12 +24,6 @@ var App = React.createClass({
    * Includes: - model_id - variable_id - experiment
    */
 
-  getDefaultProps: function () {
-    return {
-      ensemble_name: CE_ENSEMBLE_NAME
-    };
-  },
-
   mixins: [AppMixin],
 
   //This filter controls which datasets are available for viewing on this portal;
@@ -64,6 +58,7 @@ var App = React.createClass({
           </Col>
           <Col lg={6}>
             <DataController
+              ensemble_name={this.state.ensemble_name}      
               model_id={this.state.model_id}
               variable_id={this.state.variable_id}
               experiment={this.state.experiment}

--- a/src/components/AppController/AppController.js
+++ b/src/components/AppController/AppController.js
@@ -24,6 +24,12 @@ var App = React.createClass({
    * Includes: - model_id - variable_id - experiment
    */
 
+  getDefaultProps: function () {
+    return {
+      ensemble_name: CE_ENSEMBLE_NAME
+    };
+  },
+
   mixins: [AppMixin],
 
   //This filter controls which datasets are available for viewing on this portal;

--- a/src/components/AppController/AppController.js
+++ b/src/components/AppController/AppController.js
@@ -58,11 +58,8 @@ var App = React.createClass({
           </Col>
           <Col lg={6}>
             <DataController
-              ensemble_name={this.state.ensemble_name}      
-              model_id={this.state.model_id}
-              variable_id={this.state.variable_id}
-              experiment={this.state.experiment}
-              area={this.state.area}
+              // ensemble_name, model_id, variable_id, experiment, area
+              {...this.state}
               meta = {this.getfilteredMeta()}
             />
           </Col>

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -18,15 +18,21 @@ import {timestampToYear} from '../../core/util';
 
 var AppMixin = {
   getInitialState: function () {
+    var ensemble_name = (typeof this.props.params !== 'undefined') ?
+        this.props.params.ensemble_name : ((typeof this.props.ensemble_name !== 'undefined') ?
+                                          this.props.ensemble_name : CE_ENSEMBLE_NAME);
     return {
-      ensemble_name: this.props.params.ensemble_name || this.props.ensemble_name || CE_ENSEMBLE_NAME,
+      ensemble_name: ensemble_name,
       meta: [],
     };
   },
 
   componentWillReceiveProps: function(nextProps) {
+    var ensemble_name = (typeof nextProps.params !== 'undefined') ?
+        nextProps.params.ensemble_name : ((typeof nextProps.ensemble_name !== 'undefined') ?
+                                          nextProps.ensemble_name : CE_ENSEMBLE_NAME);
     this.setState({
-      ensemble_name: nextProps.params.ensemble_name || nextProps.ensemble_name || CE_ENSEMBLE_NAME,
+      ensemble_name: ensemble_name,
     });
   },
 

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -24,7 +24,17 @@ var AppMixin = {
     };
   },
 
+  componentWillReceiveProps: function(nextProps) {
+    this.setState({
+      ensemble_name: nextProps.params.ensemble_name || nextProps.ensemble_name || CE_ENSEMBLE_NAME,
+    });
+  },
+
   componentDidMount: function () {
+    this.updateMetadata();
+  },
+
+  updateMetadata: function () {
     var models = [];
     var vars;
 
@@ -49,17 +59,37 @@ var AppMixin = {
                 end_date: end,
                 variable_name: response.data[key].variables[vars[v]],
                 }, _.omit(response.data[key], 'variables', 'start_date', 'end_date')));
-              }
             }
           }
+        }
 
-         this.setState({
-         meta: models,
-         model_id: models[0].model_id,
-         variable_id: models[0].variable_id,
-         experiment: models[0].experiment,
-         });
+        // Merge the selection information
+        //
+        // If it has not already been set or the current selection
+        // is not available from the current metadata, simply use
+        // the first available
+
+        var newstate = _.mapObject(_.pick(this.state, 'model_id', 'variable_id', 'experiment'), (val, key) => {
+            return _.contains(_.pluck(models, key), val) ? val : models[0][key];
         });
+
+        this.setState({
+          meta: models,
+          model_id: newstate['model_id'],
+          variable_id: newstate['variable_id'],
+          experiment: newstate['experiment']
+        });
+    });
+  },
+
+  shouldComponentUpdate: function(nextProps, nextState) {
+    return (!_.isEqual(nextProps, this.props) || !_.isEqual(nextState, this.state));
+  },
+
+  componentDidUpdate: function(nextProps, nextState) {
+    if (nextState.ensemble_name !== this.state.ensmeble_name) {
+      this.updateMetadata();
+    }
   },
 
   handleSetArea: function (wkt) {

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -22,7 +22,11 @@ var AppMixin = {
         this.props.params.ensemble_name : ((typeof this.props.ensemble_name !== 'undefined') ?
                                           this.props.ensemble_name : CE_ENSEMBLE_NAME);
     return {
-      ensemble_name: ensemble_name,
+      ensemble_name,
+      model_id: '',
+      variable_id: '',
+      experiment: '',
+      area: '',
       meta: [],
     };
   },
@@ -32,7 +36,7 @@ var AppMixin = {
         nextProps.params.ensemble_name : ((typeof nextProps.ensemble_name !== 'undefined') ?
                                           nextProps.ensemble_name : CE_ENSEMBLE_NAME);
     this.setState({
-      ensemble_name: ensemble_name,
+      ensemble_name,
     });
   },
 
@@ -75,15 +79,15 @@ var AppMixin = {
         // is not available from the current metadata, simply use
         // the first available
 
-        var newstate = _.mapObject(_.pick(this.state, 'model_id', 'variable_id', 'experiment'), (val, key) => {
+        const {model_id, variable_id, experiment} = _.mapObject(_.pick(this.state, 'model_id', 'variable_id', 'experiment'), (val, key) => {
             return _.contains(_.pluck(models, key), val) ? val : models[0][key];
         });
 
         this.setState({
           meta: models,
-          model_id: newstate['model_id'],
-          variable_id: newstate['variable_id'],
-          experiment: newstate['experiment']
+          model_id,
+          variable_id,
+          experiment,
         });
     });
   },

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -19,6 +19,7 @@ import {timestampToYear} from '../../core/util';
 var AppMixin = {
   getInitialState: function () {
     return {
+      ensemble_name: this.props.params.ensemble_name || this.props.ensemble_name || CE_ENSEMBLE_NAME,
       meta: [],
     };
   },
@@ -29,7 +30,7 @@ var AppMixin = {
 
     axios({
       baseURL: urljoin(CE_BACKEND_URL, 'multimeta'),
-      params: { ensemble_name: this.props.ensemble_name },
+      params: { ensemble_name: this.state.ensemble_name },
       }).then(response => {
         for (var key in response.data) {
           vars = Object.keys(response.data[key].variables);

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -29,7 +29,7 @@ var AppMixin = {
 
     axios({
       baseURL: urljoin(CE_BACKEND_URL, 'multimeta'),
-      params: { ensemble_name: CE_ENSEMBLE_NAME },
+      params: { ensemble_name: this.props.ensemble_name },
       }).then(response => {
         for (var key in response.data) {
           vars = Object.keys(response.data[key].variables);

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -16,13 +16,14 @@ import urljoin from 'url-join';
 import axios from 'axios';
 import {timestampToYear} from '../../core/util';
 
+var findEnsemble = function(props) {
+    return (props.params && props.params.ensemble_name) || props.ensemble_name || CE_ENSEMBLE_NAME;
+};
+
 var AppMixin = {
   getInitialState: function () {
-    var ensemble_name = (typeof this.props.params !== 'undefined') ?
-        this.props.params.ensemble_name : ((typeof this.props.ensemble_name !== 'undefined') ?
-                                          this.props.ensemble_name : CE_ENSEMBLE_NAME);
     return {
-      ensemble_name,
+      ensemble_name: findEnsemble(this.props),
       model_id: '',
       variable_id: '',
       experiment: '',
@@ -32,11 +33,8 @@ var AppMixin = {
   },
 
   componentWillReceiveProps: function(nextProps) {
-    var ensemble_name = (typeof nextProps.params !== 'undefined') ?
-        nextProps.params.ensemble_name : ((typeof nextProps.ensemble_name !== 'undefined') ?
-                                          nextProps.ensemble_name : CE_ENSEMBLE_NAME);
     this.setState({
-      ensemble_name,
+      ensemble_name: findEnsemble(nextProps),
     });
   },
 

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -87,6 +87,7 @@ var AppMixin = {
   },
 
   componentDidUpdate: function(nextProps, nextState) {
+    // The metadata needs to be updated if the ensemble has changed
     if (nextState.ensemble_name !== this.state.ensmeble_name) {
       this.updateMetadata();
     }

--- a/src/components/DataController/DataController.js
+++ b/src/components/DataController/DataController.js
@@ -53,6 +53,7 @@ var DataController = React.createClass({
     experiment: React.PropTypes.string,
     area: React.PropTypes.string,
     meta: React.PropTypes.array,
+    ensemble_name: React.PropTypes.string,
   },
 
   mixins: [DataControllerMixin],

--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -109,7 +109,7 @@ var ModalMixin = {
     return axios({
       baseURL: urljoin(CE_BACKEND_URL, 'data'),
       params: {
-        ensemble_name: CE_ENSEMBLE_NAME,
+        ensemble_name: this.props.ensemble_name,
         model: props.model_id,
         variable: props.variable_id,
         emission: props.experiment,

--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -27,7 +27,7 @@ import {validateLongTermAverageData,
 var ModalMixin = {
 
   verifyParams: function (props) {
-    var stringPropList = _.values(_.pick(props, 'meta', 'model_id', 'variable_id', 'experiment'));
+    var stringPropList = _.values(_.pick(props, 'ensemble_name', 'meta', 'model_id', 'variable_id', 'experiment'));
     return (stringPropList.length > 0) && stringPropList.every(Boolean);
   },
 
@@ -109,7 +109,7 @@ var ModalMixin = {
     return axios({
       baseURL: urljoin(CE_BACKEND_URL, 'data'),
       params: {
-        ensemble_name: this.props.ensemble_name,
+        ensemble_name: props.ensemble_name,
         model: props.model_id,
         variable: props.variable_id,
         emission: props.experiment,
@@ -126,7 +126,7 @@ var ModalMixin = {
     return axios({
       baseURL: urljoin(CE_BACKEND_URL, 'multistats'),
       params: {
-        ensemble_name: CE_ENSEMBLE_NAME,
+        ensemble_name: props.ensemble_name,
         model: props.model_id,
         variable: props.variable_id,
         emission: props.experiment,

--- a/src/components/DualController/DualController.js
+++ b/src/components/DualController/DualController.js
@@ -35,12 +35,6 @@ var App = React.createClass({
    *  - meta
    */
 
-  getDefaultProps: function () {
-    return {
-      ensemble_name: CE_ENSEMBLE_NAME
-    };
-  },
-
   mixins: [AppMixin],
   
   //This function filters out datasets inappropriate for this portal. A dataset
@@ -90,6 +84,7 @@ var App = React.createClass({
           </Col>
           <Col lg={6}>
             <DualDataController
+              ensemble_name={this.state.ensemble_name}
               model_id={this.state.model_id}
               variable_id={this.state.variable_id}
               comparand_id={this.state.comparand_id ? this.state.comparand_id : this.state.variable_id}

--- a/src/components/DualController/DualController.js
+++ b/src/components/DualController/DualController.js
@@ -35,6 +35,12 @@ var App = React.createClass({
    *  - meta
    */
 
+  getDefaultProps: function () {
+    return {
+      ensemble_name: CE_ENSEMBLE_NAME
+    };
+  },
+
   mixins: [AppMixin],
   
   //This function filters out datasets inappropriate for this portal. A dataset

--- a/src/components/DualDataController/DualDataController.js
+++ b/src/components/DualDataController/DualDataController.js
@@ -59,7 +59,6 @@ var DualDataController = React.createClass({
     area: React.PropTypes.string,
     meta: React.PropTypes.array,
     comparandMeta: React.PropTypes.array,
-    ensemble_name: React.PropTypes.string,
   },
 
   mixins: [DataControllerMixin],

--- a/src/components/DualDataController/DualDataController.js
+++ b/src/components/DualDataController/DualDataController.js
@@ -51,6 +51,7 @@ import styles from './DualDataController.css';
 var DualDataController = React.createClass({
 
   propTypes: {
+    ensemble_name: React.PropTypes.string,
     model_id: React.PropTypes.string,
     variable_id: React.PropTypes.string,
     comparand_id: React.PropTypes.string,

--- a/src/components/DualDataController/DualDataController.js
+++ b/src/components/DualDataController/DualDataController.js
@@ -58,6 +58,7 @@ var DualDataController = React.createClass({
     area: React.PropTypes.string,
     meta: React.PropTypes.array,
     comparandMeta: React.PropTypes.array,
+    ensemble_name: React.PropTypes.string,
   },
 
   mixins: [DataControllerMixin],

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -4,6 +4,3 @@
     height: 100%;
 }
 
-.active {
-    color: green;
-}

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -3,3 +3,7 @@
     padding: 15px 0px;
     height: 100%;
 }
+
+.active {
+    color: green;
+}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Grid, Row, Col, Nav, NavItem } from 'react-bootstrap';
-import { browserHistory } from 'react-router';
+import { hashHistory } from 'react-router';
 import classNames from 'classnames';
 
 import styles from './Header.css';
@@ -19,7 +19,7 @@ const Header = React.createClass({
 
     const handleSelect = function(selectedKey, evt) {
         updateNav(selectedKey);
-        browserHistory.push(this.href);
+        hashHistory.push(this.href);
     };
 
     return (

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { Grid, Row, Col, Button } from 'react-bootstrap';
-import { Link } from 'react-router';
+import { Grid, Row, Col, Nav, NavItem } from 'react-bootstrap';
+import { browserHistory } from 'react-router';
 import classNames from 'classnames';
 
 import styles from './Header.css';
@@ -8,6 +8,11 @@ import styles from './Header.css';
 class Header extends Component {
 
   render() {
+
+    var handleSelect = function() {
+      browserHistory.push(this.href);
+    };
+
     return (
       <div className={classNames(styles.header)}>
         <Grid fluid>
@@ -23,20 +28,12 @@ class Header extends Component {
               </a>
             </Col>
             <Col lg={8}>
-              <Row>
-                <Link to="/climo/all_downscale_files" activeClassName="active">
-                  <Button bsStyle="primary">Standard climatologies</Button>
-                </Link>
-                <Link to="/climo/all_CLIMDEX_files" activeClassName="active">
-                  <Button bsStyle="primary">ClimDEX climatologies</Button>
-                </Link>
-                <Link to="/compare/all_downscale_files" activeClassName="active">
-                  <Button bsStyle="primary">Standard comparision</Button>
-                </Link>
-                <Link to="/compare/all_CLIMDEX_files" activeClassName="active">
-                  <Button bsStyle="primary">ClimDEX comparision</Button>
-                </Link>
-              </Row>
+              <Nav bsStyle="tabs" justified activeKey={1} onSelect={handleSelect}>
+                <NavItem eventKey={1} href="/climo/all_downscale_files">Standard climatologies</NavItem>
+                <NavItem eventKey={2} href="/climo/all_CLIMDEX_files">ClimDEX climatologies</NavItem>
+                <NavItem eventKey={3} href="/compare/all_downscale_files">Standard comparison</NavItem>
+                <NavItem eventKey={4} href="/compare/all_CLIMDEX_files">ClimDEX comparison</NavItem>
+              </Nav>
             </Col>
           </Row>
         </Grid>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Grid, Row, Col } from 'react-bootstrap';
+import { Link } from 'react-router';
 import classNames from 'classnames';
 
 import styles from './Header.css';
@@ -22,7 +23,14 @@ class Header extends Component {
               </a>
             </Col>
             <Col lg={4} />
-            <Col lg={4} />
+            <Col lg={4}>
+            <ul>
+              <li><Link to="/climo/all_downscale_files">Standard climatologies</Link></li>
+              <li><Link to="/climo/all_CLIMDEX_files">ClimDEX climatologies</Link></li>
+              <li><Link to="/compare/all_downscale_files">Standard comparison</Link></li>
+              <li><Link to="/compare/all_CLIMDEX_files">ClimDEX comparison</Link></li>
+            </ul>
+            </Col>
           </Row>
         </Grid>
       </div>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Grid, Row, Col } from 'react-bootstrap';
+import { Grid, Row, Col, Button } from 'react-bootstrap';
 import { Link } from 'react-router';
 import classNames from 'classnames';
 
@@ -22,14 +22,21 @@ class Header extends Component {
                 />
               </a>
             </Col>
-            <Col lg={4} />
-            <Col lg={4}>
-            <ul>
-              <li><Link to="/climo/all_downscale_files">Standard climatologies</Link></li>
-              <li><Link to="/climo/all_CLIMDEX_files">ClimDEX climatologies</Link></li>
-              <li><Link to="/compare/all_downscale_files">Standard comparison</Link></li>
-              <li><Link to="/compare/all_CLIMDEX_files">ClimDEX comparison</Link></li>
-            </ul>
+            <Col lg={8}>
+              <Row>
+                <Link to="/climo/all_downscale_files" activeClassName="active">
+                  <Button bsStyle="primary">Standard climatologies</Button>
+                </Link>
+                <Link to="/climo/all_CLIMDEX_files" activeClassName="active">
+                  <Button bsStyle="primary">ClimDEX climatologies</Button>
+                </Link>
+                <Link to="/compare/all_downscale_files" activeClassName="active">
+                  <Button bsStyle="primary">Standard comparision</Button>
+                </Link>
+                <Link to="/compare/all_CLIMDEX_files" activeClassName="active">
+                  <Button bsStyle="primary">ClimDEX comparision</Button>
+                </Link>
+              </Row>
             </Col>
           </Row>
         </Grid>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,12 +5,21 @@ import classNames from 'classnames';
 
 import styles from './Header.css';
 
-class Header extends Component {
+const Header = React.createClass({
+
+  getInitialState() {
+    return {activeKey: 1};
+  },
 
   render() {
 
-    var handleSelect = function() {
-      browserHistory.push(this.href);
+    const updateNav = function(key) {
+        this.setState({activeKey: key})
+    }.bind(this);
+
+    const handleSelect = function(selectedKey, evt) {
+        updateNav(selectedKey);
+        browserHistory.push(this.href);
     };
 
     return (
@@ -28,7 +37,7 @@ class Header extends Component {
               </a>
             </Col>
             <Col lg={8}>
-              <Nav bsStyle="tabs" justified activeKey={1} onSelect={handleSelect}>
+              <Nav bsStyle="tabs" justified activeKey={this.state.activeKey} onSelect={handleSelect}>
                 <NavItem eventKey={1} href="/climo/all_downscale_files">Standard climatologies</NavItem>
                 <NavItem eventKey={2} href="/climo/all_CLIMDEX_files">ClimDEX climatologies</NavItem>
                 <NavItem eventKey={3} href="/compare/all_downscale_files">Standard comparison</NavItem>
@@ -40,6 +49,6 @@ class Header extends Component {
       </div>
     );
   }
-}
+});
 
 export default Header;

--- a/src/components/MotiDataController/MotiDataController.js
+++ b/src/components/MotiDataController/MotiDataController.js
@@ -44,6 +44,7 @@ var MotiDataController = React.createClass({
     experiment: React.PropTypes.string,
     area: React.PropTypes.string,
     meta: React.PropTypes.array,
+    ensemble_name: React.PropTypes.string,
   },
 
   mixins: [DataControllerMixin],

--- a/src/index.js
+++ b/src/index.js
@@ -32,8 +32,8 @@ render((
   <Router history={browserHistory}>
     <Route path='/' component={App}>
       <Route path='moti' component={MotiController} />
-      <Route path='climo' component={AppController} />
-      <Route path='compare' component={DualController} />
+      <Route path='climo/:ensemble_name' component={AppController} />
+      <Route path='compare/:ensemble_name' component={DualController} />
     </Route>
   </Router>
 ), document.getElementById('wrapper'));

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'react-dom';
-import { Router, Route, browserHistory } from 'react-router';
+import { Router, Route, hashHistory } from 'react-router';
 
 import MotiController from './components/MotiController';
 import AppController from './components/AppController';
@@ -29,7 +29,7 @@ var App = React.createClass({
 });
 
 render((
-  <Router history={browserHistory}>
+  <Router history={hashHistory}>
     <Route path='/' component={App}>
       <Route path='/moti' component={MotiController} />
       <Route path='/climo/:ensemble_name' component={AppController} />

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ var App = React.createClass({
           <Header />
         </div>
         <div>
-          {this.props.children || <MotiController />}
+          {this.props.children || <AppController ensemble_name="all_downscale_files"/>}
         </div>
       </div>
     );
@@ -31,9 +31,9 @@ var App = React.createClass({
 render((
   <Router history={browserHistory}>
     <Route path='/' component={App}>
-      <Route path='moti' component={MotiController} />
-      <Route path='climo/:ensemble_name' component={AppController} />
-      <Route path='compare/:ensemble_name' component={DualController} />
+      <Route path='/moti' component={MotiController} />
+      <Route path='/climo/:ensemble_name' component={AppController} />
+      <Route path='/compare/:ensemble_name' component={DualController} />
     </Route>
   </Router>
 ), document.getElementById('wrapper'));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,7 @@ module.exports = {
   devServer : {
     disableHostCheck: true,
     historyApiFallback : true,
+    contentBase: './',
     hot : true,
     inline : true,
     progress : true,


### PR DESCRIPTION
This PR takes a look at the application routing and makes an attempt to bring together the disparate arrangement of application types and different data sets. It enables an option to use a path component to configure the ensemble name, and passes that parameter down through the application components.

[Demo docker container](http://docker-dev01.pcic.uvic.ca:30066/)

Advantages:

1. We not longer have to start _n_ different application containers to show as many different data sets/ensembles.
1. Changing between datasets and application layouts does not require a page reload. React takes care of this by only re-rendering the necessary components. So a metadata fetch is only required if the ensemble changes (not if the layout changes).

Disadvantages:

1. ensemble names are hard-coded into the navigation under this regime, which makes it *harder* (though not impossible) to dynamically configure an application with a new ensemble. (Details: one can still configure the root using the CE_BACKEND_URL environment variable, *or* navigate to /climo|compare/<ensemble_name> and get a page that shows a specific ensemble).

Current Issues:

1. Navigating from "ClimDEX comparison" to "Standard comparison"  fails to refresh the metadata. It actually errors out in DualDataController.js saying "TypeError: _underscore2.default.findWhere(...) is undefined". I have no idea why, so @corviday I'd appreciate a look (since you wrote most of that code).
1. ~~If loading the page from one of the lower path levels (e.g. /climo/all_downscale_files ) the PCIC logo fails to load. Again, I can't figure out why. If one loads the page from "/" and then navigates to the other locations, it works fine.~~
1. ~~The aethetics of the nav buttons is kind of... odd. It works OK, but seems to stand out and not fit with the rest of the page. Anyone willing to help?~~