### PR TITLE
Add a future annual cycle graph

### DIFF
--- a/src/components/data-controllers/MotiDataController/MotiDataController.js
+++ b/src/components/data-controllers/MotiDataController/MotiDataController.js
@@ -34,9 +34,8 @@ import DataGraph from '../../graphs/DataGraph/DataGraph';
 import DataTable from '../../DataTable/DataTable';
 import DataControllerMixin from '../../DataControllerMixin';
 import {timeseriesToAnnualCycleGraph,
-        timeseriesToTimeseriesGraph} from '../../../core/chart';
+        timeseriesToTimeseriesGraph} from '../../../core/chart-generators';
 import { getStats } from '../../../data-services/ce-backend';
-
 import _ from 'underscore';
 
 import AnnualCycleGraph from '../../graphs/AnnualCycleGraph';

--- a/src/components/data-controllers/SingleDataController/SingleDataController.js
+++ b/src/components/data-controllers/SingleDataController/SingleDataController.js
@@ -46,7 +46,7 @@ import SingleLongTermAveragesGraph from '../../graphs/SingleLongTermAveragesGrap
 import SingleContextGraph from '../../graphs/SingleContextGraph';
 import SingleTimeSeriesGraph from '../../graphs/SingleTimeSeriesGraph';
 import { getStats } from '../../../data-services/ce-backend';
-import FutureAnnualCycleGraph from '../../graphs/FutureAnnualCycleGraph';
+import AnomalyAnnualCycleGraph from '../../graphs/AnomalyAnnualCycleGraph';
 
 // TODO: Remove DataControllerMixin and convert to class extension style when 
 // no more dependencies on DataControllerMixin remain
@@ -184,8 +184,8 @@ export default createReactClass({
               <Tab eventKey={3} title='Model Context'>
                 <SingleContextGraph {...this.props}/>
               </Tab>
-              <Tab eventKey={4} title='Future Annual Cycle'>
-                <FutureAnnualCycleGraph {...this.props} />
+              <Tab eventKey={4} title='Future Anomaly'>
+                <AnomalyAnnualCycleGraph {...this.props} />
               </Tab>
             </Tabs>
 

--- a/src/components/data-controllers/SingleDataController/SingleDataController.js
+++ b/src/components/data-controllers/SingleDataController/SingleDataController.js
@@ -46,6 +46,7 @@ import SingleLongTermAveragesGraph from '../../graphs/SingleLongTermAveragesGrap
 import SingleContextGraph from '../../graphs/SingleContextGraph';
 import SingleTimeSeriesGraph from '../../graphs/SingleTimeSeriesGraph';
 import { getStats } from '../../../data-services/ce-backend';
+import FutureAnnualCycleGraph from '../../graphs/FutureAnnualCycleGraph';
 
 // TODO: Remove DataControllerMixin and convert to class extension style when 
 // no more dependencies on DataControllerMixin remain
@@ -182,6 +183,9 @@ export default createReactClass({
               </Tab>
               <Tab eventKey={3} title='Model Context'>
                 <SingleContextGraph {...this.props}/>
+              </Tab>
+              <Tab eventKey={4} title='Future Annual Cycle'>
+                <FutureAnnualCycleGraph {...this.props} />
               </Tab>
             </Tabs>
 

--- a/src/components/graphs/AnomalyAnnualCycleGraph.js
+++ b/src/components/graphs/AnomalyAnnualCycleGraph.js
@@ -5,7 +5,7 @@
  * provides functions to help generate a graph specification contrasting
  * current (2010-2039) and future (2040-2069, 2070-2099) Annual Cycle data:
  * 
- *   - getMetadata locates metadata for up to three climatology periods
+ *   - getMetadata locates metadata for multiple three climatology periods
  *   - dataToGraphSpec formats a graph to shade the climatology periods
  * 
  * Similar to SingleAnnualCycleGraph, but instead of displaying the annual
@@ -62,7 +62,6 @@ export default function AnomalyAnnualCycleGraph(props) {
     // Select the lowest starting year as the base series for the anomaly graph
     let seriesNames = _.without(graph.data.columns.map(series => _.first(series)), 'x');
     seriesNames.sort();
-    console.log(seriesNames[0]);
     graph = makeAnomalyGraph(seriesNames[0], graph);
     return graph;
   }

--- a/src/components/graphs/AnomalyAnnualCycleGraph.js
+++ b/src/components/graphs/AnomalyAnnualCycleGraph.js
@@ -1,5 +1,5 @@
 /****************************************************************************
- * FutureAnnualCycleGraph.js - contrast present and future climatology values
+ * AnomalyAnnualCycleGraph.js - contrast present and future climatology values
  * 
  * Given a data specification (model_id, experiment, variable_id),
  * provides functions to help generate a graph specification contrasting
@@ -18,12 +18,12 @@ import React from 'react';
 import _ from 'underscore';
 
 import { timeseriesToAnnualCycleGraph } from '../../core/chart-generators';
-import { sortSeriesByRank } from '../../core/chart-formatters';
+import { makeAnomalyGraph } from '../../core/chart-transformers';
 import { findMatchingMetadata } from './graph-helpers';
 import AnnualCycleGraph from './AnnualCycleGraph';
 
 
-export default function FutureAnnualCycleGraph(props) {
+export default function AnomalyAnnualCycleGraph(props) {
   
   function getPresentMetadatas(includeFuture = false) {
     // returns an array of all metadata objects that conform 
@@ -58,7 +58,13 @@ export default function FutureAnnualCycleGraph(props) {
   }
 
   function dataToGraphSpec(meta, data) {
-    return timeseriesToAnnualCycleGraph(meta, ...data);
+    let graph = timeseriesToAnnualCycleGraph(meta, ...data);
+    // Select the lowest starting year as the base series for the anomaly graph
+    let seriesNames = _.without(graph.data.columns.map(series => _.first(series)), 'x');
+    seriesNames.sort();
+    console.log(seriesNames[0]);
+    graph = makeAnomalyGraph(seriesNames[0], graph);
+    return graph;
   }
 
   const graphProps = _.pick(props,

--- a/src/components/graphs/DualAnnualCycleGraph.js
+++ b/src/components/graphs/DualAnnualCycleGraph.js
@@ -2,9 +2,8 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import {
-  assignColoursByGroup, fadeSeriesByRank, timeseriesToAnnualCycleGraph,
-} from '../../core/chart';
+import {timeseriesToAnnualCycleGraph} from '../../core/chart-generators';
+import {assignColoursByGroup, fadeSeriesByRank} from '../../core/chart-formatters';
 import { findMatchingMetadata } from './graph-helpers';
 import AnnualCycleGraph from './AnnualCycleGraph';
 

--- a/src/components/graphs/DualLongTermAveragesGraph.js
+++ b/src/components/graphs/DualLongTermAveragesGraph.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import { dataToLongTermAverageGraph } from '../../core/chart';
+import { dataToLongTermAverageGraph } from '../../core/chart-generators';
 import { timeKeyToResolutionIndex } from '../../core/util';
 import LongTermAveragesGraph from './LongTermAveragesGraph';
 

--- a/src/components/graphs/DualTimeSeriesGraph.js
+++ b/src/components/graphs/DualTimeSeriesGraph.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import { timeseriesToTimeseriesGraph } from '../../core/chart';
+import { timeseriesToTimeseriesGraph } from '../../core/chart-generators';
 import TimeSeriesGraph from './TimeSeriesGraph';
 
 

--- a/src/components/graphs/DualVariableResponseGraph.js
+++ b/src/components/graphs/DualVariableResponseGraph.js
@@ -23,7 +23,9 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import { timeseriesToTimeseriesGraph, makeVariableResponseGraph } from '../../core/chart';
+import { timeseriesToTimeseriesGraph} from '../../core/chart-generators';
+import { makeVariableResponseGraph } from '../../core/chart-transformers';
+
 import VariableResponseGraph from './VariableResponseGraph';
 
 export default function DualVariableResponseGraph(props) {

--- a/src/components/graphs/FutureAnnualCycleGraph.js
+++ b/src/components/graphs/FutureAnnualCycleGraph.js
@@ -17,7 +17,8 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import { sortSeriesByRank, timeseriesToAnnualCycleGraph } from '../../core/chart';
+import { timeseriesToAnnualCycleGraph } from '../../core/chart-generators';
+import { sortSeriesByRank } from '../../core/chart-formatters';
 import { findMatchingMetadata } from './graph-helpers';
 import AnnualCycleGraph from './AnnualCycleGraph';
 

--- a/src/components/graphs/FutureAnnualCycleGraph.js
+++ b/src/components/graphs/FutureAnnualCycleGraph.js
@@ -1,0 +1,75 @@
+/****************************************************************************
+ * FutureAnnualCycleGraph.js - contrast present and future climatology values
+ * 
+ * Given a data specification (model_id, experiment, variable_id),
+ * provides functions to help generate a graph specification contrasting
+ * current (2010-2039) and future (2040-2069, 2070-2099) Annual Cycle data:
+ * 
+ *   - getMetadata locates metadata for up to three climatology periods
+ *   - dataToGraphSpec formats a graph to shade the climatology periods
+ * 
+ * Similar to SingleAnnualCycleGraph, but instead of displaying the annual
+ * cycle at multiple time resolutions (yearly, seasonal, monthly), the annual
+ * cycle is displayed for different climatology periods.
+ ****************************************************************************/
+
+import React from 'react';
+
+import _ from 'underscore';
+
+import { sortSeriesByRank, timeseriesToAnnualCycleGraph } from '../../core/chart';
+import { findMatchingMetadata } from './graph-helpers';
+import AnnualCycleGraph from './AnnualCycleGraph';
+
+
+export default function FutureAnnualCycleGraph(props) {
+  
+  function getPresentMetadatas(includeFuture = false) {
+    // returns an array of all metadata objects that conform 
+    // to the user-selected parameters and contain data that 
+    // includes the current year (or future years, if includeFuture is true).
+    const currentYear = new Date().getFullYear();
+    
+    return _.filter(props.meta, md => {
+      return md.model_id === props.model_id &&
+      md.experiment === props.experiment &&
+      md.variable_id === props.variable_id &&
+      md.end_date >= currentYear &&
+      (includeFuture || md.start_date <= currentYear);
+    });
+  }
+  
+  function getMetadata(dataSpec) {
+
+    const {
+      model_id, experiment,
+      variable_id, meta,
+    } = props;
+
+    // Find the highest-resolution dataset that describes the present.
+    const presentMetadatas = getPresentMetadatas();
+    const presentMetadata = _.findWhere(presentMetadatas, {timescale: "monthly"})
+                            || _.findWhere(presentMetadatas, {timescale: "seasonal"})
+                            || _.findWhere(presentMetadatas, {timescale: "annual"});
+
+    return _.isUndefined(presentMetadata)? [] : _.where(getPresentMetadatas(meta, true), 
+        {timescale: presentMetadata.timescale});
+  }
+
+  function dataToGraphSpec(meta, data) {
+    return timeseriesToAnnualCycleGraph(meta, ...data);
+  }
+
+  const graphProps = _.pick(props,
+    'model_id', 'variable_id', 'experiment', 'area'
+  );
+
+  return (
+    <AnnualCycleGraph
+      {...graphProps}
+      meta={getPresentMetadatas(false)}
+      getMetadata={getMetadata}
+      dataToGraphSpec={dataToGraphSpec}
+    />
+  );
+}

--- a/src/components/graphs/README.md
+++ b/src/components/graphs/README.md
@@ -12,6 +12,7 @@ The graph components form a dependency hierarchy as follows (root at top):
     selected variable(s) over a full year
         - `SingleAnnualCycleGraph`
         - `DualAnnualCycleGraph`
+        - `AnomalyAnnualCycleGraph` 
     - `ContextGraph`: graphs all matching datasets from other models, 
     overlaid, to provide context for selected model's dataset
         - `SingleContextGraph`

--- a/src/components/graphs/SingleAnnualCycleGraph.js
+++ b/src/components/graphs/SingleAnnualCycleGraph.js
@@ -2,7 +2,9 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import { sortSeriesByRank, timeseriesToAnnualCycleGraph } from '../../core/chart';
+import { timeseriesToAnnualCycleGraph } from '../../core/chart-generators';
+import { sortSeriesByRank } from '../../core/chart-formatters';
+
 import { findMatchingMetadata } from './graph-helpers';
 import AnnualCycleGraph from './AnnualCycleGraph';
 

--- a/src/components/graphs/SingleContextGraph.js
+++ b/src/components/graphs/SingleContextGraph.js
@@ -2,11 +2,9 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import {
-  assignColoursByGroup,
-  dataToLongTermAverageGraph, fadeSeriesByRank, hideSeriesInLegend,
-  sortSeriesByRank,
-} from '../../core/chart';
+import { dataToLongTermAverageGraph } from '../../core/chart-generators';
+import { assignColoursByGroup, fadeSeriesByRank,
+         hideSeriesInLegend, sortSeriesByRank } from '../../core/chart-formatters';
 import ContextGraph from './ContextGraph';
 
 

--- a/src/components/graphs/SingleLongTermAveragesGraph.js
+++ b/src/components/graphs/SingleLongTermAveragesGraph.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import { dataToLongTermAverageGraph } from '../../core/chart';
+import { dataToLongTermAverageGraph } from '../../core/chart-generators';
 import { timeKeyToResolutionIndex } from '../../core/util';
 import LongTermAveragesGraph from './LongTermAveragesGraph';
 

--- a/src/components/graphs/SingleTimeSeriesGraph.js
+++ b/src/components/graphs/SingleTimeSeriesGraph.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import { timeseriesToTimeseriesGraph } from '../../core/chart';
+import { timeseriesToTimeseriesGraph } from '../../core/chart-generators';
 import TimeSeriesGraph from './TimeSeriesGraph';
 
 

--- a/src/core/__tests__/chart-formatter-tests.js
+++ b/src/core/__tests__/chart-formatter-tests.js
@@ -15,34 +15,34 @@ jest.dontMock('../chart-formatters');
 jest.dontMock('../util');
 jest.dontMock('underscore');
 
-var cg = require('../chart-generators');
-var cf = require('../chart-formatters'); 
-var validate = require('../__test_data__/test-validators');
-var mockAPI = require('../__test_data__/sample-API-results');
+const cg = require('../chart-generators');
+const cf = require('../chart-formatters'); 
+const validate = require('../__test_data__/test-validators');
+const mockAPI = require('../__test_data__/sample-API-results');
 
 describe('assignColoursByGroup', function () {
-  var metadata = mockAPI.metadataToArray();
-  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+  const metadata = mockAPI.metadataToArray();
+  let graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
       mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
   it('assigns the same color to each series in a group', function () {
-    var segmentFunc = function (col) {return "group"};
-    var newChart = cf.assignColoursByGroup(graph, segmentFunc);
+    const segmentFunc = function (col) {return "group"};
+    let newChart = cf.assignColoursByGroup(graph, segmentFunc);
     expect(validate.allDefinedObject(newChart)).toBe(true);
-    var colourAssignments = newChart.data.colors;
-    var seriesKeys = Object.keys(colourAssignments);
+    const colourAssignments = newChart.data.colors;
+    const seriesKeys = Object.keys(colourAssignments);
     expect(seriesKeys.length).toBe(3);
-    for(var i = 0; i < seriesKeys.length; i++) {
-      expect(colourAssignments[seriesKeys[i]]).toMatch(colourAssignments[seriesKeys[0]]);
+    for(let key of seriesKeys) {
+      expect(colourAssignments[key]).toMatch(colourAssignments[seriesKeys[0]]);
     }
   });
   it('assigns different colours to different groups', function () {
-    var segmentFunc = function(col) {return col[0]};
-    var newChart = cf.assignColoursByGroup(graph, segmentFunc);
+    const segmentFunc = function(col) {return col[0]};
+    let newChart = cf.assignColoursByGroup(graph, segmentFunc);
     expect(validate.allDefinedObject(newChart)).toBe(true);
-    var assignments = newChart.data.colors;
-    var seriesKeys = Object.keys(assignments);
-    for(var i = 1; i < seriesKeys.length; i++) {
-      for(var j = 0; j < i; j++) {
+    const assignments = newChart.data.colors;
+    const seriesKeys = Object.keys(assignments);
+    for(let i = 0; i < seriesKeys.length; i++) {
+      for(let j = 0; j < i; j++) {
         expect(assignments[seriesKeys[i]]).not.toBe(assignments[seriesKeys[j]]);
       }
     }
@@ -50,52 +50,52 @@ describe('assignColoursByGroup', function () {
 });
 
 describe('fadeSeriesByRank', function () {
-  var metadata = mockAPI.metadataToArray();
-  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+  const metadata = mockAPI.metadataToArray();
+  let graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
       mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
   it('does not affect tier-1 series', function () {
-    var ranker = function(series) {return 1};
-    graph = cf.fadeSeriesByRank(graph, ranker);
-    var fader = graph.data.color;
-    var series = graph.data.columns;
-    for(var i = 0; i < series.length; i++) {
-      var faded = fader("#000000", series[i][0]);
+    const ranker1 = function(series) {return 1};
+    graph = cf.fadeSeriesByRank(graph, ranker1);
+    const fader = graph.data.color;
+    let series = graph.data.columns;
+    for(let s of series) {
+      const faded = fader("#000000", s[0]);
       expect(faded).toMatch("#000000");
     }
   });
   it('fades low-ranked series', function () {});
-  var ranker = function (series) {return .5};
-  graph = cf.fadeSeriesByRank(graph, ranker);
-  var fader = graph.data.color;
-  var series = graph.data.columns;
-  for(var i = 0; i < series.length; i++) {
-    var faded = fader("#000000", series[i][0]);
+  const ranker2 = function (series) {return .5};
+  graph = cf.fadeSeriesByRank(graph, ranker2);
+  const fader = graph.data.color;
+  const series = graph.data.columns;
+  for(let s of series) {
+    let faded = fader("#000000", s[0]);
     expect(faded).not.toMatch("#000000");
   }
 });
 
 describe('hideSeriesInLegend', function () {
-  var metadata = mockAPI.metadataToArray();
-  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+  const metadata = mockAPI.metadataToArray();
+  let graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
       mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
   it('removes data series from the lengend', function() {
-    var hideAll = function(series) {return true};
+    const hideAll = function(series) {return true};
     graph = cf.hideSeriesInLegend(graph, hideAll);
     expect(graph.legend.hide.length).toBe(3);
   });
   it('retains data series in the legend', function() {
-    var showAll = function(series) {return false};
+    const showAll = function(series) {return false};
     graph = cf.hideSeriesInLegend(graph, showAll);
     expect(graph.legend.hide.length).toBe(0);
   });
 });
 
 describe('sortSeriesByRank', function (){
-  var metadata = mockAPI.metadataToArray();
-  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+  const metadata = mockAPI.metadataToArray();
+  let graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
       mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-  var rankByTimeResolution = function (series) {
-    var resolutions = ["Yearly", "Seasonal", "Monthly"];
+  const rankByTimeResolution = function (series) {
+    const resolutions = ["Yearly", "Seasonal", "Monthly"];
     for(let i = 0; i < 3; i++) {
       if(series[0].search(resolutions[i]) != -1) {
         return i;
@@ -103,7 +103,7 @@ describe('sortSeriesByRank', function (){
     }
   }
   it('orders series by ranking', function () {
-    var ranked = cf.sortSeriesByRank(graph, rankByTimeResolution);
+    const ranked = cf.sortSeriesByRank(graph, rankByTimeResolution);
     expect(ranked.data.columns[0][0]).toBe("Yearly Mean");
     expect(ranked.data.columns[1][0]).toBe("Seasonal Mean");
     expect(ranked.data.columns[2][0]).toBe("Monthly Mean");
@@ -111,18 +111,18 @@ describe('sortSeriesByRank', function (){
 });
 
 describe('hideSeriesInToolTip', function () {
-  var metadata = mockAPI.metadataToArray();
-  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+  const metadata = mockAPI.metadataToArray();
+  let graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
       mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-  var formatFunction;
+  let formatFunction;
   it('removes data series from the tooltip', function() {
-    var hideAll = function(series) {return true};
+    const hideAll = function(series) {return true};
     graph = cf.hideSeriesInTooltip(graph, hideAll);
     formatFunction = graph.tooltip.format.value;
     expect(formatFunction(10, 19, "Yearly Mean")).toBeUndefined();
   });
   it('retains data series in the tooltip', function() {
-    var showAll = function(series) {return false};
+    const showAll = function(series) {return false};
     graph.tooltip.format.value = (a, b, c, d) => {return "test"};
     graph = cf.hideSeriesInTooltip(graph, showAll);
     formatFunction = graph.tooltip.format.value; 
@@ -131,10 +131,10 @@ describe('hideSeriesInToolTip', function () {
 });
 
 describe('getDataSeriesByAxis', function () {
-  var metadata = mockAPI.metadataToArray();
-  var twoAxes = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+  const metadata = mockAPI.metadataToArray();
+  let twoAxes = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
       mockAPI.monthlyPrTimeseries);
-  var oneAxis = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+  let oneAxis = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
       mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
   it('associates data series for a 1-axis graph', function () {
     expect(cf.getDataSeriesByAxis(oneAxis, 'y').length).toBe(3);
@@ -149,10 +149,10 @@ describe('getDataSeriesByAxis', function () {
 });
 
 describe('padYAxis', function () {
-  var metadata = mockAPI.metadataToArray();
-  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+  const metadata = mockAPI.metadataToArray();
+  let graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
       mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-  var func;
+  let func;
   it('rejects negative padding', function () {
     func = function ()  {cf.padYAxis(graph, "y", "top", -1);};
     expect(func).toThrow();
@@ -162,7 +162,7 @@ describe('padYAxis', function () {
     expect(func).toThrow();
   });
   it('rejects horizontal padding directions', function () {
-    var func = function ()  {cf.padYAxis(graph, "y", "left", -1);};
+    func = function ()  {cf.padYAxis(graph, "y", "left", -1);};
     expect(func).toThrow();
   });
   it('pads a graph by adding space at the top', function () {
@@ -184,11 +184,11 @@ describe('padYAxis', function () {
 });
 
 describe('hideTicksByRange', function () {
-  var metadata = mockAPI.metadataToArray();
-  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+  const metadata = mockAPI.metadataToArray();
+  let graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
       mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-  var graph = cf.hideTicksByRange(graph, "y", 10, 20);
-  var format = graph.axis.y.tick.format;
+  graph = cf.hideTicksByRange(graph, "y", 10, 20);
+  const format = graph.axis.y.tick.format;
   it('displays axis ticks inside designated range', function () {
     expect(format(15)).toBe(15);
     expect(format(10)).toBe(10);

--- a/src/core/__tests__/chart-formatter-tests.js
+++ b/src/core/__tests__/chart-formatter-tests.js
@@ -163,5 +163,21 @@ describe('padYAxis', function () {
       expect(graph.axis.y.min < currentMin).toBeTrue();
     }
   });
+});
 
-})
+describe('hideTicksByRange', function () {
+  var metadata = mockAPI.metadataToArray();
+  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+  var graph = cf.hideTicksByRange(graph, "y", 10, 20);
+  var format = graph.axis.y.tick.format;
+  it('displays axis ticks inside designated range', function () {
+    expect(format(15)).toBe(15);
+    expect(format(10)).toBe(10);
+    expect(format(20)).toBe(20);
+  });
+  it('does not display axis ticks outside designated range', function () {
+    expect(format(0)).toBe("");
+    expect(format(39)).toBe("");
+  });
+});

--- a/src/core/__tests__/chart-formatter-tests.js
+++ b/src/core/__tests__/chart-formatter-tests.js
@@ -130,6 +130,24 @@ describe('hideSeriesInToolTip', function () {
   });
 });
 
+describe('getDataSeriesByAxis', function () {
+  var metadata = mockAPI.metadataToArray();
+  var twoAxes = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.monthlyPrTimeseries);
+  var oneAxis = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+  it('associates data series for a 1-axis graph', function () {
+    expect(cf.getDataSeriesByAxis(oneAxis, 'y').length).toBe(3);
+    expect(cf.getDataSeriesByAxis(oneAxis, 'y2').length).toBe(0);
+    expect(cf.getDataSeriesByAxis(oneAxis, 'fakeaxis').length).toBe(0);
+  });
+  it('associates data series for a 2-axis graph', function () {
+    expect(cf.getDataSeriesByAxis(twoAxes, 'y').length).toBe(1);
+    expect(cf.getDataSeriesByAxis(twoAxes, 'y2').length).toBe(1);
+    expect(cf.getDataSeriesByAxis(twoAxes, 'fakeaxis').length).toBe(0);
+  })
+});
+
 describe('padYAxis', function () {
   var metadata = mockAPI.metadataToArray();
   var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,

--- a/src/core/__tests__/chart-formatter-tests.js
+++ b/src/core/__tests__/chart-formatter-tests.js
@@ -109,3 +109,59 @@ describe('sortSeriesByRank', function (){
     expect(ranked.data.columns[2][0]).toBe("Monthly Mean");
   });
 });
+
+describe('hideSeriesInToolTip', function () {
+  var metadata = mockAPI.metadataToArray();
+  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+  var formatFunction;
+  it('removes data series from the tooltip', function() {
+    var hideAll = function(series) {return true};
+    graph = cf.hideSeriesInTooltip(graph, hideAll);
+    formatFunction = graph.tooltip.format.value;
+    expect(formatFunction(10, 19, "Yearly Mean")).toBeUndefined();
+  });
+  it('retains data series in the tooltip', function() {
+    var showAll = function(series) {return false};
+    graph.tooltip.format.value = (a, b, c, d) => {return "test"};
+    graph = cf.hideSeriesInTooltip(graph, showAll);
+    formatFunction = graph.tooltip.format.value; 
+    expect(formatFunction(10, 29, "Monthly Mean", 0)).toBeDefined();
+  });
+});
+
+describe('padYAxis', function () {
+  var metadata = mockAPI.metadataToArray();
+  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+  var func;
+  it('rejects negative padding', function () {
+    func = function ()  {cf.padYAxis(graph, "y", "top", -1);};
+    expect(func).toThrow();
+  });
+  it('rejects nonexistant axes', function () {
+    func = function ()  {cf.padYAxis(graph, "y1", "top", -1);};
+    expect(func).toThrow();
+  });
+  it('rejects horizontal padding directions', function () {
+    var func = function ()  {cf.padYAxis(graph, "y", "left", -1);};
+    expect(func).toThrow();
+  });
+  it('pads a graph by adding space at the top', function () {
+    let currentMax = graph.axis.y.max;
+    graph = cf.padYAxis(graph, "y", "top", 1);
+    expect(graph.axis.y.max).toBeDefined();
+    if(currentMax !== undefined) {
+      expect(graph.axis.y.max > currentMax).toBeTrue();
+    }
+  });
+  it('pads a graph by adding space at the bottom', function () {
+    let currentMin = graph.axis.y.min;
+    graph = cf.padYAxis(graph, "y", "bottom", 1);
+    expect(graph.axis.y.min).toBeDefined();
+    if(currentMin !== undefined) {
+      expect(graph.axis.y.min < currentMin).toBeTrue();
+    }
+  });
+
+})

--- a/src/core/__tests__/chart-formatter-tests.js
+++ b/src/core/__tests__/chart-formatter-tests.js
@@ -1,0 +1,111 @@
+/******************************************************************
+ * chart-formatter-tests.js - tests for chart formatting functions
+ * 
+ * One test (sometimes with multiple parts) for each function in 
+ * chart-formatters.js. The tests have the same names and are in 
+ * the same order as the functions. 
+ * 
+ * test data from ./sample-API-results.js
+ * validation functions from ./test-validators.js
+ * chart generation uses chart-generators.js
+ ********************************************************************/
+
+jest.dontMock('../chart-generators');
+jest.dontMock('../chart-formatters');
+jest.dontMock('../util');
+jest.dontMock('underscore');
+
+var cg = require('../chart-generators');
+var cf = require('../chart-formatters'); 
+var validate = require('../__test_data__/test-validators');
+var mockAPI = require('../__test_data__/sample-API-results');
+
+describe('assignColoursByGroup', function () {
+  var metadata = mockAPI.metadataToArray();
+  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+  it('assigns the same color to each series in a group', function () {
+    var segmentFunc = function (col) {return "group"};
+    var newChart = cf.assignColoursByGroup(graph, segmentFunc);
+    expect(validate.allDefinedObject(newChart)).toBe(true);
+    var colourAssignments = newChart.data.colors;
+    var seriesKeys = Object.keys(colourAssignments);
+    expect(seriesKeys.length).toBe(3);
+    for(var i = 0; i < seriesKeys.length; i++) {
+      expect(colourAssignments[seriesKeys[i]]).toMatch(colourAssignments[seriesKeys[0]]);
+    }
+  });
+  it('assigns different colours to different groups', function () {
+    var segmentFunc = function(col) {return col[0]};
+    var newChart = cf.assignColoursByGroup(graph, segmentFunc);
+    expect(validate.allDefinedObject(newChart)).toBe(true);
+    var assignments = newChart.data.colors;
+    var seriesKeys = Object.keys(assignments);
+    for(var i = 1; i < seriesKeys.length; i++) {
+      for(var j = 0; j < i; j++) {
+        expect(assignments[seriesKeys[i]]).not.toBe(assignments[seriesKeys[j]]);
+      }
+    }
+  });  
+});
+
+describe('fadeSeriesByRank', function () {
+  var metadata = mockAPI.metadataToArray();
+  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+  it('does not affect tier-1 series', function () {
+    var ranker = function(series) {return 1};
+    graph = cf.fadeSeriesByRank(graph, ranker);
+    var fader = graph.data.color;
+    var series = graph.data.columns;
+    for(var i = 0; i < series.length; i++) {
+      var faded = fader("#000000", series[i][0]);
+      expect(faded).toMatch("#000000");
+    }
+  });
+  it('fades low-ranked series', function () {});
+  var ranker = function (series) {return .5};
+  graph = cf.fadeSeriesByRank(graph, ranker);
+  var fader = graph.data.color;
+  var series = graph.data.columns;
+  for(var i = 0; i < series.length; i++) {
+    var faded = fader("#000000", series[i][0]);
+    expect(faded).not.toMatch("#000000");
+  }
+});
+
+describe('hideSeriesInLegend', function () {
+  var metadata = mockAPI.metadataToArray();
+  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+  it('removes data series from the lengend', function() {
+    var hideAll = function(series) {return true};
+    graph = cf.hideSeriesInLegend(graph, hideAll);
+    expect(graph.legend.hide.length).toBe(3);
+  });
+  it('retains data series in the legend', function() {
+    var showAll = function(series) {return false};
+    graph = cf.hideSeriesInLegend(graph, showAll);
+    expect(graph.legend.hide.length).toBe(0);
+  });
+});
+
+describe('sortSeriesByRank', function (){
+  var metadata = mockAPI.metadataToArray();
+  var graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+  var rankByTimeResolution = function (series) {
+    var resolutions = ["Yearly", "Seasonal", "Monthly"];
+    for(let i = 0; i < 3; i++) {
+      if(series[0].search(resolutions[i]) != -1) {
+        return i;
+      }
+    }
+  }
+  it('orders series by ranking', function () {
+    var ranked = cf.sortSeriesByRank(graph, rankByTimeResolution);
+    expect(ranked.data.columns[0][0]).toBe("Yearly Mean");
+    expect(ranked.data.columns[1][0]).toBe("Seasonal Mean");
+    expect(ranked.data.columns[2][0]).toBe("Monthly Mean");
+  });
+});

--- a/src/core/__tests__/chart-generator-tests.js
+++ b/src/core/__tests__/chart-generator-tests.js
@@ -1,44 +1,43 @@
-/*******************************************************
- * chart-test.js - tests for functions in chart.js
+/*****************************************************************
+ * chart-generator-tests.js - tests for chart generation functions
  * 
- * One test (sometimes with multiple parts) for
- * each function in chart.js. The tests have the same 
- * names and are in the same order as the functions 
- * they test in chart.js. 
+ * One test (sometimes with multiple parts) for each function in 
+ * chart-generator-tests.js. The tests have the same names and are
+ * in the same order as the functions. 
  * 
  * test data from ./sample-API-results.js
  * validation functions from ./test-validators.js
  *******************************************************/
 
-jest.dontMock('../chart');
+jest.dontMock('../chart-generators');
 jest.dontMock('../util');
 jest.dontMock('underscore');
 
-var chart = require('../chart'); 
+var cg = require('../chart-generators'); 
 var validate = require('../__test_data__/test-validators');
 var mockAPI = require('../__test_data__/sample-API-results');
 
 describe ('formatYAxis', function () {
   it('formats a c3 y axis with units label', function () {
-    var axis = chart.formatYAxis("meters");
+    var axis = cg.formatYAxis("meters");
     expect(validate.allDefinedObject(axis)).toBe(true);
     expect(axis.label).toEqual({"text": "meters", "position": "outer-middle"});
     expect(axis.show).toEqual(true);
-    expect(axis.tick.format(6.993)).toEqual(chart.fixedPrecision(6.993));
+    expect(axis.tick.format(6.993)).toEqual(cg.fixedPrecision(6.993));
   });
 });
 
 describe('fixedPrecision', function () {
   it('formats a positive number for user display', function () {
-    var formatted = chart.fixedPrecision(6.22222);
+    var formatted = cg.fixedPrecision(6.22222);
     expect(formatted).toEqual(6.22);
   });
   it('formats a negative number for user display', function() {
-    var formatted = chart.fixedPrecision(-6.3333);
+    var formatted = cg.fixedPrecision(-6.3333);
     expect(formatted).toEqual(-6.33);
   });
   it('rounds a number for user display', function () {
-    var formatted = chart.fixedPrecision(6.9999);
+    var formatted = cg.fixedPrecision(6.9999);
     expect(formatted).toEqual(7);
   });
 });
@@ -48,38 +47,38 @@ describe('makePrecisionBySeries', function () {
   //.yaml config file that isn't easily available during jest testing. 
   //In non-test usage the file is transformed and made available by webpack.
   xit('reads the config file and applies its settings', function() {
-    var precision = chart.makePrecisionBySeries({"testseries": "tasmin"});
+    var precision = cg.makePrecisionBySeries({"testseries": "tasmin"});
     expect(precision(4.777, "testseries")).toEqual(4.8);
   });
   it('uses a default precision for unspecified variables', function () {
-    var precision = chart.makePrecisionBySeries({"testseries": "tasmin"});
+    var precision = cg.makePrecisionBySeries({"testseries": "tasmin"});
     expect(precision(4.777, "testseries")).toEqual(4.78);
   });
 });
 
 describe('makeTooltipDisplayNumbersWithUnits', function () {
   var axis = {};
-  axis.y = chart.formatYAxis("meters");
+  axis.y = cg.formatYAxis("meters");
   var axes = {};
   var series1 = "height";
   var series2 = "depth";
   axes[series1] = "y";
   var tooltipFunction;
   it('displays unit labels when there is a single data series', function () {
-    tooltipFunction = chart.makeTooltipDisplayNumbersWithUnits(axes, axis);
+    tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
     expect(tooltipFunction(5, 0, series1, 0)).toEqual("5 meters");
   });
   it('displays unit labels when there are multiple data series', function () {
     axes[series2] = "y";
-    tooltipFunction = chart.makeTooltipDisplayNumbersWithUnits(axes, axis);
+    tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
     expect(tooltipFunction(6.22, 0, series1, 0)).toEqual("6.22 meters");
     expect(tooltipFunction(7.8, 0, series2, 0)).toEqual("7.8 meters");
   });
   it('displays unit labels when there are multiple unit types', function () {
     var series3 = "weight";
-    axis.y2 = chart.formatYAxis("kilograms");
+    axis.y2 = cg.formatYAxis("kilograms");
     axes[series3] = "y2";
-    tooltipFunction = chart.makeTooltipDisplayNumbersWithUnits(axes, axis);
+    tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
     expect(tooltipFunction(9.73, 0, series1, 0)).toEqual("9.73 meters");
     expect(tooltipFunction(-2.4, 0, series2, 0)).toEqual("-2.4 meters");
     expect(tooltipFunction(100000, 0, series3, 0)).toEqual("100000 kilograms");
@@ -92,13 +91,13 @@ describe('timeseriesToAnnualCycleGraph', function () {
     var fakeData = JSON.parse(JSON.stringify(mockAPI.monthlyTasminTimeseries));
     fakeData.units = "meters";
     var func = function () {
-      chart.timeseriesToAnnualCycleGraph(metadata, fakeData, 
+      cg.timeseriesToAnnualCycleGraph(metadata, fakeData, 
           mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyPrTimeseries);
       };
     expect(func).toThrow();  
   });
   it('displays a single timeseries', function () {
-    var c = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
+    var c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(c.data.columns.length).toEqual(1);
     expect(c.data.columns[0].length).toEqual(13);
@@ -107,7 +106,7 @@ describe('timeseriesToAnnualCycleGraph', function () {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays monthly, seasonal, and annual timeseries together', function () {
-    var c = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+    var c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
         mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(validate.isRectangularArray(c.data.columns, 3, 13)).toBe(true);
@@ -117,7 +116,7 @@ describe('timeseriesToAnnualCycleGraph', function () {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays two different variables at once', function () {
-    var c = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+    var c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyTasminTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(validate.isRectangularArray(c.data.columns, 2, 13)).toBe(true);
@@ -127,7 +126,7 @@ describe('timeseriesToAnnualCycleGraph', function () {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays two variables with different units at once', function () {
-    var c = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+    var c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyPrTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(validate.isRectangularArray(c.data.columns, 2, 13)).toBe(true);
@@ -144,26 +143,26 @@ describe('getMonthlyData', function () {
     for(var i = 0; i < 17; i++){
       seventeen[Date(i)] = i * 3;
     }
-    var tooMany = function() {chart.getMonthlyData(seventeen);};
+    var tooMany = function() {cg.getMonthlyData(seventeen);};
     expect(tooMany).toThrow();
   });
   it('rejects data with inconsistent time resolution', function () {
-    var inconsistent = function () {chart.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, "yearly");};
+    var inconsistent = function () {cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, "yearly");};
     expect(inconsistent).toThrow();
   });
   it('processes a monthly timeseries', function () {
-    var processed = chart.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, "monthly");
+    var processed = cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, "monthly");
     expect(processed.length).toEqual(12);
     expect(processed[5]).toEqual(11.841563876512202);
     expect(processed[11]).toEqual(-16.96361296358877);    
   });
   it('processes a seasonal timeseries', function () {
-    var processed = chart.getMonthlyData(mockAPI.seasonalTasmaxTimeseries.data, "seasonal");
+    var processed = cg.getMonthlyData(mockAPI.seasonalTasmaxTimeseries.data, "seasonal");
     expect(processed.length).toEqual(12);
     expect(processed[0]).toEqual(processed[11]);
   });
   it('processes an annual timeseries', function() {
-    var processed = chart.getMonthlyData(mockAPI.annualTasmaxTimeseries.data, "yearly");
+    var processed = cg.getMonthlyData(mockAPI.annualTasmaxTimeseries.data, "yearly");
     expect(processed.length).toEqual(12);
     expect(processed[0]).toEqual(processed[7]);
     expect(processed[4]).toEqual(processed[11]);
@@ -175,15 +174,15 @@ describe('shortestUniqueTimeseriesNamingFunction', function () {
   it('rejects identical time series', function () {
     var minimalMetadata = [{unique_id: "foo", md: "bar"}, {unique_id: "baz", md: "bar"}];
     var minimalData = [{id: "foo"}, {id: "baz"}];
-    var func = function() {chart.shortestUniqueTimeseriesNamingFunction(minimalMetadata, minimalData);};
+    var func = function() {cg.shortestUniqueTimeseriesNamingFunction(minimalMetadata, minimalData);};
     expect(func).toThrow();
   });
   it('uses a a default naming scheme for a single data series', function () {
-    var nameFunction = chart.shortestUniqueTimeseriesNamingFunction(metadata, [mockAPI.monthlyTasmaxTimeseries]);
+    var nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, [mockAPI.monthlyTasmaxTimeseries]);
     expect(nameFunction(metadata[0])).toEqual("Monthly Mean");
   });
   it('names series by time resolution', function () {
-    var nameFunction = chart.shortestUniqueTimeseriesNamingFunction(metadata, 
+    var nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, 
         [mockAPI.monthlyTasmaxTimeseries, mockAPI.seasonalTasmaxTimeseries, 
           mockAPI.annualTasmaxTimeseries]);
     expect(nameFunction(metadata[0])).toEqual("Monthly Mean");
@@ -191,7 +190,7 @@ describe('shortestUniqueTimeseriesNamingFunction', function () {
     expect(nameFunction(metadata[2])).toEqual("Yearly Mean");
   });
   it('names series by variable', function () {
-    var nameFunction = chart.shortestUniqueTimeseriesNamingFunction(metadata, 
+    var nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, 
         [mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyTasminTimeseries]);
     expect(nameFunction(metadata[0])).toEqual("Tasmax Mean");
     expect(nameFunction(metadata[3])).toEqual("Tasmin Mean");
@@ -200,12 +199,12 @@ describe('shortestUniqueTimeseriesNamingFunction', function () {
 
 describe('dataToLongTermAverageGraph', function() {
   it('rejects datasets with missing metadata', function () {
-    var func = function () {chart.dataToLongTermAverageGraph(
+    var func = function () {cg.dataToLongTermAverageGraph(
         [mockAPI.tasmaxData, mockAPI.tasminData]);};
     expect(func).toThrow();      
   });
   it('graphs a single data series', function() {
-    var c = chart.dataToLongTermAverageGraph([mockAPI.tasmaxData]);
+    var c = cg.dataToLongTermAverageGraph([mockAPI.tasmaxData]);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(c.data.columns.length).toEqual(2);
     expect(c.data.columns[0].length).toEqual(7);
@@ -216,7 +215,7 @@ describe('dataToLongTermAverageGraph', function() {
   it('graphs multiple data series', function () {
     var tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
     var tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
-    var c = chart.dataToLongTermAverageGraph(
+    var c = cg.dataToLongTermAverageGraph(
         [mockAPI.tasmaxData, mockAPI.tasminData],
         [tasmaxQuery, tasminQuery]);
     expect(validate.allDefinedObject(c)).toBe(true);
@@ -230,7 +229,7 @@ describe('dataToLongTermAverageGraph', function() {
     var tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
     var tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
     var prQuery = {"variable_id": "pr", "model_id": "bcc-csm1-1-m"};
-    var c = chart.dataToLongTermAverageGraph(
+    var c = cg.dataToLongTermAverageGraph(
         [mockAPI.tasmaxData, mockAPI.tasminData, mockAPI.prData],
         [tasmaxQuery, tasminQuery, prQuery]);
     expect(validate.allDefinedObject(c)).toBe(true);
@@ -245,37 +244,37 @@ describe('dataToLongTermAverageGraph', function() {
 
 describe('getAllTimestamps', function() {
   it('throws an error if there is no data', function () {
-    var func = function () {chart.getAllTimestamps([]);};
+    var func = function () {cg.getAllTimestamps([]);};
     expect(func).toThrow();
   });
   it('throws an error if there are no available timestamps', function () {
-    var func = function () {chart.getAllTimestamps([{"r1p1i1": {"data": {}}}]);};
+    var func = function () {cg.getAllTimestamps([{"r1p1i1": {"data": {}}}]);};
     expect(func).toThrow();
   });
   it('returns timestamps associated with a data API call', function () {
-    var stamps = chart.getAllTimestamps([mockAPI.tasmaxData]);
+    var stamps = cg.getAllTimestamps([mockAPI.tasmaxData]);
     expect(stamps.length).toBe(6);
   });
   it('combines timestamps from multiple data API calls', function () {
     var fakeData = JSON.parse(JSON.stringify(mockAPI.tasminData));
     fakeData["r1i1p1"].data = {"1990-04-01T00:00:00Z": 20, "1997-01-15T00:00:00Z": 0};
-    var stamps = chart.getAllTimestamps([mockAPI.tasmaxData, fakeData]);
+    var stamps = cg.getAllTimestamps([mockAPI.tasmaxData, fakeData]);
     expect(stamps.length).toBe(7);
   });
   it('extracts timestamps from timeseries API calls', function () {
-    var stamps = chart.getAllTimestamps([mockAPI.monthlyTasmaxTimeseries, mockAPI.seasonalTasmaxTimeseries]);
+    var stamps = cg.getAllTimestamps([mockAPI.monthlyTasmaxTimeseries, mockAPI.seasonalTasmaxTimeseries]);
     expect(stamps.length).toBe(16);
   });
 });
 
 describe('nameAPICallParametersFunction', function () {
   it('refuses identical data sets', function () {
-    var func = function () {chart.nameAPICallParametersFunction(
+    var func = function () {cg.nameAPICallParametersFunction(
         [{"variable": "foo"}, {"variable": "foo"}]);};
     expect(func).toThrow();
   });
   it('refuses data sets calculated over different areas', function () {
-    var func = function () {chart.nameAPICallParametersFunction(
+    var func = function () {cg.nameAPICallParametersFunction(
         [{"area": "POLYGON+((-114,+-113,+-103,+-104+63,+-114+63))"},
          {"area": "POLYGON+((-115,+-113,+-103,+-105+63,+-115+63))"}]);};
     expect(func).toThrow();
@@ -283,7 +282,7 @@ describe('nameAPICallParametersFunction', function () {
   it('assigns distinct names to data sets', function () {
     var tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
     var tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
-    var nameFunction = chart.nameAPICallParametersFunction([tasmaxQuery, tasminQuery]);
+    var nameFunction = cg.nameAPICallParametersFunction([tasmaxQuery, tasminQuery]);
     expect(nameFunction("r1i1p1", tasmaxQuery)).toBe("tasmax r1i1p1");
     expect(nameFunction("r1i1p1", tasminQuery)).toBe("tasmin r1i1p1");
   });
@@ -295,13 +294,13 @@ describe('timeseriesToTimeSeriesGraph', function () {
     var fakeData = JSON.parse(JSON.stringify(mockAPI.monthlyTasminTimeseries));
     fakeData.units = "meters";
     var func = function () {
-      chart.timeseriesToTimeseriesGraph(metadata, fakeData,
+      cg.timeseriesToTimeseriesGraph(metadata, fakeData,
           mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyPrTimeseries);
       };
     expect(func).toThrow();
   });
   it('displays a single timeseries', function () {
-    var c = chart.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
+    var c = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(c.data.columns[0][0]).toMatch('x');
     expect(c.data.columns.length).toEqual(2);
@@ -311,7 +310,7 @@ describe('timeseriesToTimeSeriesGraph', function () {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays two timeseries with different units', function() {
-    var c = chart.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+    var c = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyPrTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(c.data.columns[0][0]).toMatch('x');
@@ -320,131 +319,5 @@ describe('timeseriesToTimeSeriesGraph', function () {
     expect(c.axis.x).toBeDefined();
     expect(c.axis.y).toBeDefined();
     expect(c.axis.y2).toBeDefined();
-  });
-});
-
-describe('assignColoursByGroup', function () {
-  var metadata = mockAPI.metadataToArray();
-  var graph = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
-      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-  it('assigns the same color to each series in a group', function () {
-    var segmentFunc = function (col) {return "group"};
-    var newChart = chart.assignColoursByGroup(graph, segmentFunc);
-    expect(validate.allDefinedObject(newChart)).toBe(true);
-    var colourAssignments = newChart.data.colors;
-    var seriesKeys = Object.keys(colourAssignments);
-    expect(seriesKeys.length).toBe(3);
-    for(var i = 0; i < seriesKeys.length; i++) {
-      expect(colourAssignments[seriesKeys[i]]).toMatch(colourAssignments[seriesKeys[0]]);
-    }
-  });
-  it('assigns different colours to different groups', function () {
-    var segmentFunc = function(col) {return col[0]};
-    var newChart = chart.assignColoursByGroup(graph, segmentFunc);
-    expect(validate.allDefinedObject(newChart)).toBe(true);
-    var assignments = newChart.data.colors;
-    var seriesKeys = Object.keys(assignments);
-    for(var i = 1; i < seriesKeys.length; i++) {
-      for(var j = 0; j < i; j++) {
-        expect(assignments[seriesKeys[i]]).not.toBe(assignments[seriesKeys[j]]);
-      }
-    }
-  });  
-});
-
-describe('fadeSeriesByRank', function () {
-  var metadata = mockAPI.metadataToArray();
-  var graph = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
-      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-  it('does not affect tier-1 series', function () {
-    var ranker = function(series) {return 1};
-    graph = chart.fadeSeriesByRank(graph, ranker);
-    var fader = graph.data.color;
-    var series = graph.data.columns;
-    for(var i = 0; i < series.length; i++) {
-      var faded = fader("#000000", series[i][0]);
-      expect(faded).toMatch("#000000");
-    }
-  });
-  it('fades low-ranked series', function () {});
-  var ranker = function (series) {return .5};
-  graph = chart.fadeSeriesByRank(graph, ranker);
-  var fader = graph.data.color;
-  var series = graph.data.columns;
-  for(var i = 0; i < series.length; i++) {
-    var faded = fader("#000000", series[i][0]);
-    expect(faded).not.toMatch("#000000");
-  }
-});
-
-describe('hideSeriesInLegend', function () {
-  var metadata = mockAPI.metadataToArray();
-  var graph = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
-      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-  it('removes data series from the lengend', function() {
-    var hideAll = function(series) {return true};
-    graph = chart.hideSeriesInLegend(graph, hideAll);
-    expect(graph.legend.hide.length).toBe(3);
-  });
-  it('retains data series in the legend', function() {
-    var showAll = function(series) {return false};
-    graph = chart.hideSeriesInLegend(graph, showAll);
-    expect(graph.legend.hide.length).toBe(0);
-  });
-});
-
-describe('sortSeriesByRank', function (){
-  var metadata = mockAPI.metadataToArray();
-  var graph = chart.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
-      mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-  var rankByTimeResolution = function (series) {
-    var resolutions = ["Yearly", "Seasonal", "Monthly"];
-    for(let i = 0; i < 3; i++) {
-      if(series[0].search(resolutions[i]) != -1) {
-        return i;
-      }
-    }
-  }
-  it('orders series by ranking', function () {
-    var ranked = chart.sortSeriesByRank(graph, rankByTimeResolution);
-    expect(ranked.data.columns[0][0]).toBe("Yearly Mean");
-    expect(ranked.data.columns[1][0]).toBe("Seasonal Mean");
-    expect(ranked.data.columns[2][0]).toBe("Monthly Mean");
-  });
-});
-
-describe('makeVariableResponseGraph', function () {
-  it('transforms two timeseries into a scatterplot', function() {
-    var c = chart.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
-        mockAPI.monthlyTasmaxTimeseries,
-        mockAPI.monthlyPrTimeseries);
-    c = chart.makeVariableResponseGraph("pr", "tasmax", c);
-    expect(validate.allDefinedObject(c)).toBe(true);
-    for(let i = 0; i < 12; i++) {
-      let pr = Object.values(mockAPI.monthlyPrTimeseries)[i];
-      let tasmax = Object.values(mockAPI.monthlyTasmaxTimeseries)[i];
-      let pri = c.data.columns[0].indexOf(pr);
-      let tasmaxi = c.data.columns[1].indexOf(tasmax);
-      expect(pri).toEqual(tasmaxi);
-    }
-  });
-});
-
-describe('getAxisTextForVariable', function () {
-  it('retrieves axis labels for a two-variable graph', function () {
-    var c = chart.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
-        mockAPI.monthlyTasmaxTimeseries,
-        mockAPI.monthlyPrTimeseries);
-    expect(chart.getAxisTextForVariable(c, "tasmax")).toBe("degC");
-    expect(chart.getAxisTextForVariable(c, "pr")).toBe("kg m-2 d-1");
-  });
-  it('throws an error on a single-variable graph', function () {
-    var c2 = chart.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
-        mockAPI.monthlyTasmaxTimeseries,
-        mockAPI.seasonalTasmaxTimeseries, 
-        mockAPI.annualTasmaxTimeseries);
-    var func = function () {
-      chart.getAxisTextForVariable(c2, "tasmax");      };
-    expect(func).toThrow(); 
   });
 });

--- a/src/core/__tests__/chart-generator-tests.js
+++ b/src/core/__tests__/chart-generator-tests.js
@@ -13,13 +13,13 @@ jest.dontMock('../chart-generators');
 jest.dontMock('../util');
 jest.dontMock('underscore');
 
-var cg = require('../chart-generators'); 
-var validate = require('../__test_data__/test-validators');
-var mockAPI = require('../__test_data__/sample-API-results');
+const cg = require('../chart-generators'); 
+const validate = require('../__test_data__/test-validators');
+const mockAPI = require('../__test_data__/sample-API-results');
 
 describe ('formatYAxis', function () {
   it('formats a c3 y axis with units label', function () {
-    var axis = cg.formatYAxis("meters");
+    const axis = cg.formatYAxis("meters");
     expect(validate.allDefinedObject(axis)).toBe(true);
     expect(axis.label).toEqual({"text": "meters", "position": "outer-middle"});
     expect(axis.show).toEqual(true);
@@ -29,15 +29,15 @@ describe ('formatYAxis', function () {
 
 describe('fixedPrecision', function () {
   it('formats a positive number for user display', function () {
-    var formatted = cg.fixedPrecision(6.22222);
+    const formatted = cg.fixedPrecision(6.22222);
     expect(formatted).toEqual(6.22);
   });
   it('formats a negative number for user display', function() {
-    var formatted = cg.fixedPrecision(-6.3333);
+    const formatted = cg.fixedPrecision(-6.3333);
     expect(formatted).toEqual(-6.33);
   });
   it('rounds a number for user display', function () {
-    var formatted = cg.fixedPrecision(6.9999);
+    const formatted = cg.fixedPrecision(6.9999);
     expect(formatted).toEqual(7);
   });
 });
@@ -47,23 +47,23 @@ describe('makePrecisionBySeries', function () {
   //.yaml config file that isn't easily available during jest testing. 
   //In non-test usage the file is transformed and made available by webpack.
   xit('reads the config file and applies its settings', function() {
-    var precision = cg.makePrecisionBySeries({"testseries": "tasmin"});
+    const precision = cg.makePrecisionBySeries({"testseries": "tasmin"});
     expect(precision(4.777, "testseries")).toEqual(4.8);
   });
   it('uses a default precision for unspecified variables', function () {
-    var precision = cg.makePrecisionBySeries({"testseries": "tasmin"});
+    const precision = cg.makePrecisionBySeries({"testseries": "tasmin"});
     expect(precision(4.777, "testseries")).toEqual(4.78);
   });
 });
 
 describe('makeTooltipDisplayNumbersWithUnits', function () {
-  var axis = {};
+  let axis = {};
   axis.y = cg.formatYAxis("meters");
-  var axes = {};
-  var series1 = "height";
-  var series2 = "depth";
+  let axes = {};
+  const series1 = "height";
+  const series2 = "depth";
   axes[series1] = "y";
-  var tooltipFunction;
+  let tooltipFunction;
   it('displays unit labels when there is a single data series', function () {
     tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
     expect(tooltipFunction(5, 0, series1, 0)).toEqual("5 meters");
@@ -75,7 +75,7 @@ describe('makeTooltipDisplayNumbersWithUnits', function () {
     expect(tooltipFunction(7.8, 0, series2, 0)).toEqual("7.8 meters");
   });
   it('displays unit labels when there are multiple unit types', function () {
-    var series3 = "weight";
+    const series3 = "weight";
     axis.y2 = cg.formatYAxis("kilograms");
     axes[series3] = "y2";
     tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
@@ -86,18 +86,18 @@ describe('makeTooltipDisplayNumbersWithUnits', function () {
 });
 
 describe('timeseriesToAnnualCycleGraph', function () {
-  var metadata = mockAPI.metadataToArray();
+  const metadata = mockAPI.metadataToArray();
   it('rejects data sets with too many units', function () {
-    var fakeData = JSON.parse(JSON.stringify(mockAPI.monthlyTasminTimeseries));
+    let fakeData = JSON.parse(JSON.stringify(mockAPI.monthlyTasminTimeseries));
     fakeData.units = "meters";
-    var func = function () {
+    const func = function () {
       cg.timeseriesToAnnualCycleGraph(metadata, fakeData, 
           mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyPrTimeseries);
       };
     expect(func).toThrow();  
   });
   it('displays a single timeseries', function () {
-    var c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
+    const c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(c.data.columns.length).toEqual(1);
     expect(c.data.columns[0].length).toEqual(13);
@@ -106,7 +106,7 @@ describe('timeseriesToAnnualCycleGraph', function () {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays monthly, seasonal, and annual timeseries together', function () {
-    var c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+    const c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
         mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(validate.isRectangularArray(c.data.columns, 3, 13)).toBe(true);
@@ -116,7 +116,7 @@ describe('timeseriesToAnnualCycleGraph', function () {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays two different variables at once', function () {
-    var c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+    const c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyTasminTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(validate.isRectangularArray(c.data.columns, 2, 13)).toBe(true);
@@ -126,7 +126,7 @@ describe('timeseriesToAnnualCycleGraph', function () {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays two variables with different units at once', function () {
-    var c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+    const c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyPrTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(validate.isRectangularArray(c.data.columns, 2, 13)).toBe(true);
@@ -139,30 +139,30 @@ describe('timeseriesToAnnualCycleGraph', function () {
 
 describe('getMonthlyData', function () {
   it('rejects data with an unsupported time resolution', function (){
-    var seventeen = {};
-    for(var i = 0; i < 17; i++){
+    let seventeen = {};
+    for(let i = 0; i < 17; i++){
       seventeen[Date(i)] = i * 3;
     }
-    var tooMany = function() {cg.getMonthlyData(seventeen);};
+    const tooMany = function() {cg.getMonthlyData(seventeen);};
     expect(tooMany).toThrow();
   });
   it('rejects data with inconsistent time resolution', function () {
-    var inconsistent = function () {cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, "yearly");};
+    const inconsistent = function () {cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, "yearly");};
     expect(inconsistent).toThrow();
   });
   it('processes a monthly timeseries', function () {
-    var processed = cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, "monthly");
+    const processed = cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, "monthly");
     expect(processed.length).toEqual(12);
     expect(processed[5]).toEqual(11.841563876512202);
     expect(processed[11]).toEqual(-16.96361296358877);    
   });
   it('processes a seasonal timeseries', function () {
-    var processed = cg.getMonthlyData(mockAPI.seasonalTasmaxTimeseries.data, "seasonal");
+    const processed = cg.getMonthlyData(mockAPI.seasonalTasmaxTimeseries.data, "seasonal");
     expect(processed.length).toEqual(12);
     expect(processed[0]).toEqual(processed[11]);
   });
   it('processes an annual timeseries', function() {
-    var processed = cg.getMonthlyData(mockAPI.annualTasmaxTimeseries.data, "yearly");
+    const processed = cg.getMonthlyData(mockAPI.annualTasmaxTimeseries.data, "yearly");
     expect(processed.length).toEqual(12);
     expect(processed[0]).toEqual(processed[7]);
     expect(processed[4]).toEqual(processed[11]);
@@ -170,19 +170,19 @@ describe('getMonthlyData', function () {
 });
 
 describe('shortestUniqueTimeseriesNamingFunction', function () {
-  var metadata = mockAPI.metadataToArray();
+  const metadata = mockAPI.metadataToArray();
   it('rejects identical time series', function () {
-    var minimalMetadata = [{unique_id: "foo", md: "bar"}, {unique_id: "baz", md: "bar"}];
-    var minimalData = [{id: "foo"}, {id: "baz"}];
-    var func = function() {cg.shortestUniqueTimeseriesNamingFunction(minimalMetadata, minimalData);};
+    const minimalMetadata = [{unique_id: "foo", md: "bar"}, {unique_id: "baz", md: "bar"}];
+    const minimalData = [{id: "foo"}, {id: "baz"}];
+    const func = function() {cg.shortestUniqueTimeseriesNamingFunction(minimalMetadata, minimalData);};
     expect(func).toThrow();
   });
   it('uses a a default naming scheme for a single data series', function () {
-    var nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, [mockAPI.monthlyTasmaxTimeseries]);
+    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, [mockAPI.monthlyTasmaxTimeseries]);
     expect(nameFunction(metadata[0])).toEqual("Monthly Mean");
   });
   it('names series by time resolution', function () {
-    var nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, 
+    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, 
         [mockAPI.monthlyTasmaxTimeseries, mockAPI.seasonalTasmaxTimeseries, 
           mockAPI.annualTasmaxTimeseries]);
     expect(nameFunction(metadata[0])).toEqual("Monthly Mean");
@@ -190,7 +190,7 @@ describe('shortestUniqueTimeseriesNamingFunction', function () {
     expect(nameFunction(metadata[2])).toEqual("Yearly Mean");
   });
   it('names series by variable', function () {
-    var nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, 
+    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, 
         [mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyTasminTimeseries]);
     expect(nameFunction(metadata[0])).toEqual("Tasmax Mean");
     expect(nameFunction(metadata[3])).toEqual("Tasmin Mean");
@@ -199,12 +199,12 @@ describe('shortestUniqueTimeseriesNamingFunction', function () {
 
 describe('dataToLongTermAverageGraph', function() {
   it('rejects datasets with missing metadata', function () {
-    var func = function () {cg.dataToLongTermAverageGraph(
+    const func = function () {cg.dataToLongTermAverageGraph(
         [mockAPI.tasmaxData, mockAPI.tasminData]);};
     expect(func).toThrow();      
   });
   it('graphs a single data series', function() {
-    var c = cg.dataToLongTermAverageGraph([mockAPI.tasmaxData]);
+    const c = cg.dataToLongTermAverageGraph([mockAPI.tasmaxData]);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(c.data.columns.length).toEqual(2);
     expect(c.data.columns[0].length).toEqual(7);
@@ -213,9 +213,9 @@ describe('dataToLongTermAverageGraph', function() {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('graphs multiple data series', function () {
-    var tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
-    var tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
-    var c = cg.dataToLongTermAverageGraph(
+    const tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
+    const tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
+    const c = cg.dataToLongTermAverageGraph(
         [mockAPI.tasmaxData, mockAPI.tasminData],
         [tasmaxQuery, tasminQuery]);
     expect(validate.allDefinedObject(c)).toBe(true);
@@ -226,10 +226,10 @@ describe('dataToLongTermAverageGraph', function() {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('graphs data series with distinct units', function () {
-    var tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
-    var tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
-    var prQuery = {"variable_id": "pr", "model_id": "bcc-csm1-1-m"};
-    var c = cg.dataToLongTermAverageGraph(
+    const tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
+    const tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
+    const prQuery = {"variable_id": "pr", "model_id": "bcc-csm1-1-m"};
+    const c = cg.dataToLongTermAverageGraph(
         [mockAPI.tasmaxData, mockAPI.tasminData, mockAPI.prData],
         [tasmaxQuery, tasminQuery, prQuery]);
     expect(validate.allDefinedObject(c)).toBe(true);
@@ -244,63 +244,63 @@ describe('dataToLongTermAverageGraph', function() {
 
 describe('getAllTimestamps', function() {
   it('throws an error if there is no data', function () {
-    var func = function () {cg.getAllTimestamps([]);};
+    const func = function () {cg.getAllTimestamps([]);};
     expect(func).toThrow();
   });
   it('throws an error if there are no available timestamps', function () {
-    var func = function () {cg.getAllTimestamps([{"r1p1i1": {"data": {}}}]);};
+    const func = function () {cg.getAllTimestamps([{"r1p1i1": {"data": {}}}]);};
     expect(func).toThrow();
   });
   it('returns timestamps associated with a data API call', function () {
-    var stamps = cg.getAllTimestamps([mockAPI.tasmaxData]);
+    const stamps = cg.getAllTimestamps([mockAPI.tasmaxData]);
     expect(stamps.length).toBe(6);
   });
   it('combines timestamps from multiple data API calls', function () {
-    var fakeData = JSON.parse(JSON.stringify(mockAPI.tasminData));
+    let fakeData = JSON.parse(JSON.stringify(mockAPI.tasminData));
     fakeData["r1i1p1"].data = {"1990-04-01T00:00:00Z": 20, "1997-01-15T00:00:00Z": 0};
-    var stamps = cg.getAllTimestamps([mockAPI.tasmaxData, fakeData]);
+    const stamps = cg.getAllTimestamps([mockAPI.tasmaxData, fakeData]);
     expect(stamps.length).toBe(7);
   });
   it('extracts timestamps from timeseries API calls', function () {
-    var stamps = cg.getAllTimestamps([mockAPI.monthlyTasmaxTimeseries, mockAPI.seasonalTasmaxTimeseries]);
+    const stamps = cg.getAllTimestamps([mockAPI.monthlyTasmaxTimeseries, mockAPI.seasonalTasmaxTimeseries]);
     expect(stamps.length).toBe(16);
   });
 });
 
 describe('nameAPICallParametersFunction', function () {
   it('refuses identical data sets', function () {
-    var func = function () {cg.nameAPICallParametersFunction(
+    const func = function () {cg.nameAPICallParametersFunction(
         [{"variable": "foo"}, {"variable": "foo"}]);};
     expect(func).toThrow();
   });
   it('refuses data sets calculated over different areas', function () {
-    var func = function () {cg.nameAPICallParametersFunction(
+    const func = function () {cg.nameAPICallParametersFunction(
         [{"area": "POLYGON+((-114,+-113,+-103,+-104+63,+-114+63))"},
          {"area": "POLYGON+((-115,+-113,+-103,+-105+63,+-115+63))"}]);};
     expect(func).toThrow();
   });
   it('assigns distinct names to data sets', function () {
-    var tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
-    var tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
-    var nameFunction = cg.nameAPICallParametersFunction([tasmaxQuery, tasminQuery]);
+    const tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
+    const tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
+    const nameFunction = cg.nameAPICallParametersFunction([tasmaxQuery, tasminQuery]);
     expect(nameFunction("r1i1p1", tasmaxQuery)).toBe("tasmax r1i1p1");
     expect(nameFunction("r1i1p1", tasminQuery)).toBe("tasmin r1i1p1");
   });
 });
 
 describe('timeseriesToTimeSeriesGraph', function () {
-  var metadata = mockAPI.metadataToArray();
+  const metadata = mockAPI.metadataToArray();
   it('rejects data sets with too many units', function () {
-    var fakeData = JSON.parse(JSON.stringify(mockAPI.monthlyTasminTimeseries));
+    let fakeData = JSON.parse(JSON.stringify(mockAPI.monthlyTasminTimeseries));
     fakeData.units = "meters";
-    var func = function () {
+    const func = function () {
       cg.timeseriesToTimeseriesGraph(metadata, fakeData,
           mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyPrTimeseries);
       };
     expect(func).toThrow();
   });
   it('displays a single timeseries', function () {
-    var c = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
+    const c = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(c.data.columns[0][0]).toMatch('x');
     expect(c.data.columns.length).toEqual(2);
@@ -310,7 +310,7 @@ describe('timeseriesToTimeSeriesGraph', function () {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays two timeseries with different units', function() {
-    var c = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+    const c = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyPrTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(c.data.columns[0][0]).toMatch('x');

--- a/src/core/__tests__/chart-transformer-tests.js
+++ b/src/core/__tests__/chart-transformer-tests.js
@@ -1,0 +1,59 @@
+/******************************************************************
+ * chart-transformer-tests.js - tests for chart transformation 
+ * functions
+ * 
+ * One test (sometimes with multiple parts) for each function in 
+ * chart-transformers. The tests have the same names and are in 
+ * the same order as the functions. 
+ * 
+ * test data from ./sample-API-results.js
+ * validation functions from ./test-validators.js
+ * chart generation uses chart-generators.js
+ ********************************************************************/
+
+jest.dontMock('../chart-generators');
+jest.dontMock('../chart-transformers');
+jest.dontMock('../util');
+jest.dontMock('underscore');
+
+var cg = require('../chart-generators');
+var ct = require('../chart-transformers'); 
+var validate = require('../__test_data__/test-validators');
+var mockAPI = require('../__test_data__/sample-API-results');
+
+
+describe('makeVariableResponseGraph', function () {
+  it('transforms two timeseries into a scatterplot', function() {
+    var c = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+        mockAPI.monthlyTasmaxTimeseries,
+        mockAPI.monthlyPrTimeseries);
+    c = ct.makeVariableResponseGraph("pr", "tasmax", c);
+    expect(validate.allDefinedObject(c)).toBe(true);
+    for(let i = 0; i < 12; i++) {
+      let pr = Object.values(mockAPI.monthlyPrTimeseries)[i];
+      let tasmax = Object.values(mockAPI.monthlyTasmaxTimeseries)[i];
+      let pri = c.data.columns[0].indexOf(pr);
+      let tasmaxi = c.data.columns[1].indexOf(tasmax);
+      expect(pri).toEqual(tasmaxi);
+    }
+  });
+});
+
+describe('getAxisTextForVariable', function () {
+  it('retrieves axis labels for a two-variable graph', function () {
+    var c = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+        mockAPI.monthlyTasmaxTimeseries,
+        mockAPI.monthlyPrTimeseries);
+    expect(ct.getAxisTextForVariable(c, "tasmax")).toBe("degC");
+    expect(ct.getAxisTextForVariable(c, "pr")).toBe("kg m-2 d-1");
+  });
+  it('throws an error on a single-variable graph', function () {
+    var c2 = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
+        mockAPI.monthlyTasmaxTimeseries,
+        mockAPI.seasonalTasmaxTimeseries, 
+        mockAPI.annualTasmaxTimeseries);
+    var func = function () {
+      ct.getAxisTextForVariable(c2, "tasmax");      };
+    expect(func).toThrow(); 
+  });
+});

--- a/src/core/__tests__/chart-transformer-tests.js
+++ b/src/core/__tests__/chart-transformer-tests.js
@@ -16,15 +16,15 @@ jest.dontMock('../chart-transformers');
 jest.dontMock('../util');
 jest.dontMock('underscore');
 
-var cg = require('../chart-generators');
-var ct = require('../chart-transformers'); 
-var validate = require('../__test_data__/test-validators');
-var mockAPI = require('../__test_data__/sample-API-results');
+const cg = require('../chart-generators');
+const ct = require('../chart-transformers'); 
+const validate = require('../__test_data__/test-validators');
+const mockAPI = require('../__test_data__/sample-API-results');
 
 
 describe('makeVariableResponseGraph', function () {
   it('transforms two timeseries into a scatterplot', function() {
-    var c = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+    let c = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
         mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyPrTimeseries);
     c = ct.makeVariableResponseGraph("pr", "tasmax", c);
@@ -41,18 +41,18 @@ describe('makeVariableResponseGraph', function () {
 
 describe('getAxisTextForVariable', function () {
   it('retrieves axis labels for a two-variable graph', function () {
-    var c = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+    const c = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
         mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyPrTimeseries);
     expect(ct.getAxisTextForVariable(c, "tasmax")).toBe("degC");
     expect(ct.getAxisTextForVariable(c, "pr")).toBe("kg m-2 d-1");
   });
   it('throws an error on a single-variable graph', function () {
-    var c2 = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
+    const c2 = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
         mockAPI.monthlyTasmaxTimeseries,
         mockAPI.seasonalTasmaxTimeseries, 
         mockAPI.annualTasmaxTimeseries);
-    var func = function () {
+    const func = function () {
       ct.getAxisTextForVariable(c2, "tasmax");      };
     expect(func).toThrow(); 
   });
@@ -69,11 +69,11 @@ describe('makeAnomalyGraph', function() {
     expect(doubleFunc).toThrow();
   });
   it('rejects graphs with no base data', function () {
-    let noBaseGraph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+    const noBaseGraph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
         mockAPI.monthlyTasmaxTimeseries,
         mockAPI.seasonalTasmaxTimeseries, 
         mockAPI.annualTasmaxTimeseries);
-    let noBaseFunc= function () { ct.makeAnomalyGraph("pr", noBaseGraph)};
+    const noBaseFunc= function () { ct.makeAnomalyGraph("pr", noBaseGraph)};
     expect(noBaseFunc).toThrow();
   });
   it('rejects graphs with mismatched data resolutions', function () {
@@ -82,15 +82,15 @@ describe('makeAnomalyGraph', function() {
         mockAPI.seasonalTasmaxTimeseries, 
         mockAPI.annualTasmaxTimeseries);
     dataMissingGraph.data.columns[1] = dataMissingGraph.data.columns[1].slice(0, 5);
-    let dataMissingFunc = function () {ct.makeAnomalyGraph("Monthly Mean", dataMissingGraph)};
+    const dataMissingFunc = function () {ct.makeAnomalyGraph("Monthly Mean", dataMissingGraph)};
     expect(dataMissingFunc).toThrow();
   });
   it('generates an anomaly graph', function () {
-    let graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+    const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
         mockAPI.monthlyTasmaxTimeseries,
         mockAPI.seasonalTasmaxTimeseries, 
         mockAPI.annualTasmaxTimeseries);
-    let anomalyGraph = ct.makeAnomalyGraph("Monthly Mean", graph);
+    const anomalyGraph = ct.makeAnomalyGraph("Monthly Mean", graph);
     expect(anomalyGraph.data.columns.length).toBe(5);
     expect(validate.allDefinedObject(anomalyGraph)).toBe(true);
     expect(validate.allDefinedArray(anomalyGraph.data.columns)).toBe(true);
@@ -100,13 +100,13 @@ describe('makeAnomalyGraph', function() {
 
 describe('addAnomalyTooltipFormatter', function () {
   it('appends an anomaly value to tooltip listings', function () {
-  let graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
       mockAPI.monthlyTasmaxTimeseries,
       mockAPI.seasonalTasmaxTimeseries, 
       mockAPI.annualTasmaxTimeseries);
-  let oldTooltipFormat = graph.tooltip.format.value;
-  let anomalyGraph = ct.makeAnomalyGraph("Monthly Mean", graph);
-  let newTooltipFormat = anomalyGraph.tooltip.format.value;
+  const oldTooltipFormat = graph.tooltip.format.value;
+  const anomalyGraph = ct.makeAnomalyGraph("Monthly Mean", graph);
+  const newTooltipFormat = anomalyGraph.tooltip.format.value;
   expect(oldTooltipFormat(-18, 0, "Monthly Mean", 1)).toBe("-18 degC");
   expect(newTooltipFormat(-18, 0, "Monthly Mean", 1)).toBe("-18 degC (+0.81)");
   });

--- a/src/core/__tests__/chart-transformer-tests.js
+++ b/src/core/__tests__/chart-transformer-tests.js
@@ -91,7 +91,7 @@ describe('makeAnomalyGraph', function() {
         mockAPI.seasonalTasmaxTimeseries, 
         mockAPI.annualTasmaxTimeseries);
     let anomalyGraph = ct.makeAnomalyGraph("Monthly Mean", graph);
-    expect(anomalyGraph.data.columns.length).toBe(6);
+    expect(anomalyGraph.data.columns.length).toBe(5);
     expect(validate.allDefinedObject(anomalyGraph)).toBe(true);
     expect(validate.allDefinedArray(anomalyGraph.data.columns)).toBe(true);
     expect(anomalyGraph.axis.y2).toBeDefined();

--- a/src/core/__tests__/export-test.js
+++ b/src/core/__tests__/export-test.js
@@ -10,7 +10,7 @@
  ******************************************************************/
 
 jest.dontMock('../util');
-jest.dontMock('../chart');
+jest.dontMock('../chart-generators');
 jest.dontMock('../export');
 jest.dontMock('underscore');
 jest.dontMock('xlsx');
@@ -21,7 +21,7 @@ var exportdata = require('../export');
 var validate = require('../__test_data__/test-validators');
 var mockAPI = require('../__test_data__/sample-API-results');
 var util = require('../util');
-var chart = require('../chart');
+var chart = require('../chart-generators');
 
 /*
  * It's not clear how to test exportDataToWorksheet, which would require

--- a/src/core/chart-formatters.js
+++ b/src/core/chart-formatters.js
@@ -184,7 +184,6 @@ var sortSeriesByRank = function(graph, ranker) {
   return graph;
 };
 
-//TODO: this function needs a test.
 /*
  * Post-processing graph function that hides specific series from the tooltip.
  * 
@@ -220,7 +219,6 @@ var hideSeriesInTooltip = function(graph, predicate) {
   return graph;
 }
 
-//TODO: this function needs a test
 /*
  * Post-processing graph function that adds extra space above or below
  * data on a graph by setting the y-axis maximums and minimums to multiples
@@ -236,11 +234,15 @@ var hideSeriesInTooltip = function(graph, predicate) {
  */
 var padYAxis = function (graph, axis = "y", direction = "top", padding = 1) {
   if(padding <= 0) {
-    throw new Error("Graph axis padding value must be greater than 0");
+    throw new Error("Error: Graph axis padding value must be greater than 0");
   }
   
   if(direction != "top" && direction != "bottom") {
-    throw new Error("Unknown graph axis padding direction");
+    throw new Error("Error: Unknown graph axis padding direction");
+  }
+  
+  if(axis !== "y" && axis !== "y2") {
+    throw new Error("Error: invalid scaling axis");
   }
   
   // if this graph does not yet have minimums and maximums defined, calculate

--- a/src/core/chart-formatters.js
+++ b/src/core/chart-formatters.js
@@ -231,6 +231,16 @@ function hideSeriesInTooltip (graph, predicate) {
 /****************************************************************************
  * 1. Axis formatters
  ****************************************************************************/
+/*
+ * Helper function that returns an array of all data series associated with 
+ * a specific y axis (y or y2). Ignores category or time series, if present.
+ */
+function getDataSeriesByAxis(graph, axis) {
+  return _.filter(graph.data.columns, series => {
+    const seriesName = series[0];
+    return seriesName !== 'x' && graph.data.axes[seriesName] === axis;
+  });
+}
 
 /*
  * Post-processing graph function that adds extra space above or below
@@ -262,9 +272,7 @@ function padYAxis (graph, axis = "y", direction = "top", padding = 1) {
   // them from the data.
   let min = graph.axis[axis].min;
   let max = graph.axis[axis].max
-  const axisSeries = _.filter(graph.data.columns, series => {
-      return series[0] !== 'x' && graph.data.axes[series[0]] === axis
-    });
+  const axisSeries = getDataSeriesByAxis(graph, axis);
   
   if(_.isUndefined(min)) {
     min = _.min(_.map(axisSeries, series => _.min(series)));
@@ -296,9 +304,7 @@ function padYAxis (graph, axis = "y", direction = "top", padding = 1) {
 
 function hideTicksByRange(graph, axis = "y", min, max) {
   const oldFormatFunction = graph.axis[axis].tick.format;
-  const axisSeries = _.filter(graph.data.columns, series => {
-    return series[0] !== 'x' && graph.data.axes[series[0]] === axis
-  });
+  const axisSeries = getDataSeriesByAxis(graph, axis);
   
   //if a range is not supplied, generate one from the data
   const genMin = _.isUndefined(min);
@@ -325,4 +331,7 @@ function hideTicksByRange(graph, axis = "y", min, max) {
 
 module.exports = { assignColoursByGroup, fadeSeriesByRank,
     hideSeriesInLegend, sortSeriesByRank, hideSeriesInTooltip,
-    padYAxis, hideTicksByRange};
+    padYAxis, hideTicksByRange,
+    //helper functions exported only for testing:
+    getDataSeriesByAxis
+    };

--- a/src/core/chart-formatters.js
+++ b/src/core/chart-formatters.js
@@ -1,0 +1,188 @@
+/************************************************************************
+ * chart-formatters.js - functions that modify a C3 chart specification
+ *   to alter the way data is displayed to make charts more readable. These
+ *   functions do not affect the data itself, only its formatting and display.
+ * 
+ * Each function in this file accepts a C3 graph specification object and a
+ * segmentation function. The segmentation function will be applied to each
+ * data series in the C3 graph object, with the results being used to decide
+ * how to format data from that series. It returns the modified graph spec.
+ * 
+ * The functions in this file are:
+ *  - assignColoursByGroup: assigns the same display colour to all data series
+ *      belonging to the same group
+ *      
+ *  - fadeSeriesByRank: lightens the colours used to display data series assigned
+ *      a lower rank, to make them less distracting from the "main" data.
+ *      
+ *  - hideSeriesInLegend: removes specific data series from the legend
+ *  
+ *  - sortSeriesByRank: draw higher ranked data series above (higher z-axis)
+ *      lower ranked series
+ ***************************************************************************/
+import _ from 'underscore';
+import {PRECISION,
+        extendedDateToBasicDate,
+        capitalizeWords,
+        caseInsensitiveStringSearch,
+        nestedAttributeIsDefined,
+        getVariableOptions} from './util';
+import chroma from 'chroma-js';
+
+/*
+ * Reiteration of D3's "category10" colors. They underlie c3's default
+ * colours but are not directly accessible. Allows creating custom
+ * colour palettes that use the same colors as the default assignments.
+ */
+
+var category10Colours = ["#1f77b4",
+                         "#ff7f03",
+                         "#2ca02c",
+                         "#d62728",
+                         "#9467bd",
+                         "#8c564b",
+                         "#e377c2",
+                         "#7f7f7f",
+                         "#bcbd22",
+                         "#17becf"];
+
+
+/*
+ * Post-processing graph function that assigns shared colours to
+ * related data series.
+ *
+ * Accepts a C3 graph object and a segmentation function. Applies the
+ * segmentation function to each data column in the graph object. All
+ * data columns that evaluate to the same result are grouped together
+ * and assigned the same display colour.
+ *
+ * Returns a modified graph object with colours assigned in graph.data.colors
+ * accordingly.
+ *
+ * _.isEqual() is used to evaluate whether two segmentation results are equal.
+ * Each data column is an array with the series name in the 0th location, example:
+ *
+ * ['Monthly Mean Tasmin', 30, 20, 50, 40, 60, 50, 10, 10, 20, 30, 40, 50]
+ *
+ */
+var assignColoursByGroup = function (graph, segmentor, colourList = category10Colours) {
+  var categories = [];
+  var colors = {};
+
+  _.each(graph.data.columns, column => {
+    var seriesName = column[0];
+    if(!_.isEqual(seriesName, "x")) { //"x" series used to provide categories, not data.
+      var category = segmentor(column);
+      var index = _.indexOf(categories, category);
+      if(index == -1) {
+        //first time we've encountered this category,
+        //add it to the list.
+        categories.push(category);
+        if(categories.length > colourList.length) {
+          throw new Error("Error: too many data categories for colour palette");
+        }
+        index = categories.length - 1;
+      }
+      colors[seriesName] = colourList[index];
+    }
+  });
+  graph.data.colors = colors;
+  return graph;
+};
+
+/*
+ * Post-processing graph function that visually de-emphasizes certain
+ * data series by lightening their assigned colour. (Assumes the graph
+ * has a white background, otherwise lightening isn't de-emphasizing.)
+ *
+ * Accepts a C3 graph object and a ranking function. The ranking function
+ * will be applied to each data column in the graph object, and should
+ * output a number between 0 and 1, which will be used to determine the
+ * visual prominence of the associated data series. Series ranked 1 will
+ * be drawn normally with their assigned colour, values less than one and
+ * greater than zero will be lightened proportionately. A data series ranked
+ * 0 by the ranking function will be drawn in white.
+ *
+ * Returns the graph object, modified by the addition of a data.color
+ * function to operate on assigned series colours.
+ * Each data column passed to the ranking function is an array like this:
+ *
+ * ['Monthly Mean Tasmin', 30, 20, 50, 40, 60, 50, 10, 10, 20, 30, 40, 50]
+ */
+var fadeSeriesByRank = function (graph, ranker) {
+
+  var rankDictionary = {};
+
+  _.each(graph.data.columns, column => {
+    var seriesName = column[0];
+    if(!_.isEqual(seriesName, "x")) {
+      rankDictionary[seriesName] = ranker(column);
+    }
+  });
+
+  //c3 will pass the function the assigned colour, and either:
+  //     * a string with the name of the time series (drawing legend)
+  //     * an object with attributes about the time series (drawing a point or line)
+  var fader = function(colour, d) {
+    var scale = chroma.scale(['white', colour]);
+    if(_.isObject(d)) { //d = data attributes
+      return scale(rankDictionary[d.id]).hex();
+    }
+    else { //d = series name only
+      return scale(rankDictionary[d]).hex();
+    }
+  };
+
+  graph.data.color = fader;
+  return graph;
+};
+
+/*
+ * Post-processing graph function that removes data series from the legend.
+ *
+ * Accepts a C3 graph and a predicate function. Applies the predicate to
+ * each data series. If the predicate returns true, the data series will
+ * be hidden from the legend. If the predicate returns false, the data series
+ * will appear in the legend as normal.
+ *
+ * By default, every data series appears in the legend; this postprocessor
+ * is only needed if at least one series should be hidden.
+ */
+var hideSeriesInLegend = function(graph, predicate) {
+  var hiddenSeries = [];
+
+  _.each(graph.data.columns, column => {
+    var seriesName = column[0];
+    if(!_.isEqual(seriesName, "x")) {
+      if(predicate(column)){
+        hiddenSeries.push(seriesName);
+      }
+    }
+  });
+
+  if(!graph.legend) {
+    graph.legend = {};
+  }
+
+  graph.legend.hide = hiddenSeries;
+  return graph;
+};
+
+/*
+ * Post-processing graph function that sets the order of the data series.
+ * The last-drawn series is the most clearly visible; its points and lines
+ * will be on top where they intersect with other series.
+ *
+ * Accepts a C3 graph and a ranking function. The ranking function will be
+ * applied to each series in the graph, and the series will be sorted by the
+ * ranking function's results. The higher a series is ranked, the later it
+ * will be drawn and the more prominent it will appear.
+ */
+var sortSeriesByRank = function(graph, ranker) {
+  var sorter = function(a, b) {return ranker(a) - ranker(b);}
+  graph.data.columns = graph.data.columns.sort(sorter);
+  return graph;
+};
+
+module.exports = { assignColoursByGroup, fadeSeriesByRank,
+    hideSeriesInLegend, sortSeriesByRank};

--- a/src/core/chart-formatters.js
+++ b/src/core/chart-formatters.js
@@ -69,27 +69,27 @@ const category10Colours = ["#1f77b4",
  * Accepts a C3 graph object and a segmentation function. Applies the
  * segmentation function to each data column in the graph object. All
  * data columns that evaluate to the same result are grouped together
- * and assigned the same display colour.
+ * and assigned the same display colour. _.isEqual() is used (by _.indexOf()) 
+ * to evaluate whether two segmentation results are equal.
  *
  * Returns a modified graph object with colours assigned in graph.data.colors
  * accordingly.
  *
- * _.isEqual() is used to evaluate whether two segmentation results are equal.
  * Each data column is an array with the series name in the 0th location, example:
  *
  * ['Monthly Mean Tasmin', 30, 20, 50, 40, 60, 50, 10, 10, 20, 30, 40, 50]
  *
  */
 function assignColoursByGroup (graph, segmentor, colourList = category10Colours) {
-  var categories = [];
-  var colors = {};
+  let categories = [];
+  let colors = {};
 
-  _.each(graph.data.columns, column => {
-    var seriesName = column[0];
-    if(!_.isEqual(seriesName, "x")) { //"x" series used to provide categories, not data.
-      var category = segmentor(column);
-      var index = _.indexOf(categories, category);
-      if(index == -1) {
+  for(let column of graph.data.columns) {
+    const seriesName = column[0];
+    if(seriesName !== "x") { //"x" series used to provide categories, not data.
+      let category = segmentor(column);
+      let index = _.indexOf(categories, category);
+      if(index === -1) {
         //first time we've encountered this category,
         //add it to the list.
         categories.push(category);
@@ -100,7 +100,7 @@ function assignColoursByGroup (graph, segmentor, colourList = category10Colours)
       }
       colors[seriesName] = colourList[index];
     }
-  });
+  }
   graph.data.colors = colors;
   return graph;
 };
@@ -126,20 +126,20 @@ function assignColoursByGroup (graph, segmentor, colourList = category10Colours)
  */
 function fadeSeriesByRank (graph, ranker) {
 
-  var rankDictionary = {};
+  let rankDictionary = {};
 
-  _.each(graph.data.columns, column => {
-    var seriesName = column[0];
-    if(!_.isEqual(seriesName, "x")) {
+  for(let column of graph.data.columns) {
+    const seriesName = column[0];
+    if(seriesName !== "x") {
       rankDictionary[seriesName] = ranker(column);
     }
-  });
+  }
 
   //c3 will pass the function the assigned colour, and either:
   //     * a string with the name of the time series (drawing legend)
   //     * an object with attributes about the time series (drawing a point or line)
-  var fader = function(colour, d) {
-    var scale = chroma.scale(['white', colour]);
+  function fader (colour, d) {
+    const scale = chroma.scale(['white', colour]);
     if(_.isObject(d)) { //d = data attributes
       return scale(rankDictionary[d.id]).hex();
     }
@@ -150,7 +150,7 @@ function fadeSeriesByRank (graph, ranker) {
 
   graph.data.color = fader;
   return graph;
-};
+}
 
 /*
  * Post-processing graph function that removes data series from the legend.
@@ -164,14 +164,12 @@ function fadeSeriesByRank (graph, ranker) {
  * is only needed if at least one series should be hidden.
  */
 function hideSeriesInLegend (graph, predicate) {
-  var hiddenSeries = [];
+  let hiddenSeries = [];
 
   _.each(graph.data.columns, column => {
-    var seriesName = column[0];
-    if(!_.isEqual(seriesName, "x")) {
-      if(predicate(column)){
-        hiddenSeries.push(seriesName);
-      }
+    const seriesName = column[0];
+    if(seriesName !== "x" && predicate(column)) {
+      hiddenSeries.push(seriesName);
     }
   });
 
@@ -194,7 +192,7 @@ function hideSeriesInLegend (graph, predicate) {
  * will be drawn and the more prominent it will appear.
  */
 function sortSeriesByRank (graph, ranker) {
-  var sorter = function(a, b) {return ranker(a) - ranker(b);}
+  const sorter = function(a, b) {return ranker(a) - ranker(b);}
   graph.data.columns = graph.data.columns.sort(sorter);
   return graph;
 };

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -34,7 +34,7 @@ import chroma from 'chroma-js';
  *****************************************************/
 
 //Generates a typical y-axis configuration, given the text of the label.
-var formatYAxis = function (label) {
+function formatYAxis (label) {
   return {
     "label": {
       "text": label,
@@ -52,7 +52,7 @@ var formatYAxis = function (label) {
  * Used as a default when a more specialized formatting function isn't
  * available; ignores all its inputs except the number to be formatted.
  */
-var fixedPrecision = function (n, ...rest) { return +n.toFixed(PRECISION);};
+function fixedPrecision (n, ...rest) { return +n.toFixed(PRECISION);};
 
 /*
  * Accepts a object with seriesname:variable pairs.
@@ -61,7 +61,7 @@ var fixedPrecision = function (n, ...rest) { return +n.toFixed(PRECISION);};
  * file for the associated variable, or a default precision with
  * util.PRECISION for variables with no precision options in the file.
  */
-var makePrecisionBySeries = function (series) {
+function makePrecisionBySeries (series) {
   var dictionary = {};
   for(var s in series) {
     var fromConfig = getVariableOptions(series[s], "decimalPrecision");
@@ -86,7 +86,7 @@ var makePrecisionBySeries = function (series) {
  * numbers. precisionFunction will be passed the number to format and the
  * series id it belongs to.
  */
-var makeTooltipDisplayNumbersWithUnits = function(axes, axis, precisionFunction) {
+function makeTooltipDisplayNumbersWithUnits (axes, axis, precisionFunction) {
   var unitsDictionary = {};
   if(_.isUndefined(precisionFunction)) { //use a default.
     precisionFunction = fixedPrecision;
@@ -130,7 +130,7 @@ var makeTooltipDisplayNumbersWithUnits = function(axes, axis, precisionFunction)
  * seasonal (4), or yearly (1); an error will be thrown 
  * if this function is called on data with another time resolution.
  */
-var timeseriesToAnnualCycleGraph = function(metadata, ...data) {
+function timeseriesToAnnualCycleGraph (metadata, ...data) {
 
   //blank graph data object to be populated - holds data values
   //and individual-timeseries-level display options.
@@ -210,7 +210,7 @@ var timeseriesToAnnualCycleGraph = function(metadata, ...data) {
  * and returns an array with twelve values in order by timestamp,
  * repeating values as necessary to get a monthly-resolution sequence.
  */
-var getMonthlyData = function(data, timescale = "monthly") {
+function getMonthlyData (data, timescale = "monthly") {
 
   var expectedTimestamps = {"monthly": 12, "seasonal": 4, "yearly": 1};
   var monthlyData = [];
@@ -256,7 +256,7 @@ var getMonthlyData = function(data, timescale = "monthly") {
 //TODO: special case climatological period to display as (XXXX-XXXX)
 //TODO: possibly cue descriptors to appear in a specific order?
 // "Tasmin Monthly Mean" sounds better than "Monthly Tasmin Mean".
-var shortestUniqueTimeseriesNamingFunction = function (metadata, data) {
+function shortestUniqueTimeseriesNamingFunction (metadata, data) {
   if (metadata.length === 0) {
     throw new Error('No data to show');
   }
@@ -306,7 +306,7 @@ var shortestUniqueTimeseriesNamingFunction = function (metadata, data) {
  * Helper constant for timeseriesToAnnualCycleGraph: an X-axis configuration 
  * object representing a categorical axis labeled in months.
  */
-var monthlyXAxis = {
+const monthlyXAxis = {
     type: 'category',
     categories: ['January', 'February', 'March', 'April', 'May', 'June',
           'July', 'August', 'September', 'October', 'November', 'December']
@@ -359,7 +359,7 @@ var monthlyXAxis = {
  * The context objects are used in the graph legend, to distinguish runs
  * with the same name ("r1i1p1") from different datasets.
  */
-var dataToLongTermAverageGraph = function(data, contexts = []){
+function dataToLongTermAverageGraph (data, contexts = []){
 
   //blank graph data object to be populated - holds data values
   //and individual-timeseries-level display options.
@@ -470,7 +470,7 @@ var dataToLongTermAverageGraph = function(data, contexts = []){
  * Helper function for dataToLongTermAverageGraph. Extracts the
  * list of all unique timestamps found in the data.
  */
-var getAllTimestamps = function(data) {
+function getAllTimestamps (data) {
   var allTimes = [];
 
   var addSeries = function(seriesData) {
@@ -508,7 +508,7 @@ var getAllTimestamps = function(data) {
  * specific run's call and other calls being graphed at the same time. 
  * Example: "tasmax r1i1p1" vs "pr r1i1p1"
  */
-var nameAPICallParametersFunction = function(contexts) {
+function nameAPICallParametersFunction (contexts) {
   
   var variation = [];
   var exemplarContext = contexts[0];
@@ -551,7 +551,7 @@ var nameAPICallParametersFunction = function(contexts) {
  * Helper constant for dataToLongTermAverageGraph: Format object 
  * for a timeseries X axis.
  */
-var timeseriesXAxis = {
+const timeseriesXAxis = {
     type: 'timeseries',
     tick: {
       format: '%Y-%m-%d'
@@ -596,7 +596,7 @@ var timeseriesXAxis = {
  * Accepts an arbitrary number of data objects, but no more than
  * two separate unit types.
  */
-var timeseriesToTimeseriesGraph = function(metadata, ...data) {
+function timeseriesToTimeseriesGraph (metadata, ...data) {
   //blank graph data object to be populated - holds data values
   //and individual-timeseries-level display options.
   var c3Data = {

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -62,9 +62,9 @@ function fixedPrecision (n, ...rest) { return +n.toFixed(PRECISION);};
  * util.PRECISION for variables with no precision options in the file.
  */
 function makePrecisionBySeries (series) {
-  var dictionary = {};
-  for(var s in series) {
-    var fromConfig = getVariableOptions(series[s], "decimalPrecision");
+  let dictionary = {};
+  for(let s in series) {
+    const fromConfig = getVariableOptions(series[s], "decimalPrecision");
     dictionary[s] = _.isUndefined(fromConfig) ? PRECISION : fromConfig;
   }
 
@@ -87,13 +87,13 @@ function makePrecisionBySeries (series) {
  * series id it belongs to.
  */
 function makeTooltipDisplayNumbersWithUnits (axes, axis, precisionFunction) {
-  var unitsDictionary = {};
+  let unitsDictionary = {};
   if(_.isUndefined(precisionFunction)) { //use a default.
     precisionFunction = fixedPrecision;
   }
   
   //build a dictionary between timeseries names and units
-  for(var series in axes) {
+  for(let series in axes) {
     unitsDictionary[series] = axis[axes[series]].label.text;
   }
 
@@ -134,26 +134,25 @@ function timeseriesToAnnualCycleGraph (metadata, ...data) {
 
   //blank graph data object to be populated - holds data values
   //and individual-timeseries-level display options.
-  var c3Data = {
+  let c3Data = {
       columns: [],
       types: {},
       labels: {},
       axes: {}
   };
 
-  var yUnits = "";
-  var y2Units = "";
-  var seriesVariables = {};
+  let yUnits = "";
+  let y2Units = "";
+  let seriesVariables = {};
   
-  var getTimeseriesName = shortestUniqueTimeseriesNamingFunction(metadata, data);
+  const getTimeseriesName = shortestUniqueTimeseriesNamingFunction(metadata, data);
   
   //Add each timeseries to the graph
-  for(var i = 0; i < data.length; i++) {
+  for(let timeseries of data) {
 
     //get metadata for this timeseries
-    var timeseries = data[i];
-    var timeseriesMetadata = _.find(metadata, function(m) {return m.unique_id === timeseries.id;});  
-    var timeseriesName = getTimeseriesName(timeseriesMetadata);
+    const timeseriesMetadata = _.find(metadata, function(m) {return m.unique_id === timeseries.id;});  
+    const timeseriesName = getTimeseriesName(timeseriesMetadata);
     seriesVariables[timeseriesName] = timeseriesMetadata.variable_id;
        
     //add the actual data to the graph
@@ -185,15 +184,15 @@ function timeseriesToAnnualCycleGraph (metadata, ...data) {
   }
   
   //whole-graph display options: axis formatting and tooltip behaviour
-  var c3Axis = {};
+  let c3Axis = {};
   c3Axis.x = monthlyXAxis;
   c3Axis.y = formatYAxis(yUnits);
   if(y2Units) { 
     c3Axis.y2 = formatYAxis(y2Units);
     }
 
-  var precision = makePrecisionBySeries(seriesVariables);
-  var c3Tooltip = {format: {}};
+  const precision = makePrecisionBySeries(seriesVariables);
+  let c3Tooltip = {format: {}};
   c3Tooltip.grouped = "true";
   c3Tooltip.format.value = makeTooltipDisplayNumbersWithUnits(c3Data.axes, c3Axis, precision);
   
@@ -212,9 +211,9 @@ function timeseriesToAnnualCycleGraph (metadata, ...data) {
  */
 function getMonthlyData (data, timescale = "monthly") {
 
-  var expectedTimestamps = {"monthly": 12, "seasonal": 4, "yearly": 1};
-  var monthlyData = [];
-  var timestamps = Object.keys(data).sort();
+  const expectedTimestamps = {"monthly": 12, "seasonal": 4, "yearly": 1};
+  let monthlyData = [];
+  const timestamps = Object.keys(data).sort();
   
   if(timestamps.length == 17) {
     throw new Error("Error: concatenated 17-point chronology.");
@@ -224,8 +223,8 @@ function getMonthlyData (data, timescale = "monthly") {
     throw new Error("Error: inconsistent time resolution in data");
   }
   
-  for(var i = 0; i < 12; i++) {
-    var mapped = Math.ceil((timestamps.length / 12.0) * (i + 1)) - 1;
+  for(let i = 0; i < 12; i++) {
+    let mapped = Math.ceil((timestamps.length / 12.0) * (i + 1)) - 1;
     monthlyData.push(data[timestamps[mapped]]);
   }
   
@@ -266,13 +265,13 @@ function shortestUniqueTimeseriesNamingFunction (metadata, data) {
     return function(m) { return capitalizeWords(`${m.timescale} mean`);};
   }
   
-  var variation = [];
-  var exemplarMetadata = _.find(metadata, function(m) {return m.unique_id === data[0].id;});
+  let variation = [];
+  const exemplarMetadata = _.find(metadata, function(m) {return m.unique_id === data[0].id;});
   
-  for(var i = 0; i < data.length; i++) {
-    var comparandMetadata = _.find(metadata, function(m) {return m.unique_id == data[i].id;});
+  for(let datum of data) {
+    const comparandMetadata = _.find(metadata, function(m) {return m.unique_id == datum.id;});
 
-    for(var att in comparandMetadata) {
+    for(let att in comparandMetadata) {
       if(exemplarMetadata[att] !== comparandMetadata[att] && variation.indexOf(att) == -1) {
         variation.push(att);
       }
@@ -293,9 +292,9 @@ function shortestUniqueTimeseriesNamingFunction (metadata, data) {
   }
   
   return function (m) {
-    var name = "";
-    for(var j = 0; j < variation.length; j++) {
-      name = name.concat(`${m[variation[j]]} `);
+    let name = "";
+    for(let v of variation) {
+      name = name.concat(`${m[v]} `);
     }
     name = name.concat("mean");
     return capitalizeWords(name);
@@ -363,18 +362,18 @@ function dataToLongTermAverageGraph (data, contexts = []){
 
   //blank graph data object to be populated - holds data values
   //and individual-timeseries-level display options.
-  var c3Data = {
+  let c3Data = {
       columns: [],
       types: {},
       labels: {},
       axes: {}
   };
   
-  var yUnits = "";
-  var y2Units = "";
+  let yUnits = "";
+  let y2Units = "";
   
-  var seriesVariables = {};
-  var nameSeries;
+  let seriesVariables = {};
+  let nameSeries;
   
   if(data.length == 1) {
     nameSeries = function(run, context) {return run;};
@@ -388,28 +387,28 @@ function dataToLongTermAverageGraph (data, contexts = []){
 
   //get the list of all timestamps and add them to the chart
   //(C3 requires x-axis timestamps be added as a data column)
-  var timestamps = getAllTimestamps(data);
+  const timestamps = getAllTimestamps(data);
   c3Data.columns.push(['x'].concat(_.map(timestamps, extendedDateToBasicDate)));
   c3Data.x = "x";
   
 
   //add each API call to the chart
-  for(var i = 0; i < data.length; i++) {
-    var context = contexts.length ? contexts[i] : {};
-    var call = data[i];
+  for(let i = 0; i < data.length; i++) {
+    const context = contexts.length ? contexts[i] : {};
+    const call = data[i];
     
     //add each individual dataset from the API to the chart
     for(let run in call) {
-      var runName = nameSeries(run, context);
+      const runName = nameSeries(run, context);
       seriesVariables[runName] = _.isEmpty(context) ? undefined : context.variable_id;
-      var series = [runName];
+      const series = [runName];
       
       //if a given timestamp is present in some, but not all
       //datasets, set the timestamp's value to "null"
       //in the C3 data object. This will cause C3 to render the
       //line with a break where the missing timestamp is.
-      for(var t = 0; t < timestamps.length; t++ ) {
-        series.push(_.isUndefined(call[run].data[timestamps[t]]) ? null : call[run].data[timestamps[t]]);
+      for(let t of timestamps ) {
+        series.push(_.isUndefined(call[run].data[t]) ? null : call[run].data[t]);
       }
       c3Data.columns.push(series);
       c3Data.types[runName] = "line";
@@ -436,7 +435,7 @@ function dataToLongTermAverageGraph (data, contexts = []){
   }
   
   //whole-graph display options: axis formatting and tooltip behaviour
-  var c3Axis = {};
+  let c3Axis = {};
   c3Axis.x = timeseriesXAxis;
   c3Axis.y = formatYAxis(yUnits);
   if(y2Units) { 
@@ -446,15 +445,15 @@ function dataToLongTermAverageGraph (data, contexts = []){
   //The long term average graph doesn't require every series to have the exact
   //same timestamps, since it's comparing long term trends anyway. Allow C3
   //to smoothly connect series even if they're "missing" timestamps.
-  var c3Line = {
+  const c3Line = {
       connectNull: true
   };
 
   //Note: if context is empty (dataToLongTermAverageGraph was called with only
   //one time series), variable-determined precision will not be available and
   //numbers will be formatted with default precision.
-  var precision = makePrecisionBySeries(seriesVariables);
-  var c3Tooltip = {format: {}};
+  const precision = makePrecisionBySeries(seriesVariables);
+  let c3Tooltip = {format: {}};
   c3Tooltip.grouped = "true";
   c3Tooltip.format.value = makeTooltipDisplayNumbersWithUnits(c3Data.axes, c3Axis, precision);
   
@@ -471,9 +470,9 @@ function dataToLongTermAverageGraph (data, contexts = []){
  * list of all unique timestamps found in the data.
  */
 function getAllTimestamps (data) {
-  var allTimes = [];
+  let allTimes = [];
 
-  var addSeries = function(seriesData) {
+  const addSeries = function(seriesData) {
     for(let timestamp in seriesData) {
       if(!_.find(allTimes, function(t){return t== timestamp;})) {
         allTimes.push(timestamp);
@@ -481,7 +480,7 @@ function getAllTimestamps (data) {
     }
   };
 
-  for(var i in _.keys(data)) {
+  for(let i in _.keys(data)) {
     if(!_.isUndefined(data[i].data)) { //data is from "timeseries" API
       addSeries(data[i].data);
     }
@@ -510,12 +509,12 @@ function getAllTimestamps (data) {
  */
 function nameAPICallParametersFunction (contexts) {
   
-  var variation = [];
-  var exemplarContext = contexts[0];
+  let variation = [];
+  const exemplarContext = contexts[0];
   
-  for (var i = 0; i < contexts.length; i++) {
-    for(var att in contexts[i]) {
-      if(exemplarContext[att] != contexts[i][att] && variation.indexOf(att) == -1) {
+  for (let context of contexts) {
+    for(let att in context) {
+      if(exemplarContext[att] != context[att] && variation.indexOf(att) == -1) {
         variation.push(att);
       }
     }
@@ -538,9 +537,9 @@ function nameAPICallParametersFunction (contexts) {
   }
   
   return function (run, context) {
-    var name = "";
-    for(var j = 0; j < variation.length; j++) {
-      name = name.concat(`${context[variation[j]]} `);
+    let name = "";
+    for(let v of variation) {
+      name = name.concat(`${context[v]} `);
     }
     name = name.concat(run);
     return name;
@@ -599,39 +598,38 @@ const timeseriesXAxis = {
 function timeseriesToTimeseriesGraph (metadata, ...data) {
   //blank graph data object to be populated - holds data values
   //and individual-timeseries-level display options.
-  var c3Data = {
+  let c3Data = {
       columns: [],
       types: {},
       labels: {},
       axes: {}
   };
 
-  var yUnits = "";
-  var y2Units = "";
-  var seriesVariables = {};
+  let yUnits = "";
+  let y2Units = "";
+  let seriesVariables = {};
 
-  var getTimeseriesName = shortestUniqueTimeseriesNamingFunction(metadata, data);
+  const getTimeseriesName = shortestUniqueTimeseriesNamingFunction(metadata, data);
 
   //get list of all timestamps
-  var timestamps = getAllTimestamps(data);
+  const timestamps = getAllTimestamps(data);
   c3Data.columns.push(['x'].concat(_.map(timestamps, extendedDateToBasicDate)));
   c3Data.x = "x";
 
   //Add each timeseries to the graph
-  for(var i = 0; i < data.length; i++) {
+  for(let timeseries of data) {
     //get metadata for this timeseries
-    var timeseries = data[i];
-    var timeseriesMetadata = _.find(metadata, function(m) {return m.unique_id === timeseries.id;});
-    var timeseriesName = getTimeseriesName(timeseriesMetadata);
+    const timeseriesMetadata = _.find(metadata, function(m) {return m.unique_id === timeseries.id;});
+    const timeseriesName = getTimeseriesName(timeseriesMetadata);
     seriesVariables[timeseriesName] = timeseriesMetadata.variable_id;
 
     //add the actual data to the graph
-    var column = [timeseriesName];
+    let column = [timeseriesName];
 
-    for(var t = 0; t < timestamps.length; t++ ) {
+    for(let t in timestamps) {
       //assigns "null" for any timestamps missing from this series.
       //C3's behaviour toward null values is set by the line.connectNull attribute
-      column.push(_.isUndefined(timeseries.data[timestamps[t]]) ? null : timeseries.data[timestamps[t]]);
+      column.push(_.isUndefined(timeseries.data[t]) ? null : timeseries.data[t]);
     }
 
     c3Data.columns.push(column);
@@ -659,14 +657,14 @@ function timeseriesToTimeseriesGraph (metadata, ...data) {
   }
 
   //whole-graph display options: axis formatting and tooltip behaviour
-  var c3Axis = {};
+  let c3Axis = {};
   c3Axis.x = timeseriesXAxis;
   c3Axis.y = formatYAxis(yUnits);
   if(y2Units) {
     c3Axis.y2 = formatYAxis(y2Units);
     }
 
-  var c3Subchart = {show: true,
+  const c3Subchart = {show: true,
       size: {height: 20} };
 
   //instructs c3 to connect series across gaps where a timeseries is missing
@@ -674,12 +672,12 @@ function timeseriesToTimeseriesGraph (metadata, ...data) {
   //is actually missing from a series, it's helpful in cases where
   //series are at different time resolutions (monthly/yearly), so it's
   //included by default.
-  var c3Line = {
+  const c3Line = {
       connectNull: true
   };
 
-  var precision = makePrecisionBySeries(seriesVariables);
-  var c3Tooltip = {format: {}};
+  const precision = makePrecisionBySeries(seriesVariables);
+  let c3Tooltip = {format: {}};
   c3Tooltip.grouped = "true";
   c3Tooltip.format.value = makeTooltipDisplayNumbersWithUnits(c3Data.axes, c3Axis, precision);
 

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -86,22 +86,24 @@ function makeVariableResponseGraph (x, y, graph) {
   }
   //sort by x value, preperatory to putting on the graph.
   tuples.sort((a, b) => a[0] - b[0]);  
-  c3Data.columns = [["x"], [y]];
-
-
-  for(let i = 1; i < tuples.length; i++) {
-    c3Data.columns[0].push(tuples[i][0]);
-    c3Data.columns[1].push(tuples[i][1]);
-    //C3 doesn't really support scatterplots, but we can fake it by adding
-    //a missing data point between each actual data point, and instructing C3
-    //not to connect across missing data points with {connectNull: false} 
-    //TODO: breake this out into makeScatterplot(); we'll likely need it again
-    if(i < tuples.length - 1) {
-      c3Data.columns[0].push((tuples[i][0] + tuples[i+1][0])/2);
-      c3Data.columns[1].push(null);
+  
+  //C3 doesn't really support scatterplots, but we can fake it by adding
+  //a missing data point between each actual data point, and instructing C3
+  //not to connect across missing data points with {connectNull: false} 
+  //TODO: break this out into makeScatterplot(); we'll likely need it again
+  c3Data.columns = [];
+  c3Data.columns.push(_.reduce(tuples, (memo, tuple, index, list) => {
+    memo.push(tuple[0]);
+    if(index < list.length - 1) {
+      memo.push(tuple[0] / 2 + list[index + 1][0] / 2);
     }
-  }
-
+    return memo;
+  }, ["x"]));  
+  c3Data.columns.push(_.reduce(tuples, (memo, tuple, index, list) => {
+    index < list.length - 1 ? memo.push(tuple[1], null) : memo.push(tuple[1]);
+    return memo;
+  }, [y]));
+  
   // Generate x and y axes. Reuse labels from source graph,
   // but add variable names if not present.
   let xAxisLabel = getAxisTextForVariable(graph, x);

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -21,7 +21,7 @@ import {caseInsensitiveStringSearch} from './util';
 import {fixedPrecision} from './chart-generators';
 import {assignColoursByGroup, hideSeriesInTooltip,
         hideSeriesInLegend, padYAxis,
-        fadeSeriesByRank} from './chart-formatters';
+        fadeSeriesByRank, hideTicksByRange} from './chart-formatters';
 
 /***************************************************************************
  * 0. makeVariableReponseGraph and its helper functions
@@ -218,7 +218,8 @@ function makeAnomalyGraph (base, graph) {
   graph.axis.y2.label = {};
   graph.axis.y2.label.position = 'outer-middle';
   graph.axis.y2.label.text = `${getAxisTextForVariable(graph, baseSeries[0])} anomaly from ${baseSeries[0]}`;
-  
+  graph.axis.y2.tick = {};
+  graph.axis.y2.tick.format = graph.axis.y.tick.format;
   
   // function that determines whether a data series an anomaly series.
   // used to format anomalies differently than data
@@ -252,9 +253,12 @@ function makeAnomalyGraph (base, graph) {
   graph.tooltip.format.value = addAnomalyTooltipFormatter(graph.tooltip.format.value, baseSeries);
   
   //move the two sets of data apart for less confusing visuals
-  graph = padYAxis(graph, 'y2', 'top', 8);
-  graph = padYAxis(graph, 'y', 'bottom', .2);
+  graph = padYAxis(graph, 'y2', 'top', 1);
+  graph = padYAxis(graph, 'y', 'bottom', 1);
   
+  graph = hideTicksByRange(graph, "y");
+  graph = hideTicksByRange(graph, "y2");
+
   return graph;
 };
 

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -1,0 +1,161 @@
+/************************************************************************
+ * chart-transformers.js - functions that accept a C3 chart specification
+ *   for a timeseries chart and alter the data to produce a different
+ *   type of chart.
+ *   
+ * These functions accepts a C3 graph specification object and supplemental
+ * parameters that vary by function. They return a C3 graph spec.
+ * 
+ * The main functions in this file are:
+ * 
+ *  - makeVariableReponseGraph: transforms a graph with one or more pairs 
+ *    of timeseries representing different variables into a graph showing
+ *    correlation between the variables (x and y axes are the variables)
+ ***************************************************************************/
+import _ from 'underscore';
+import {caseInsensitiveStringSearch} from './util';
+import {fixedPrecision} from './chart-generators';
+
+/***************************************************************************
+ * 0. makeVariableReponseGraph and its helper functions
+ ***************************************************************************/
+
+/*
+ * Graph transformation function that accepts two keywords (x and y) and a graph
+ * containing one or more pairs of timeseries and combines pairs of matching time 
+ * series into a variable response graph.
+ * 
+ * Each data series should match exactly one other series. In order to match, two 
+ * data series must:
+ *   - have names that are identical except for the substitution of x for y
+ *   - have data at all the same timestamps
+ * 
+ * This function combines each pair of matching data series into a new data series. For
+ * each (time, data) tuple present in both original time series, it creates a new
+ * (data-x, data-y) tuple, using the series with the x keyword as the x coordinate
+ * and the series with the y keyword as the y coordinate.
+ *
+ * The axis labels of the new graph will be generated from the y axis label(s) of the
+ * old graph.
+ *
+ * Example:
+ * x: pr
+ * y: tasmax
+ * chart with data.columns:
+ * ["Monthly pr", 10, 20, 30, 40, 50 ]
+ * ["Monthly tasmax", 1, 2, 3, 4, 5 ]
+ * ["x", 1/1/15, 1/2/15, 1/3/15, 1/4/15, 1/5/15]
+ * 
+ * Would result in a new chart with data.columns:
+ * ["x", 10, 20, 30, 40, 50]
+ * ["pr", 1, 2, 3, 4, 5]
+ * 
+ * This is intended to graph the effect of one variable (x) on another (y).
+ */
+var makeVariableResponseGraph = function(x, y, graph) {
+  let c3Data = {};
+
+  const seriesNameContains = function (series, keyword) {
+    return caseInsensitiveStringSearch(series[0], keyword);
+  }
+  
+  const xseries = _.filter(graph.data.columns, series => seriesNameContains(series, x));
+  const yseries = _.filter(graph.data.columns, series => seriesNameContains(series, y));
+    
+  let tuples = [];
+  
+  for(let i = 0; i < xseries.length; i++) {
+    //Try to match each dependent variable series with an independent variable series
+    let dependent = xseries[i];
+    let independent = _.find(yseries, series => {
+      return series[0].toLowerCase().replace(y.toLowerCase(), x.toLowerCase()) === 
+        dependent[0].toLowerCase();
+      });
+    for(let d = 1; d < dependent.length; d++) {
+      if(!_.isNull(dependent[d]) && !_.isNull(independent[d])) {
+        tuples.push([independent[d], dependent[d]]);
+      }
+    }
+  }
+  //sort by x value, preperatory to putting on the graph.
+  tuples.sort((a, b) => a[0] - b[0]);  
+  c3Data.columns = [["x"], [y]];
+
+
+  for(let i = 1; i < tuples.length; i++) {
+    c3Data.columns[0].push(tuples[i][0]);
+    c3Data.columns[1].push(tuples[i][1]);
+    //C3 doesn't really support scatterplots, but we can fake it by adding
+    //a missing data point between each actual data point, and instructing C3
+    //not to connect across missing data points with {connectNull: false} 
+    if(i < tuples.length - 1) {
+      c3Data.columns[0].push((tuples[i][0] + tuples[i+1][0])/2);
+      c3Data.columns[1].push(null);
+    }
+  }
+
+  // Generate x and y axes. Reuse labels from source graph,
+  // but add variable names if not present.
+  let xAxisLabel = getAxisTextForVariable(graph, x);
+  xAxisLabel = xAxisLabel.search(x) === -1 ? `${x} ${xAxisLabel}` : xAxisLabel;
+  const xAxis = {
+      tick: {
+        count: 8,
+        fit: true,
+        format: fixedPrecision
+      },
+      label: xAxisLabel
+    };
+
+  let yAxisLabel = getAxisTextForVariable(graph, y);
+  yAxisLabel = yAxisLabel.search(y) === -1 ? `${y} ${yAxisLabel}` : yAxisLabel;
+  const yAxis = {
+      tick: {
+        format: fixedPrecision
+      },
+      label: yAxisLabel
+  };
+
+  //Whole-graph formatting options
+  c3Data.x = 'x'; //use x series
+  const c3Line = {connectNull: false}; //don't connect point data
+  const c3Tooltip = {show: false}; //no tooltip or legend, simplify graph.
+  const c3Legend = {show: false};
+
+  return {
+    data: c3Data,
+    line: c3Line,
+    tooltip: c3Tooltip,
+    legend: c3Legend,
+    axis: {
+      y: yAxis,
+      x: xAxis
+    },
+  };
+};
+
+/*
+ * Helper function for makeVariableResponseGraph: given a graph and a
+ * variable name, returns the axis label text associated with that variable.
+ */
+var getAxisTextForVariable = function(graph, variable) {
+  let series = graph.data.columns.find(s => {
+    return caseInsensitiveStringSearch(s[0], variable);
+    });
+  
+  if(_.isUndefined(series)) {
+    throw new Error("Cannot build variable response chart from single variable chart");
+  }
+  series = series[0];
+
+  //see if this series has an explicit axis association, default to y if not.
+  const axis = graph.data.axes[series] ? graph.data.axes[series] : 'y';
+
+  return _.isString(graph.axis[axis].label) ?
+      graph.axis[axis].label :
+      graph.axis[axis].label.text;
+};
+
+module.exports = { makeVariableResponseGraph,
+    //exported only for testing purposes:
+    getAxisTextForVariable};

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -200,21 +200,22 @@ function makeAnomalyGraph (base, graph) {
   graph.axis.y2 = {show: true};
   
   for(let i = 0; i < origLength; i++) {
-    if(graph.data.columns[i][0] !== 'x') {
+    let seriesName = graph.data.columns[i][0];
+    if(seriesName !== 'x' && seriesName !== base) {
       let oldSeries = graph.data.columns[i];
       if(oldSeries.length !== baseSeries.length) {
         throw new Error("Error: Incorrect data series length, cannot calculate anomaly");
       }
 
       let newSeries = [];
-      newSeries.push(`${oldSeries[0]} Anomaly`);
+      newSeries.push(`${seriesName} Anomaly`);
       for(let j = 1; j < oldSeries.length; j++){
         newSeries.push(oldSeries[j] - baseSeries[j]);
       }
       graph.data.columns.push(newSeries);
-      graph.data.axes[oldSeries[0]] = 'y';
-      graph.data.axes[`${oldSeries[0]} Anomaly`] = 'y2';
-      graph.data.types[`${oldSeries[0]} Anomaly`] = oldSeries[0] === base ? "line" : "bar";
+      graph.data.axes[seriesName] = 'y';
+      graph.data.axes[`${seriesName} Anomaly`] = 'y2';
+      graph.data.types[`${seriesName} Anomaly`] = "line";
     }
   }
   graph.axis.y2.label = {};

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -212,6 +212,7 @@ var makeAnomalyGraph = function(base, graph) {
       graph.data.columns.push(newSeries);
       graph.data.axes[oldSeries[0]] = 'y';
       graph.data.axes[`${oldSeries[0]} Anomaly`] = 'y2';
+      graph.data.types[`${oldSeries[0]} Anomaly`] = oldSeries[0] === base ? "line" : "bar";
     }
   }
   graph.axis.y2.label = {};

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -71,9 +71,8 @@ function makeVariableResponseGraph (x, y, graph) {
     
   let tuples = [];
   
-  for(let i = 0; i < xseries.length; i++) {
+  for(let dependent of xseries) {
     //Try to match each dependent variable series with an independent variable series
-    let dependent = xseries[i];
     let independent = _.find(yseries, series => {
       return series[0].toLowerCase().replace(y.toLowerCase(), x.toLowerCase()) === 
         dependent[0].toLowerCase();

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -12,7 +12,7 @@
  *    of timeseries representing different variables into a graph showing
  *    correlation between the variables (x and y axes are the variables)
  *  
- *  -makeAnomalyGraph: using one of the existing data series as the base, 
+ *  - makeAnomalyGraph: using one of the existing data series as the base, 
  *    adds additional data series representing the difference between the
  *    base series and each other data series (including itself)
  ***************************************************************************/
@@ -59,7 +59,7 @@ import {assignColoursByGroup, hideSeriesInTooltip,
  * 
  * This is intended to graph the effect of one variable (x) on another (y).
  */
-var makeVariableResponseGraph = function(x, y, graph) {
+function makeVariableResponseGraph (x, y, graph) {
   let c3Data = {};
 
   const seriesNameContains = function (series, keyword) {
@@ -95,6 +95,7 @@ var makeVariableResponseGraph = function(x, y, graph) {
     //C3 doesn't really support scatterplots, but we can fake it by adding
     //a missing data point between each actual data point, and instructing C3
     //not to connect across missing data points with {connectNull: false} 
+    //TODO: breake this out into makeScatterplot(); we'll likely need it again
     if(i < tuples.length - 1) {
       c3Data.columns[0].push((tuples[i][0] + tuples[i+1][0])/2);
       c3Data.columns[1].push(null);
@@ -145,7 +146,7 @@ var makeVariableResponseGraph = function(x, y, graph) {
  * Helper function for makeVariableResponseGraph: given a graph and a
  * variable name, returns the axis label text associated with that variable.
  */
-var getAxisTextForVariable = function(graph, variable) {
+function getAxisTextForVariable (graph, variable) {
   let series = graph.data.columns.find(s => {
     return caseInsensitiveStringSearch(s[0], variable);
     });
@@ -166,7 +167,6 @@ var getAxisTextForVariable = function(graph, variable) {
 /***************************************************************************
  * 1. makeAnomalyGraph and its helper functions
  ***************************************************************************/
-//TODO: this function needs a test
 /*
  * Graph transformation function that accepts a graph containing one or more
  * timeseries associated with a single axis, and the name of one of the 
@@ -182,7 +182,7 @@ var getAxisTextForVariable = function(graph, variable) {
  * This is intended to display change over time on a single graph.
  */
 
-var makeAnomalyGraph = function(base, graph) {
+function makeAnomalyGraph (base, graph) {
   
   if(!_.isUndefined(graph.axis.y2)) {
     throw new Error("Error: Cannot calculate anomalies for multiple data types.");
@@ -222,20 +222,20 @@ var makeAnomalyGraph = function(base, graph) {
   
   // function that determines whether a data series an anomaly series.
   // used to format anomalies differently than data
-  let isAnomaly = function (series) {
-    return series[0].indexOf("Anomaly") != -1;
+  function isAnomaly (series) {
+    return caseInsensitiveStringSearch(series[0], "Anomaly");
   }
   
   // classifier function that matches each "anomaly" data series with
   // the nominal series it is based on. Used to match colours.
-  let anomalyMatcher = function(series) {
-    let sName = series[0];
+  function anomalyMatcher (series) {
+    const sName = series[0];
     return isAnomaly(series) ? sName.substring(0, sName.length - 8) : sName;
   };  
   
   // ranking function that assigns anomaly series lower results than 
   // nominal series, used to make them distinguishable.
-  let anomalyRanker = function (series) {
+  function anomalyRanker (series) {
     return isAnomaly(series) ? .7 : 1;
   }
   
@@ -263,7 +263,7 @@ var makeAnomalyGraph = function(base, graph) {
  * formatting function, and adds a wrapper which appends the anomaly from
  * the specified base series.
  */
-var addAnomalyTooltipFormatter = function (oldFormatter, baseSeries) {  
+function addAnomalyTooltipFormatter (oldFormatter, baseSeries) {  
   const newTooltipValueFormatter = function(value, ratio, id, index) {
     let nominal = oldFormatter(value, ratio, id, index);
     if(_.isUndefined(nominal)) { //this series doesn't display in tooltip.

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -255,8 +255,8 @@ function makeAnomalyGraph (base, graph) {
   graph.tooltip.format.value = addAnomalyTooltipFormatter(graph.tooltip.format.value, baseSeries);
   
   //move the two sets of data apart for less confusing visuals
-  graph = padYAxis(graph, 'y2', 'top', 1);
-  graph = padYAxis(graph, 'y', 'bottom', 1);
+  graph = padYAxis(graph, 'y2', 'top', 1.1);
+  graph = padYAxis(graph, 'y', 'bottom', 1.1);
   
   graph = hideTicksByRange(graph, "y");
   graph = hideTicksByRange(graph, "y2");


### PR DESCRIPTION
[Adds a present / future comparison graph to single-variable portals showing future values.](https://github.com/pacificclimate/climate-explorer-frontend/issues/145) The difference between January 2010 and January 2040 is _much_ smaller than the difference between January 2010 and June 2010 and gets lost in the noise. So in addition to the usual annual cycle time series for each climatology, there is a row of bar charts along the bottom, showing the difference between each climatology and the present-day base climatology. This lets a user see, in more detail, "Oh, it will be warmer in January but colder in March according to this model."

![screenshot from 2018-04-17 14-05-44](https://user-images.githubusercontent.com/4512605/38896893-d2cb47d2-4248-11e8-85e5-9fa0e4d0c0f8.png)

This PR is much smaller than it looks. Most of the putatively new or deleted lines actually stem from splitting the over-long `chart.js` into three files, `chart-generators.js`, `chart-formatters.js`, and `chart-transformers.js`, which was straightforward and didn't require rewriting anything beyond file paths. 

Actual new code is the following:

- `chart-formatters.js`: `padYAxis()` and `hideSeriesInTooltip()`
- `chart-transformers.js`: `makeAnomalyGraph()` and `addAnomalyTooltipFormatter()`
- `AnomalyAnnualCycleGraph.js`
- `SingleDataController.js` : the section in render() that calls AnomalyAnnualCycleGraph
- `chart-formatter-tests.js` : tests for `padYAxis()` and `hideSeriesInTooltip()`
- `chart-transformer-tests.js`: tests for `makeAnomalyGraph()` and `addAnomalyTooltipFormatter()`

Everything else is from splitting up chart.js, splitting up chart.js's tests, or editing imports to point to where chart functions ended up.