### PR TITLE
Add multi-model context graph to main portal

### DIFF
--- a/src/components/AppController/AppController.js
+++ b/src/components/AppController/AppController.js
@@ -78,6 +78,7 @@ var App = createReactClass({
               experiment={this.state.experiment}
               area={g.geojson(this.state.area).toWKT()}
               meta = {this.getfilteredMeta()}
+              contextMeta={this.state.meta} //for Context Graph: metadata from all models
             />
           </Col>
         </Row>

--- a/src/components/DataController/DataController.js
+++ b/src/components/DataController/DataController.js
@@ -63,6 +63,7 @@ var DataController = createReactClass({
     experiment: PropTypes.string,
     area: PropTypes.string,
     meta: PropTypes.array,
+    contextMeta: PropTypes.array,
     ensemble_name: PropTypes.string,
   },
 
@@ -411,7 +412,7 @@ var DataController = createReactClass({
   },
 
   render: function () {
-    var statsData = this.state.statsData ? this.state.statsData : [];
+    var statsData = this.state.statsData ? this.state.statsData : this.blankStatsData;
 
     //make a list of all the unique combinations of run + climatological period
     //a user could decide to view.
@@ -457,11 +458,13 @@ var DataController = createReactClass({
 
       // Long Term Average Graph
       var longTermAverageData = this.state.longTermAverageData ? this.state.longTermAverageData : this.blankGraph;
+      var longTermAverageSelected = resolutionIndexToTimeKey(this.state.longTermAverageTimeScale,
+          this.state.longTermAverageTimeOfYear);
       longTermTab = (
         <Tab eventKey={2} title='Long Term Averages'>
           <Row>
             <Col lg={4} lgPush={8} md={6} mdPush={6} sm={6} smPush={6}>
-              <TimeOfYearSelector onChange={this.updateLongTermAverageTimeOfYear} />
+              <TimeOfYearSelector onChange={this.updateLongTermAverageTimeOfYear} value={longTermAverageSelected} />
             </Col>
             <Col>
               <div>

--- a/src/components/DataController/DataController.js
+++ b/src/components/DataController/DataController.js
@@ -436,6 +436,7 @@ var DataController = createReactClass({
     var annualTab = null, longTermTab = null, timeseriesTab = null, contextTab = null;
     if (this.multiYearMeanSelected()) {
       // Annual Cycle Graph
+      var annualCycleData = this.state.annualCycleData ? this.state.annualCycleData : this.blankGraph;
       annualTab = (
         <Tab eventKey={1} title='Annual Cycle'>
           <Row>
@@ -455,6 +456,7 @@ var DataController = createReactClass({
       );
 
       // Long Term Average Graph
+      var longTermAverageData = this.state.longTermAverageData ? this.state.longTermAverageData : this.blankGraph;
       longTermTab = (
         <Tab eventKey={2} title='Long Term Averages'>
           <Row>
@@ -472,10 +474,11 @@ var DataController = createReactClass({
           <DataGraph data={longTermAverageData.data} axis={longTermAverageData.axis} tooltip={longTermAverageData.tooltip} />
         </Tab>
       );
+
       //Context Graph
       var contextData = this.state.contextData ? this.state.contextData : this.blankGraph;
-      var contextTab = (
-          <Tab> eventKey={3} title='Model Context'>
+      contextTab = (
+          <Tab eventKey={4} title='Model Context'>
             <DataGraph
               data={contextData.data}
               axis={contextData.axis}
@@ -487,6 +490,7 @@ var DataController = createReactClass({
       );
     } else {
       // Time Series Graph
+      var timeseriesData = this.state.timeseriesData ? this.state.timeseriesData : this.blankGraph;
       timeseriesTab = (
         <Tab eventKey={3} title='Time Series'>
           <DataGraph data={timeseriesData.data} axis={timeseriesData.axis} tooltip={timeseriesData.tooltip} subchart={timeseriesData.subchart} />

--- a/src/components/DataController/DataController.js
+++ b/src/components/DataController/DataController.js
@@ -328,14 +328,14 @@ var DataController = createReactClass({
     var dataPromises = [];
     var dataQueryParams = [];
     var contextModels = _.without(_.uniq(_.pluck(props.contextMeta, "model_id")), props.model_id);
-    var params = _.pick(props, 'experiment', 'variable_id', "ensemble_name");
+    var params = _.pick(props, 'experiment', 'variable_id', 'ensemble_name');
     params.timescale = 'yearly';
     params.multi_year_mean = true;
 
     //determine which models have data that matches this variable and experiment
     for(let i = 0; i < contextModels.length; i++ ) {
       params.model_id = contextModels[i];
-      if(_.where(props.contextMeta, params)){
+      if(_.where(props.contextMeta, _.omit(params, 'ensemble_name')).length > 0){
         dataPromises.push(this.getDataPromise(params, "yearly", 0));
         dataQueryParams.push(_.extend({}, params));
       }

--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -246,7 +246,10 @@ var ModalMixin = {
         columns: []
       },
       axis: {}
-    }
+    },
+
+    //Used to render uninitialized stats tables
+    blankStatsData: []
 };
 
 export default ModalMixin;

--- a/src/components/MotiDataController/MotiDataController.js
+++ b/src/components/MotiDataController/MotiDataController.js
@@ -155,11 +155,11 @@ var MotiDataController = createReactClass({
   },
 
   render: function () {
-    var statsData = this.state.statsData ? this.state.statsData : [];
+    var statsData = this.state.statsData ? this.state.statsData : this.blankStatsData;
 
     var graph;
     if(this.multiYearMeanSelected(this.props)) {
-      var annualCycleData = this.state.annualCycleData ? this.state.annualCycleData : { data: { columns: [] }, axis: {} };
+      var annualCycleData = this.state.annualCycleData ? this.state.annualCycleData : this.blankGraph;
       graph = (
           <div>
             <div>

--- a/src/core/__tests__/chart-test.js
+++ b/src/core/__tests__/chart-test.js
@@ -392,3 +392,23 @@ describe('hideSeriesInLegend', function () {
     expect(graph.legend.hide.length).toBe(0);
   });
 });
+
+describe('sortSeriesByRank', function (){
+  var metadata = mockAPI.metadataToArray();
+  var graph = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+  var rankByTimeResolution = function (series) {
+    var resolutions = ["Yearly", "Seasonal", "Monthly"];
+    for(let i = 0; i < 3; i++) {
+      if(series[0].search(resolutions[i]) != -1) {
+        return i;
+      }
+    }
+  }
+  it('orders series by ranking', function () {
+    var ranked = chart.sortSeriesByRank(graph, rankByTimeResolution);
+    expect(ranked.data.columns[0][0]).toBe("Yearly Mean");
+    expect(ranked.data.columns[1][0]).toBe("Seasonal Mean");
+    expect(ranked.data.columns[2][0]).toBe("Monthly Mean");
+  });
+});

--- a/src/core/__tests__/chart-test.js
+++ b/src/core/__tests__/chart-test.js
@@ -356,8 +356,6 @@ describe('fadeSeriesByRank', function () {
   var metadata = mockAPI.metadataToArray();
   var graph = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
       mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-  var segmentFunc = function (col) {return col[0];};
-  graph = chart.assignColoursByGroup(graph, segmentFunc);
   it('does not affect tier-1 series', function () {
     var ranker = function(series) {return 1};
     graph = chart.fadeSeriesByRank(graph, ranker);
@@ -377,4 +375,20 @@ describe('fadeSeriesByRank', function () {
     var faded = fader("#000000", series[i][0]);
     expect(faded).not.toMatch("#000000");
   }
+});
+
+describe('hideSeriesInLegend', function () {
+  var metadata = mockAPI.metadataToArray();
+  var graph = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+  it('removes data series from the lengend', function() {
+    var hideAll = function(series) {return true};
+    graph = chart.hideSeriesInLegend(graph, hideAll);
+    expect(graph.legend.hide.length).toBe(3);
+  });
+  it('retains data series in the legend', function() {
+    var showAll = function(series) {return false};
+    graph = chart.hideSeriesInLegend(graph, showAll);
+    expect(graph.legend.hide.length).toBe(0);
+  });
 });

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -197,7 +197,7 @@ var timeseriesToAnnualCycleGraph = function(metadata, ...data) {
   return {
     data: c3Data,
     tooltip: c3Tooltip,
-    axis: c3Axis
+    axis: c3Axis,
   }; 
 };
 
@@ -379,7 +379,7 @@ var dataToLongTermAverageGraph = function(data, contexts = []){
   else {
     throw new Error("Error: no context provided for timeseries data");
   }
-  
+
   //get the list of all timestamps and add them to the chart
   //(C3 requires x-axis timestamps be added as a data column)
   var timestamps = getAllTimestamps(data);
@@ -437,6 +437,13 @@ var dataToLongTermAverageGraph = function(data, contexts = []){
     c3Axis.y2 = formatYAxis(y2Units);
     }
 
+  //The long term average graph doesn't require every series to have the exact
+  //same timestamps, since it's comparing long term trends anyway. Allow C3
+  //to smoothly connect series even if they're "missing" timestamps.
+  var c3Line = {
+      connectNull: true
+  };
+
   //Note: if context is empty (dataToLongTermAverageGraph was called with only
   //one time series), variable-determined precision will not be available and
   //numbers will be formatted with default precision.
@@ -448,7 +455,8 @@ var dataToLongTermAverageGraph = function(data, contexts = []){
   return {
     data: c3Data,
     tooltip: c3Tooltip,
-    axis: c3Axis
+    axis: c3Axis,
+    line: c3Line
   }; 
 };
 
@@ -790,8 +798,39 @@ var fadeSeriesByRank = function (graph, ranker) {
   return graph;
 };
 
+/*
+ * Post-processing graph function that removes data series from the legend.
+ *
+ * Accepts a C3 graph and a predicate function. Applies the predicate to
+ * each data series. If the predicate returns true, the data series will
+ * be hidden from the legend. If the predicate returns false, the data series
+ * will appear in the legend as normal.
+ *
+ * By default, every data series appears in the legend; this postprocessor
+ * is only needed if at least one series should be hidden.
+ */
+var hideSeriesInLegend = function(graph, predicate) {
+  var hiddenSeries = [];
+
+  _.each(graph.data.columns, column => {
+    var seriesName = column[0];
+    if(!_.isEqual(seriesName, "x")) {
+      if(predicate(column)){
+        hiddenSeries.push(seriesName);
+      }
+    }
+  });
+
+  if(!graph.legend) {
+    graph.legend = {};
+  }
+
+  graph.legend.hide = hiddenSeries;
+  return graph;
+};
+
 module.exports = { timeseriesToAnnualCycleGraph, dataToLongTermAverageGraph,
-    timeseriesToTimeseriesGraph, assignColoursByGroup, fadeSeriesByRank,
+    timeseriesToTimeseriesGraph, assignColoursByGroup, fadeSeriesByRank, hideSeriesInLegend,
     //exported only for testing purposes:
     formatYAxis, fixedPrecision, makePrecisionBySeries, makeTooltipDisplayNumbersWithUnits,
     getMonthlyData, shortestUniqueTimeseriesNamingFunction,

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -829,8 +829,25 @@ var hideSeriesInLegend = function(graph, predicate) {
   return graph;
 };
 
+/*
+ * Post-processing graph function that sets the order of the data series.
+ * The last-drawn series is the most clearly visible; its points and lines
+ * will be on top where they intersect with other series.
+ *
+ * Accepts a C3 graph and a ranking function. The ranking function will be
+ * applied to each series in the graph, and the series will be sorted by the
+ * ranking function's results. The higher a series is ranked, the later it
+ * will be drawn and the more prominent it will appear.
+ */
+var sortSeriesByRank = function(graph, ranker) {
+  var sorter = function(a, b) {return ranker(a) - ranker(b);}
+  graph.data.columns = graph.data.columns.sort(sorter);
+  return graph;
+}
+
 module.exports = { timeseriesToAnnualCycleGraph, dataToLongTermAverageGraph,
-    timeseriesToTimeseriesGraph, assignColoursByGroup, fadeSeriesByRank, hideSeriesInLegend,
+    timeseriesToTimeseriesGraph, assignColoursByGroup, fadeSeriesByRank,
+    hideSeriesInLegend, sortSeriesByRank,
     //exported only for testing purposes:
     formatYAxis, fixedPrecision, makePrecisionBySeries, makeTooltipDisplayNumbersWithUnits,
     getMonthlyData, shortestUniqueTimeseriesNamingFunction,


### PR DESCRIPTION
Adds a multiple-model "spaghetti plot" when viewing datasets with precalculated multi-year-means on the /climo portal. The graph - at least on my workstation - takes about ten seconds to load, due to querying the backend separately for each model. It does seem to delay generation of other graphs, but only very slightly. I'll get a docker running so we can judge that.

A version of this graph for datasets that lack precalculated multi year means is not included in this pull request; it was too slow.