### PR TITLE
Update comparison variable when switching ensembles

### DIFF
--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -81,12 +81,21 @@ var AppMixin = {
             return _.contains(_.pluck(models, key), val) ? val : models[0][key];
         });
 
-        this.setState({
-          meta: models,
-          model_id,
-          variable_id,
-          experiment,
-        });
+        var update = {
+            meta: models,
+            model_id,
+            variable_id,
+            experiment,
+          };
+
+        //if this portal is using a comparison variable, check to see if it is present
+        //in the current data, and update it if not.
+        if(!_.isUndefined(this.state.comparand_id)) {
+          if(!_.contains(_.pluck(models, "variable_id"), this.comparand_id)) {
+            update["comparand_id"] = models[0].variable_id;
+          }
+        }
+        this.setState(update);
     });
   },
 
@@ -96,7 +105,7 @@ var AppMixin = {
 
   componentDidUpdate: function(nextProps, nextState) {
     // The metadata needs to be updated if the ensemble has changed
-    if (nextState.ensemble_name !== this.state.ensmeble_name) {
+    if (nextState.ensemble_name !== this.state.ensemble_name) {
       this.updateMetadata();
     }
   },

--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -139,7 +139,7 @@ var ModalMixin = {
   //Fetches and validates data from a call to the backend's
   //"timeseries" endpoint
   getTimeseriesPromise: function (props, timeseriesDatasetId) {
-    var validate = this.multiYearMeanSelected() ? validateAnnualCycleData : validateUnstructuredTimeseriesData;
+    var validate = this.multiYearMeanSelected(props) ? validateAnnualCycleData : validateUnstructuredTimeseriesData;
     return axios({
       baseURL: urljoin(CE_BACKEND_URL, 'timeseries'),
       params: {
@@ -203,7 +203,7 @@ var ModalMixin = {
     //Indicates whether or not the currently selected dataset is
     //a multi-year-mean
     multiYearMeanSelected: function(props = this.props) {
-      if(_.isUndefined(props) || props.meta.length == 0) {
+      if(_.isUndefined(props) || _.isUndefined(props.meta) || props.meta.length == 0) {
         return undefined;
       }
       var params = _.pick(props, "model_id", 'variable_id', 'experiment');


### PR DESCRIPTION
Added a check to `AppMixin.updateMetadata()` that checks when switching ensembles to see whether a comparison variable (used by the `/compare` portal) is defined and if so, whether it refers to a variable not present in the new ensemble, updating it if so.