### PR TITLE
Fix #108, include area in comparison query

### DIFF
--- a/src/components/DualDataController/DualDataController.js
+++ b/src/components/DualDataController/DualDataController.js
@@ -339,6 +339,7 @@ var DualDataController = React.createClass({
 
     //add data from the comparand, if it exists
     if(comparandMetadata && comparandMetadata.unique_id != variableMetadata.unique_id) {
+      params.area = props.area;
       timeseriesPromises.push(this.getTimeseriesPromise(params, comparandMetadata.unique_id));
     }
 


### PR DESCRIPTION
The query for the secondary variable on unstructured timeseries graphs previously failed to include the "area" parameter, resulting in graphs that didn't take the user-defined area into account for one of the variables.