### PR TITLE
Fix DualDataController query bugs

### DIFF
--- a/src/components/DualDataController/DualDataController.js
+++ b/src/components/DualDataController/DualDataController.js
@@ -247,7 +247,7 @@ var DualDataController = createReactClass({
 
     var timeseriesPromises = [];
     
-    var variableTimeseriesParams = {variable_id: props.variable_id, area: props.area};
+    var variableTimeseriesParams = _.pick(props, "variable_id", "area", "meta");
     timeseriesPromises.push(this.getTimeseriesPromise(variableTimeseriesParams, variableMetadata.unique_id));
     
     //determine whether seasonal and annual resolution data are available for
@@ -263,7 +263,9 @@ var DualDataController = createReactClass({
     //but it is not guarenteed to exist for the comparison variable, so fall back to only
     //showing one variable in that case.
     if(comparandMetadata && comparandMetadata.unique_id != variableMetadata.unique_id) {
-      var comparandTimeseriesParams = {variable_id: props.comparand_id, area: props.area};
+      var comparandTimeseriesParams = _.pick(props, "area");
+      comparandTimeseriesParams.variable_id = props.comparand_id;
+      comparandTimeseriesParams.meta = props.comparandMeta;
       timeseriesPromises.push(this.getTimeseriesPromise(comparandTimeseriesParams, comparandMetadata.unique_id));
 
       //check availability of seasonal and annual data on the comparand,
@@ -353,6 +355,7 @@ var DualDataController = createReactClass({
     //add data from the comparand, if it exists
     if(comparandMetadata && comparandMetadata.unique_id != variableMetadata.unique_id) {
       params.area = props.area;
+      params.meta = props.comparandMeta;
       timeseriesPromises.push(this.getTimeseriesPromise(params, comparandMetadata.unique_id));
     }
 

--- a/src/components/DualDataController/DualDataController.js
+++ b/src/components/DualDataController/DualDataController.js
@@ -196,7 +196,7 @@ var DualDataController = createReactClass({
     //for the second variable. This query will always return a result, but
     //the result may be an empty object {}.
     if(props.comparand_id && props.comparand_id != props.variable_id) {
-      var comparandDataParams = _.pick(props, 'model_id', 'experiment', 'area');
+      var comparandDataParams = _.pick(props, 'model_id', 'experiment', 'area', 'ensemble_name');
       comparandDataParams.variable_id = props.comparand_id;
       dataPromises.push(this.getDataPromise(comparandDataParams, timeres, timeidx));
       dataParams.push(comparandDataParams);


### PR DESCRIPTION
Fix two minor DualDataController bugs discovered while testing the react refactor PR.

1. DualDataController was sometimes sending off queries to the `data` API without an ensemble parameter. Added that.

2. [Recently switched](https://github.com/pacificclimate/climate-explorer-frontend/pull/116) to using the props passed to the query instead of props stored on the controller for determining whether the data being queried was a multi-year-mean, which led to an issue in `DualDataController`. `DualDataController` "fakes" props for queries on the secondary variable; it parsimoniously mocks up props containing only attributes needed to run the query. The fake props didn't contain enough information to determine whether the comparand dataset was a multi-year mean, which was preventing the secondary variable (`comparand`) from loading on some graphs. Added the missing attributes to the mockup props.