### PR TITLE
Add currently running version number and commitish to footer

### DIFF
--- a/generate-commitish.sh
+++ b/generate-commitish.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#Generates a commitish string for climate explorer and stores it in 
+# the CE_CURRENT_VERSION environment variable.
+
+VERSIONTAG="$(git describe --tags --abbrev=0)"
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+COMMITSHA="$(git log -1 --format=%h)"
+
+export CE_CURRENT_VERSION="Climate Explorer $VERSIONTAG ($BRANCH: $COMMITSHA)"
+echo "generate-commitish.sh: Current version is ${CE_CURRENT_VERSION}"
+

--- a/generate-commitish.sh
+++ b/generate-commitish.sh
@@ -6,6 +6,4 @@ VERSIONTAG="$(git describe --tags --abbrev=0)"
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 COMMITSHA="$(git log -1 --format=%h)"
 
-export CE_CURRENT_VERSION="Climate Explorer $VERSIONTAG ($BRANCH: $COMMITSHA)"
-echo "generate-commitish.sh: Current version is ${CE_CURRENT_VERSION}"
-
+echo "$VERSIONTAG ($BRANCH: $COMMITSHA)"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prestart": "if [ ! -f ./variable-options.yaml ]; then touch ./variable-options.yaml; fi",
-    "start": ". ./generate-commitish.sh; webpack-dev-server --host 0.0.0.0 --history-api-fallback",
+    "start": "CE_CURRENT_VERSION=$(./generate-commitish.sh) webpack-dev-server --host 0.0.0.0 --history-api-fallback",
     "build": "webpack --progress --colors",
     "test": "jest --verbose --runInBand",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prestart": "if [ ! -f ./variable-options.yaml ]; then touch ./variable-options.yaml; fi",
-    "start": "webpack-dev-server --host 0.0.0.0 --history-api-fallback",
+    "start": ". ./generate-commitish.sh; webpack-dev-server --host 0.0.0.0 --history-api-fallback",
     "build": "webpack --progress --colors",
     "test": "jest --verbose --runInBand",
     "lint": "eslint .",
@@ -29,7 +29,8 @@
       "CE_BACKEND_URL": "http://tools.pacificclimate.org/climate-data",
       "TILECACHE_URL": "http://tiles.pacificclimate.org/tilecache/tilecache.py",
       "NCWMS_URL": "http://tools.pacificclimate.org/ncWMS-PCIC/wms",
-      "CE_ENSEMBLE_NAME": "ce"
+      "CE_ENSEMBLE_NAME": "ce",
+      "CE_CURRENT_VERSION": "Climate Explorer test version"
     },
     "unmockedModulePathPatterns": [
       "fbjs",

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -13,7 +13,7 @@ var Footer = createReactClass({
         <Grid fluid>
           <Row>
             <Col lg={4}>
-              PCIC {CE_CURRENT_VERSION}
+              PCIC Climate Explorer {CE_CURRENT_VERSION}
             </Col>
             <Col lg={4} />
             <Col lg={4} />

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
+import createReactClass from 'create-react-class';
 import { Grid, Row, Col } from 'react-bootstrap';
 import classNames from 'classnames';
 
 import styles from './Footer.css';
 
-class Footer extends Component {
+var Footer = createReactClass({
 
   render() {
     return (
@@ -12,14 +13,7 @@ class Footer extends Component {
         <Grid fluid>
           <Row>
             <Col lg={4}>
-              <a href='https://pacificclimate.org/'>
-                <img
-                  src={require('./logo.png')}
-                  width='328'
-                  height='38'
-                  alt='Pacific Climate Impacts Consortium'
-                />
-              </a>
+              PCIC {CE_CURRENT_VERSION}
             </Col>
             <Col lg={4} />
             <Col lg={4} />
@@ -28,6 +22,6 @@ class Footer extends Component {
       </div>
     );
   }
-}
+});
 
 export default Footer;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import AppController from './components/AppController';
 import DualController from './components/DualController';
 
 import Header from './components/Header';
+import Footer from './components/Footer';
 
 class App extends React.Component {
   static propTypes = {
@@ -22,6 +23,9 @@ class App extends React.Component {
         </div>
         <div>
           {this.props.children || <AppController ensemble_name="all_downscale_files"/>}
+        </div>
+        <div>
+          <Footer />
         </div>
       </div>
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ const GLOBALS = {
   NCWMS_URL : JSON.stringify(process.env.NCWMS_URL
       || 'http://tools.pacificclimate.org/ncWMS-PCIC/wms'),
   CE_ENSEMBLE_NAME : JSON.stringify(process.env.CE_ENSEMBLE_NAME || 'ce'),
+  CE_CURRENT_VERSION : JSON.stringify(process.env.CE_CURRENT_VERSION || 'Climate Explorer')
 };
 
 const AUTOPREFIXER_BROWSERS = [ 'Chrome >= 35', 'Firefox >= 31',


### PR DESCRIPTION

![screenshot from 2018-02-16 12-19-03](https://user-images.githubusercontent.com/4512605/36327522-ada06aaa-1313-11e8-8574-c9c7f2a7d383.png)
This is a little awkward. It uses a shell script run at startup to store a current version string in the environment variable `CE_CURRENT_VERSION`, which is then imported along with the other environment variables like `CE_BACKEND_URL`. 

I didn't find a good path forward for a pure javascript solution. simple-git wasn't playing well with our version of Node, and nodegit is a very powerful set of bindings to libgit, but people have reported having a hard time building it on Travis, which gave me pause. 

I'm open to suggestions for alternate approaches.