### PR TITLE
Drop "modtime" from file metadata used inside Climate Explorer

### DIFF
--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -68,7 +68,7 @@ var AppMixin = {
                 start_date: start,
                 end_date: end,
                 variable_name: response.data[key].variables[vars[v]],
-                }, _.omit(response.data[key], 'variables', 'start_date', 'end_date')));
+                }, _.omit(response.data[key], 'variables', 'start_date', 'end_date', 'modtime')));
             }
           }
         }


### PR DESCRIPTION
The climate explorer frontend doesn't need to know about modtime of queries run to the backend.

Functions that look for matching datasets based on metadata attributes or write human-friendly descriptions of data based on metadata attributes were taking modtime into account, with unhelpful results.