### PR TITLE
Choose data validation method based on incoming dataset

### DIFF
--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -139,7 +139,7 @@ var ModalMixin = {
   //Fetches and validates data from a call to the backend's
   //"timeseries" endpoint
   getTimeseriesPromise: function (props, timeseriesDatasetId) {
-    var validate = this.multiYearMeanSelected() ? validateAnnualCycleData : validateUnstructuredTimeseriesData;
+    var validate = this.multiYearMeanSelected(props) ? validateAnnualCycleData : validateUnstructuredTimeseriesData;
     return axios({
       baseURL: urljoin(CE_BACKEND_URL, 'timeseries'),
       params: {


### PR DESCRIPTION
Use props corresponding to the dataset _about_ to be loaded, not props corresponding to the _currently_ loaded dataset, to determine whether to validate with `validateAnnualCycleData()` (for multi-year means) or `validateUnstructuredTimeseriesData()` (for nominal time datasets).