### PR TITLE
Refactor map controller state

### DIFF
--- a/src/components/DataMap/DataLayer.js
+++ b/src/components/DataMap/DataLayer.js
@@ -9,16 +9,16 @@ import _ from "underscore";
 export default class DataLayer extends React.Component {
   static propTypes = {
     // Layer props
-    layerType: PropTypes.string, // 'raster' | 'isoline'
+    layerType: PropTypes.string.isRequired, // 'raster' | 'isoline'
     dataset: PropTypes.string,
-    variable: PropTypes.string,
-    time: PropTypes.string,
+    variableId: PropTypes.string,
+    wmsTime: PropTypes.string,
     palette: PropTypes.string,
     logscale: PropTypes.string,
     range: PropTypes.object,
+    onChangeRange: PropTypes.func.isRequired,
 
     onLayerRef: PropTypes.func,
-    onChangeRange: PropTypes.func.isRequired,
   };
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -135,12 +135,6 @@ class DataMap extends React.Component {
     return b;
   }
 
-  componentDidMount() {
-  }
-
-  componentDidUpdate() {
-  }
-
   render() {
     // TODO: Add positioning for autoset
     return (

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -19,6 +19,15 @@ import DataLayer from './DataLayer';
 import NcWMSColorbarControl from '../NcWMSColorbarControl';
 import NcWMSAutosetColorscaleControl from '../NcWMSAutosetColorscaleControl';
 
+const layerPropTypes = PropTypes.shape({
+  dataset: PropTypes.string,
+  variableId: PropTypes.string,
+  time: PropTypes.string,
+  palette: PropTypes.string,
+  logscale: PropTypes.string, // arg for ncwms: 'true' | 'false' (String)
+  range: PropTypes.object,
+  onChangeRange: PropTypes.func.isRequired,
+});
 
 class DataMap extends React.Component {
   // This component provides data display layers (DataLayer) for up to two
@@ -27,23 +36,8 @@ class DataMap extends React.Component {
   // Renders its children within the base map.
 
   static propTypes = {
-    rasterDataset: PropTypes.string,
-    rasterVariable: PropTypes.string,
-    rasterTime: PropTypes.string,
-    rasterPalette: PropTypes.string,
-    rasterLogscale: PropTypes.string, // arg for ncwms: 'true' | 'false'
-    rasterRange: PropTypes.object,
-    onChangeRasterRange: PropTypes.func.isRequired,
-
-    isolineDataset: PropTypes.string,
-    isolineVariable: PropTypes.string,
-    isolineTime: PropTypes.string,
-    isolinePalette: PropTypes.string,
-    numberOfContours: PropTypes.number,
-    isolineLogscale: PropTypes.string, // arg for ncwms: 'true' | 'false'
-    isolineRange: PropTypes.object,
-    onChangeIsolineRange: PropTypes.func.isRequired,
-
+    raster: layerPropTypes,
+    isoline: layerPropTypes,
     area: PropTypes.object,
     onSetArea: PropTypes.func.isRequired,
   };
@@ -109,10 +103,7 @@ class DataMap extends React.Component {
   handleLayerRef(layerType, layer) {
     const leafletElement = layer && layer.leafletElement;
     if (leafletElement) {
-      const onChangeRange = {
-        raster: this.props.onChangeRasterRange,
-        isoline: this.props.onChangeIsolineRange,
-      }[layerType];
+      const onChangeRange = this.props[layerType].onChangeRange;
       leafletElement.on('load', () => {
         this.updateLayerRange(layerType, this.props, onChangeRange);
       });
@@ -158,38 +149,19 @@ class DataMap extends React.Component {
       >
         <DataLayer
           layerType='raster'
-          dataset={this.props.rasterDataset}
-          variable={this.props.rasterVariable}
-          time={this.props.rasterTime}
-          palette={this.props.rasterPalette}
-          logscale={this.props.rasterLogscale}
-          range={this.props.rasterRange}
-
+          {...this.props.raster}
           onLayerRef={this.handleRasterLayerRef}
-          onChangeRange={this.props.onChangeRasterRange}
         />
 
         <DataLayer
           layerType='isoline'
-          dataset={this.props.isolineDataset}
-          variable={this.props.isolineVariable}
-          time={this.props.isolineTime}
-          palette={this.props.isolinePalette}
-          logscale={this.props.isolineLogscale}
-          range={this.props.isolineRange}
-
+          {...this.props.isoline}
           onLayerRef={this.handleIsolineLayerRef}
-          onChangeRange={this.props.onChangeIsolineRange}
         />
 
         <NcWMSColorbarControl
           layer={this.state.rasterLayer}
-          // update when any raster prop changes
-          dataset={this.state.rasterDataset}
-          variable={this.props.rasterVariable}
-          time={this.props.rasterTime}
-          palette={this.props.rasterPalette}
-          logscale={this.props.rasterLogscale}
+          {...this.props.raster}  // update when any raster prop changes
         />
 
         <NcWMSAutosetColorscaleControl
@@ -198,12 +170,7 @@ class DataMap extends React.Component {
 
         <NcWMSColorbarControl
           layer={this.state.isolineLayer}
-          // update when any isoline prop changes
-          dataset={this.state.isolineDataset}
-          variable={this.props.isolineVariable}
-          time={this.props.isolineTime}
-          palette={this.props.isolinePalette}
-          logscale={this.props.isolineLogscale}
+          {...this.props.isoline}  // update when any isoline prop changes
         />
 
         <FeatureGroup>

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -119,7 +119,6 @@ export default class MapController extends React.Component {
 
   // Support functions for event/callback handlers
 
-  // TODO: Refactor; see issue #TODO
   loadMap(
     props,
     dataset,
@@ -304,9 +303,9 @@ export default class MapController extends React.Component {
       var switchComparand = hasComparand && !_.isEqual(newComparandId, oldComparandId);
 
       // set display colours. In order of preference:
-      // 2. colours from state (set by the user or this function previously)
-      // 3. colours specified in variables.yaml, if applicable (raster only)
-      // 4. defaults (raster rainbow if a single dataset,
+      // 1. colours from state (set by the user or this function previously)
+      // 2. colours specified in variables.yaml, if applicable (raster only)
+      // 3. defaults (raster rainbow if a single dataset,
       //             raster greyscale and isolines rainbow for 2)
       var sPalette, cPalette;
       if (this.state.raster.palette && !switchVariable) {

--- a/src/components/MapController/MapController.js
+++ b/src/components/MapController/MapController.js
@@ -349,7 +349,6 @@ export default class MapController extends React.Component {
     return b;
   }
 
-
   render() {
     const { rasterDatasetId, isolineDatasetId } = this.getDatasetIds();
 
@@ -358,6 +357,7 @@ export default class MapController extends React.Component {
         <DataMap
           rasterDataset={rasterDatasetId}
           rasterVariable={this.state.variable}
+          rasterTime={this.state.variableWmsTime}
           rasterPalette={this.state.rasterPalette}
           rasterLogscale={this.state.rasterLogscale}
           rasterRange={this.state.rasterRange}
@@ -365,14 +365,12 @@ export default class MapController extends React.Component {
 
           isolineDataset={isolineDatasetId}
           isolineVariable={this.state.comparand}
+          isolineTime={this.state.comparandWmsTime}
           isolinePalette={this.state.isolinePalette}
           numberOfContours={this.state.numberOfContours}
           isolineLogscale={this.state.isolineLogscale}
           isolineRange={this.state.isolineRange}
           onChangeIsolineRange={this.handleChangeIsolineRange}
-
-          rasterTime={this.state.variableWmsTime}
-          isolineTime={this.state.comparandWmsTime}
 
           onSetArea={this.props.onSetArea}
           area={this.props.area}
@@ -398,24 +396,19 @@ export default class MapController extends React.Component {
               variableTimes={this.state.variableTimes}
               variableTimeIdx={this.state.variableTimeIdx}
               onChangeVariableTime={this.handleChangeVariableTime}
-
-              hasComparand={this.hasComparand()}
-              comparandTimes={this.state.comparandTimes}
-              comparandTimeIdx={this.state.comparandTimeIdx}
-              onChangeComparandTime={this.handleChangeComparandTime}
-
-              timesLinkable={this.timesMatch()}
-
               rasterPalette={this.state.rasterPalette}
               onChangeRasterPalette={this.handleChangeRasterPalette}
-
-              isolinePalette={this.state.isolinePalette}
-              onChangeIsolinePalette={this.handleChangeIsolinePalette}
-
               rasterLayerMin={this.state.rasterRange.min}
               rasterLogscale={this.state.rasterLogscale}
               onChangeRasterScale={this.handleChangeRasterScale}
 
+              hasComparand={this.hasComparand()}
+              timesLinkable={this.timesMatch()}
+              comparandTimes={this.state.comparandTimes}
+              comparandTimeIdx={this.state.comparandTimeIdx}
+              onChangeComparandTime={this.handleChangeComparandTime}
+              isolinePalette={this.state.isolinePalette}
+              onChangeIsolinePalette={this.handleChangeIsolinePalette}
               isolineLayerMin={this.state.isolineRange.min}
               isolineLogscale={this.state.isolineLogscale}
               onChangeIsolineScale={this.handleChangeIsolineScale}

--- a/src/components/MapFooter/MapFooter.js
+++ b/src/components/MapFooter/MapFooter.js
@@ -12,13 +12,9 @@ class MapFooter extends React.Component {
     start_date: PropTypes.string,
     end_date: PropTypes.string,
     run: PropTypes.string,
-    variable: PropTypes.string,
-    variableTimes: PropTypes.object,
-    variableWmsTime: PropTypes.string,
+    raster: PropTypes.object,
+    isoline: PropTypes.object,
     hasValidComparand: PropTypes.bool,
-    comparandTimes: PropTypes.object,
-    comparand: PropTypes.string,
-    comparandWmsTime: PropTypes.string,
   };
   
   timeOfYear(times, wmsTime) {
@@ -29,8 +25,8 @@ class MapFooter extends React.Component {
     return timestampToTimeOfYear(wmsTime, timescale, disambiguateYears);
   }
   
-  timeAndSymbol(times, wmsTime, symbol) {
-    return `${this.timeOfYear(times, wmsTime)} ${symbol}`;
+  timeAndVariable({ times, wmsTime, variableId }) {
+    return `${this.timeOfYear(times, wmsTime)} ${variableId}`;
   }
 
   render() {
@@ -38,11 +34,11 @@ class MapFooter extends React.Component {
         <h5>
           Dataset {`${this.props.start_date}-${this.props.end_date}`} {this.props.run}:
           {' '}
-          {this.timeAndSymbol(this.props.variableTimes, this.props.variableWmsTime, this.props.variable)}
+          {this.timeAndVariable(this.props.raster)}
           {' '}
           {
-            this.props.hasValidComparand && 
-            `vs. ${this.timeAndSymbol(this.props.comparandTimes, this.props.comparandWmsTime, this.props.comparand)}`
+            this.props.hasValidComparand &&
+            `vs. ${this.timeAndVariable(this.props.isoline)}`
           }
         </h5>
     );

--- a/src/components/MapFooter/__tests__/smoke.js
+++ b/src/components/MapFooter/__tests__/smoke.js
@@ -10,9 +10,11 @@ it('renders without crashing', () => {
       start_date={'start'}
       end_date={'end'}
       run={'run'}
-      variable={'tasmax'}
-      variableTimes={times}
-      variableWmsTime={'1977-02-15T00:00:00Z'}
+      raster={{
+        variableId: 'tasmax',
+        times,
+        wmsTime: '1977-02-15T00:00:00Z',
+      }}
       hasValidComparand={false}
     />,
     div

--- a/src/components/MapSettings/DataDisplayControls.js
+++ b/src/components/MapSettings/DataDisplayControls.js
@@ -19,7 +19,7 @@ export default class DataDisplayControls extends React.Component {
     onChangePalette: PropTypes.func.isRequired,
 
     variableId: PropTypes.string,
-    layerMin: PropTypes.number,
+    range: PropTypes.object,
     logscale: PropTypes.string,
     onChangeScale: PropTypes.func.isRequired,
   };
@@ -27,13 +27,6 @@ export default class DataDisplayControls extends React.Component {
   static defaultProps = {
     timeLinked: false,
   };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-    };
-  }
 
   render() {
     return (
@@ -53,7 +46,7 @@ export default class DataDisplayControls extends React.Component {
         <ScaleSelector
           name={this.props.name}
           variableId={this.props.variableId}
-          layerMin={this.props.layerMin}
+          layerMin={this.props.range.min}
           value={this.props.logscale}
           onChange={this.props.onChangeScale}
         />

--- a/src/components/MapSettings/MapSettingsDialog.js
+++ b/src/components/MapSettings/MapSettingsDialog.js
@@ -1,11 +1,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Grid, Row, Col, Button, Modal } from 'react-bootstrap';
+import _ from 'underscore';
 
 import DatasetSelector from './DatasetSelector';
 import DataDisplayControls from './DataDisplayControls';
 import TimeLinkButton from './TimeLinkButton';
 
+
+const layerPropTypes = PropTypes.shape({
+  times: PropTypes.object,
+  timeIdx: PropTypes.string,
+  palette: PropTypes.string,
+  range: PropTypes.object,
+  logscale: PropTypes.string,
+  onChangeTime: PropTypes.func.isRequired,
+  onChangePalette: PropTypes.func.isRequired,
+  onChangeScale: PropTypes.func.isRequired,
+});
 
 export default class MapSettingsDialog extends React.Component {
   static propTypes = {
@@ -16,31 +28,17 @@ export default class MapSettingsDialog extends React.Component {
 
     title: PropTypes.string,
     // TODO: Refactor according to comments in DatasetSelector
-    meta: PropTypes.array,
+    meta: PropTypes.array.isRequired,
     comparandMeta: PropTypes.array,
 
     dataset: PropTypes.string,  // current dataset selection, encoded as JSON string
     onDatasetChange: PropTypes.func.isRequired,  // callback, arg is enocded JSON string
 
-    variableTimes: PropTypes.object,
-    variableTimeIdx: PropTypes.string,
-    onChangeVariableTime: PropTypes.func.isRequired,
-    rasterPalette: PropTypes.string,
-    onChangeRasterPalette: PropTypes.func.isRequired,
-    rasterLayerMin: PropTypes.number,
-    rasterLogscale: PropTypes.string,
-    onChangeRasterScale: PropTypes.func.isRequired,
+    raster: layerPropTypes.isRequired,
 
     hasComparand: PropTypes.bool,
     timesLinkable: PropTypes.bool,
-    comparandTimes: PropTypes.object,
-    comparandTimeIdx: PropTypes.string,
-    onChangeComparandTime: PropTypes.func.isRequired, // required???
-    isolinePalette: PropTypes.string,
-    onChangeIsolinePalette: PropTypes.func.isRequired, // required???
-    isolineLayerMin: PropTypes.number,
-    isolineLogscale: PropTypes.string,
-    onChangeIsolineScale: PropTypes.func.isRequired,
+    isoline: layerPropTypes,
   };
 
   constructor(props) {
@@ -66,21 +64,21 @@ export default class MapSettingsDialog extends React.Component {
   toggleLinkTimes = () => {
     const toggledlinkTimes = !this.state.linkTimes;
     if (toggledlinkTimes) {
-      this.props.onChangeComparandTime(this.props.variableTimeIdx);
+      this.props.isoline.onChangeTime(this.props.raster.timeIdx);
     }
     this.setState({ linkTimes: toggledlinkTimes });
   };
 
   handleChangeVariableTime = (time) => {
-    this.props.onChangeVariableTime(time);
+    this.props.raster.onChangeTime(time);
     if (this.state.linkTimes) {
-      this.props.onChangeComparandTime(time);
+      this.props.isoline.onChangeTime(time);
     }
   };
 
   handleChangeComparandTime = (time) => {
     if (!this.state.linkTimes) {
-      this.props.onChangeComparandTime(time);
+      this.props.isoline.onChangeTime(time);
     }
   };
 
@@ -107,15 +105,8 @@ export default class MapSettingsDialog extends React.Component {
               <Col lg={this.props.hasComparand ? 6 : 12}>
                 <DataDisplayControls
                   name='Raster'
-                  times={this.props.variableTimes}
-                  timeIdx={this.props.variableTimeIdx}
+                  {..._.omit(this.props.raster, 'onChangeTime')}
                   onChangeTime={this.handleChangeVariableTime}
-                  palette={this.props.rasterPalette}
-                  onChangePalette={this.props.onChangeRasterPalette}
-                  variableId={this.rasterVariableId()}
-                  layerMin={this.props.rasterLayerMin}
-                  logscale={this.props.rasterLogscale}
-                  onChangeScale={this.props.onChangeRasterScale}
                 />
               </Col>
               {
@@ -133,15 +124,9 @@ export default class MapSettingsDialog extends React.Component {
                 <Col lg={5}>
                   <DataDisplayControls
                     name='Isoline'
-                    times={this.props.comparandTimes}
-                    timeIdx={this.props.comparandTimeIdx}
                     timeLinked={this.state.linkTimes}
+                    {..._.omit(this.props.isoline, 'onChangeTime')}
                     onChangeTime={this.handleChangeComparandTime}
-                    palette={this.props.isolinePalette}
-                    onChangePalette={this.props.onChangeIsolinePalette}
-                    layerMin={this.props.isolineLayerMin}
-                    logscale={this.props.isolineLogscale}
-                    onChangeScale={this.props.onChangeIsolineScale}
                   />
                 </Col>
               }

--- a/src/components/MapSettings/MapSettingsDialog.js
+++ b/src/components/MapSettings/MapSettingsDialog.js
@@ -49,18 +49,6 @@ export default class MapSettingsDialog extends React.Component {
     };
   }
 
-  variableId(meta) {
-    return meta.length > 0 && meta[0].variable_id;
-  }
-
-  rasterVariableId() {
-    return this.variableId(this.props.meta);
-  }
-
-  isolineVariableId() {
-    return this.variableId(this.props.comparandMeta);
-  }
-
   toggleLinkTimes = () => {
     const toggledlinkTimes = !this.state.linkTimes;
     if (toggledlinkTimes) {

--- a/src/components/MapSettings/MapSettingsDialog.js
+++ b/src/components/MapSettings/MapSettingsDialog.js
@@ -25,24 +25,19 @@ export default class MapSettingsDialog extends React.Component {
     variableTimes: PropTypes.object,
     variableTimeIdx: PropTypes.string,
     onChangeVariableTime: PropTypes.func.isRequired,
-
-    hasComparand: PropTypes.bool,
-    comparandTimes: PropTypes.object,
-    comparandTimeIdx: PropTypes.string,
-    onChangeComparandTime: PropTypes.func.isRequired, // required???
-
-    timesLinkable: PropTypes.bool,
-
     rasterPalette: PropTypes.string,
     onChangeRasterPalette: PropTypes.func.isRequired,
-
-    isolinePalette: PropTypes.string,
-    onChangeIsolinePalette: PropTypes.func.isRequired, // required???
-
     rasterLayerMin: PropTypes.number,
     rasterLogscale: PropTypes.string,
     onChangeRasterScale: PropTypes.func.isRequired,
 
+    hasComparand: PropTypes.bool,
+    timesLinkable: PropTypes.bool,
+    comparandTimes: PropTypes.object,
+    comparandTimeIdx: PropTypes.string,
+    onChangeComparandTime: PropTypes.func.isRequired, // required???
+    isolinePalette: PropTypes.string,
+    onChangeIsolinePalette: PropTypes.func.isRequired, // required???
     isolineLayerMin: PropTypes.number,
     isolineLogscale: PropTypes.string,
     onChangeIsolineScale: PropTypes.func.isRequired,

--- a/src/components/MapSettings/__tests__/DataDisplayControls-smoke.js
+++ b/src/components/MapSettings/__tests__/DataDisplayControls-smoke.js
@@ -19,7 +19,7 @@ it('renders without crashing', () => {
       onChangePalette={noop}
 
       variableId='tasmax'
-      layerMin={-23.34}
+      range={{ min: -23.34 }}
       logscale={'false'}
       onChangeScale={noop}
     />,

--- a/src/components/MapSettings/__tests__/MapSettingsDialog-smoke.js
+++ b/src/components/MapSettings/__tests__/MapSettingsDialog-smoke.js
@@ -19,24 +19,23 @@ describe('with one variable', () => {
         dataset='r1i1p1 1961-1990'
         onDatasetChange={noop}
 
-        variableTimes={times}
-        variableTimeIdx={Object.keys(times)[0]}
-        onChangeVariableTime={noop}
+        raster={{
+          times,
+          timeIdx: Object.keys(times)[0],
+          palette: 'seq-Blues',
+          range: { min: -23 },
+          logscale: 'false',
+          onChangeTime: noop,
+          onChangePalette: noop,
+          onChangeScale: noop,
+        }}
 
         hasComparand={false}
-        onChangeComparandTime={noop}
-
-        rasterPalette={'seq-Blues'}
-        onChangeRasterPalette={noop}
-
-        onChangeIsolinePalette={noop}
-
-        rasterLayerMin={-23}
-        rasterLogscale={'false'}
-        onChangeRasterScale={noop}
-
-        onChangeIsolineScale={noop}
-
+        isoline={{
+          onChangeTime: noop,
+          onChangePalette: noop,
+          onChangeScale: noop,
+        }}
       />,
       div
     );

--- a/src/data-services/ncwms.js
+++ b/src/data-services/ncwms.js
@@ -5,10 +5,10 @@ import axios from 'axios/index';
 import _ from 'underscore';
 
 
-function getBaseWMSParams({ dataset, variable, time, logscale, range }) {
+function getBaseWMSParams({ dataset, variableId, wmsTime, logscale, range }) {
   const fixedParams = {
-    layers: `${dataset}/${variable}`,
-    time,
+    layers: `${dataset}/${variableId}`,
+    time: wmsTime,
     noWrap: true,
     format: 'image/png',
     transparent: true,
@@ -35,9 +35,9 @@ function getBaseWMSParams({ dataset, variable, time, logscale, range }) {
 }
 
 
-function getRasterWMSParams({ dataset, variable, time, palette, logscale, range }) {
+function getRasterWMSParams({ dataset, variableId, wmsTime, palette, logscale, range }) {
   return Object.assign(
-    getBaseWMSParams({ dataset, variable, time, logscale, range }),
+    getBaseWMSParams({ dataset, variableId, wmsTime, logscale, range }),
     {
       styles: `default-scalar/${palette}`,
       opacity: 0.7,
@@ -46,9 +46,9 @@ function getRasterWMSParams({ dataset, variable, time, palette, logscale, range 
 }
 
 
-function getIsolineWMSParams({ dataset, variable, time, palette, logscale, range }) {
+function getIsolineWMSParams({ dataset, variableId, wmsTime, palette, logscale, range }) {
   return Object.assign(
-    getBaseWMSParams({ dataset, variable, time, logscale, range }),
+    getBaseWMSParams({ dataset, variableId, wmsTime, logscale, range }),
     {
       styles: `colored_contours/${palette}`,
       opacity: 1.0,
@@ -59,25 +59,11 @@ function getIsolineWMSParams({ dataset, variable, time, palette, logscale, range
 function getWMSParams(layerType, props) {
   // Return parameters required for a call to the ncWMS tile layer API.
   console.log('getWMSParams', layerType, props);
-
+  // TODO: simplify
   if (layerType === 'raster') {
-    return getRasterWMSParams({
-      dataset: props.rasterDataset,
-      variable: props.rasterVariable,
-      time: props.rasterTime,
-      palette: props.rasterPalette,
-      logscale: props.rasterLogscale,
-      range: props.rasterRange,
-    });
+    return getRasterWMSParams(props);
   } else if (layerType === 'isoline') {
-    return getIsolineWMSParams({
-      dataset: props.isolineDataset,
-      variable: props.isolineVariable,
-      time: props.isolineTime,
-      palette: props.isolinePalette,
-      logscale: props.isolineLogscale,
-      range: props.isolineRange,
-    });
+    return getIsolineWMSParams(props);
   }
 }
 
@@ -86,7 +72,7 @@ function getLayerMinMax(layer, props, bounds) {
   // Request min and max values from ncWMS layer.
   // Returns a promise for the request response.
 
-  const { layers, version, srs, time } = getWMSParams(layer, props);
+  const { layers, version, srs, time } = getWMSParams(layer, props[layer]);
 
   return axios(
     NCWMS_URL,


### PR DESCRIPTION
Refactor map controller state so that parallel values associated with each layer (raster, isoline) are stored in objects on state instead of separate, somewhat inconsistently named, lists of properties. Refactor the props of many descendant components similarly.

This makes it much simpler to pass the relevant parameters down through the component hierarchy: they are passed as a consistent group. The very lowest level components were already abstracted to very nearly exactly this grouping, so the hierarchy is now also much more consistent in naming of props.