### PR TITLE
Fix #103, update comparand on ensemble switch

### DIFF
--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -98,7 +98,7 @@ var AppMixin = {
 
   componentDidUpdate: function(nextProps, nextState) {
     // The metadata needs to be updated if the ensemble has changed
-    if (nextState.ensemble_name !== this.state.ensmeble_name) {
+    if (nextState.ensemble_name !== this.state.ensemble_name) {
       this.updateMetadata();
     }
   },

--- a/src/components/DualController/DualController.js
+++ b/src/components/DualController/DualController.js
@@ -25,6 +25,7 @@ import Selector from '../Selector';
 import AppMixin from '../AppMixin';
 import g from '../../core/geo';
 import MapController from '../MapController';
+import _ from 'underscore';
 
 var App = createReactClass({
   displayName: 'App',
@@ -48,10 +49,16 @@ var App = createReactClass({
   },
 
   //because componentDidMount() is shared by all three App Controllers via a 
-  //mixin, it doesn't set the initial state of the comparison variable 
-  //(comparand_id), so needs to be initialized seperately here.
+  //mixin, it doesn't set the initial state of DualController's unique comparison
+  //variable (comparand_id), which is handled seperately here.
   componentDidUpdate: function (prevProps, prevState) {
-    if(!this.state.comparand_id) {
+    if(!this.state.comparand_id) {//comparand uninitialized
+      this.setState({
+        comparand_id: this.state.variable_id
+      });
+    }
+    else if(!_.contains(_.pluck(this.state.meta, "variable_id"), this.state.comparand_id)) {
+      //comparand leftover from previous ensemble; not present in current one
       this.setState({
         comparand_id: this.state.variable_id
       });

--- a/src/components/DualDataController/DualDataController.js
+++ b/src/components/DualDataController/DualDataController.js
@@ -92,6 +92,17 @@ var DualDataController = createReactClass({
    * in the first qualifying dataset.
    */
   getData: function (props) {
+    //When switching ensembles, DualDataController is sometimes rendered when
+    //the primary variable has been updated to reflect the new ensemble,
+    //but the comparand hasn't yet.
+    if(props.meta.length > 0 && props.comparandMeta.length < 1) {
+      var text = "Loading ensemble";
+      this.setLongTermAverageGraphNoDataMessage(text);
+      this.setAnnualCycleGraphNoDataMessage(text);
+      this.setTimeseriesGraphNoDataMessage(text);
+      return;
+    }
+
     var variableMYM = this.multiYearMeanSelected(props);
     var comparandParams = _.pick(props, 'model_id', 'experiment');
     comparandParams.variable_id = props.comparand_id;


### PR DESCRIPTION
Updates secondary variable in comparison portal after switching ensembles. Checks to make sure _both_ variables are valid before trying to load data from the backend.