### PR TITLE
Add stick plot

### DIFF
--- a/src/components/data-controllers/SingleDataController/SingleDataController.js
+++ b/src/components/data-controllers/SingleDataController/SingleDataController.js
@@ -47,6 +47,7 @@ import SingleContextGraph from '../../graphs/SingleContextGraph';
 import SingleTimeSeriesGraph from '../../graphs/SingleTimeSeriesGraph';
 import { getStats } from '../../../data-services/ce-backend';
 import AnomalyAnnualCycleGraph from '../../graphs/AnomalyAnnualCycleGraph';
+import SingleTimeSliceGraph from '../../graphs/SingleTimeSliceGraph';
 
 // TODO: Remove DataControllerMixin and convert to class extension style when 
 // no more dependencies on DataControllerMixin remain
@@ -186,6 +187,9 @@ export default createReactClass({
               </Tab>
               <Tab eventKey={4} title='Future Anomaly'>
                 <AnomalyAnnualCycleGraph {...this.props} />
+              </Tab>
+              <Tab eventKey={5} title='Snapshot'>
+                <SingleTimeSliceGraph {...this.props} />
               </Tab>
             </Tabs>
 

--- a/src/components/graphs/SingleContextGraph.js
+++ b/src/components/graphs/SingleContextGraph.js
@@ -3,6 +3,7 @@ import React from 'react';
 import _ from 'underscore';
 
 import { dataToLongTermAverageGraph } from '../../core/chart-generators';
+import { emphasizeSeries } from './graph-helpers';
 import { assignColoursByGroup, fadeSeriesByRank,
          hideSeriesInLegend, sortSeriesByRank } from '../../core/chart-formatters';
 import ContextGraph from './ContextGraph';
@@ -40,29 +41,13 @@ export default function SingleContextGraph(props) {
   function dataToGraphSpec(meta, data, selectedModelId) {
     // Convert `data` (described by `meta`) to a graph specification compatible
     // with `DataGraph`.
+    let graph = dataToLongTermAverageGraph(data, meta);
+    graph = emphasizeSeries(graph, selectedModelId);
 
-    const emphasizeCurrentModel = function(graph) {
-      // Classify data series by which model generated them
-      const makeModelSegmentor = function (selectedModelOutput, otherModelOutput) {
-        return function(dataseries) {
-          return dataseries[0].search(selectedModelId) !== -1 ?
-            selectedModelOutput :
-            otherModelOutput;
-        };
-      };
-
-      graph = assignColoursByGroup(graph, makeModelSegmentor(1, 0));
-      graph = fadeSeriesByRank(graph, makeModelSegmentor(1, 0.35));
-      graph = hideSeriesInLegend(graph, makeModelSegmentor(false, true));
-      graph = sortSeriesByRank(graph, makeModelSegmentor(1, 0));
-
-      //simplify graph by turning off tooltip and missing data gaps
-      graph.line.connectNull = true;
-      graph.tooltip = { show: false };
-      return graph;
-    };
-
-    return emphasizeCurrentModel(dataToLongTermAverageGraph(data, meta));
+    //simplify graph by turning off tooltip and missing data gaps
+    graph.line.connectNull = true;
+    graph.tooltip = { show: false };
+    return graph;
   }
 
   const graphProps = _.pick(props,

--- a/src/components/graphs/SingleTimeSliceGraph.js
+++ b/src/components/graphs/SingleTimeSliceGraph.js
@@ -1,0 +1,114 @@
+/*****************************************************************
+ * SingleTimeSliceGraph.js - shows model results at a single point
+ *   in time, variable and emissions scenario, with one model 
+ *   highlighted.
+ *   
+ * Produced from the same data as SingleContextGraph, but shows a
+ * single timestamp rather than comparing multiple long term 
+ * averages. Whils this graph shows a strict subset of the data
+ * available in a Model Context Graph, its simplicity and narrowness 
+ * makes it possible to use it as a sidebar or popup for 
+ * providing context.
+ *****************************************************************/
+import React from 'react';
+
+import _ from 'underscore';
+
+import { dataToLongTermAverageGraph } from '../../core/chart-generators';
+import { makeTimeSliceGraph } from '../../core/chart-transformers';
+import ContextGraph from './ContextGraph';
+
+
+export default function SingleTimeSliceGraph(props) {
+  //TODO: this is 100% identical to SingleContextGraph.getMetadata(),
+  //as this graph uses a subset of that one's data. Combine if possible for 
+  //https://github.com/pacificclimate/climate-explorer-frontend/issues/139.
+  function getMetadata() {
+    const {
+      ensemble_name, experiment, variable_id, area, contextMeta,
+    } = props;
+
+    // Array of unique model_id's
+    const uniqueContextModelIds = _.uniq(_.pluck(contextMeta, 'model_id'));
+    const baseMetadata = {
+      ensemble_name,
+      experiment,
+      variable_id,
+      area,
+      timescale: 'yearly',
+      timeidx: 0,
+      multi_year_mean: true,
+    };
+    const metadatas =
+      uniqueContextModelIds
+        .map(model_id => ({ ...baseMetadata, model_id }))
+        .filter(metadata =>
+          // Note: length > 0 guaranteed for item containing props.model_id
+          _.where(contextMeta,
+            _.omit(metadata, 'ensemble_name', 'timeidx', 'area')
+          ).length > 0
+        );
+    return metadatas;
+  }
+
+  function dataToGraphSpec(meta, data, selectedModelId) {
+    let graph = dataToLongTermAverageGraph(data, meta);
+    graph.legend = _.isUndefined(graph.legend) ? {}: graph.legend;
+    graph.legend.position = "right";
+    
+    
+    //select the median timestamp present in the future.
+    let timestamps = graph.data.columns.find(function(series) {return series[0] === 'x'});
+    let futureTimestamps = [];
+    for(let i = 1; i < timestamps.length; i++){
+      let timestamp = Date.parse(timestamps[i]);
+      if(timestamp > Date.now()) {
+        futureTimestamps.push(timestamps[i]);
+      }
+    }
+    futureTimestamps.sort();
+    let selectedTimestamp = futureTimestamps[Math.ceil((futureTimestamps.length - 1) / 2)];
+    
+    graph = makeTimeSliceGraph(selectedTimestamp, graph);
+    console.log(`timestamps: ${futureTimestamps} ${selectedTimestamp}`);
+
+    // Convert `data` (described by `meta`) to a graph specification compatible
+    // with `DataGraph`.
+
+//    const emphasizeCurrentModel = function(graph) {
+      // Classify data series by which model generated them
+//      const makeModelSegmentor = function (selectedModelOutput, otherModelOutput) {
+//        return function(dataseries) {
+//          return dataseries[0].search(selectedModelId) !== -1 ?
+//            selectedModelOutput :
+//            otherModelOutput;
+//        };
+//      };
+
+//      graph = assignColoursByGroup(graph, makeModelSegmentor(1, 0));
+//      graph = fadeSeriesByRank(graph, makeModelSegmentor(1, 0.35));
+//      graph = hideSeriesInLegend(graph, makeModelSegmentor(false, true));
+//      graph = sortSeriesByRank(graph, makeModelSegmentor(1, 0));
+
+      //simplify graph by turning off tooltip and missing data gaps
+//      graph.line.connectNull = true;
+//      graph.tooltip = { show: false };
+//      return graph;
+//    };
+
+//    return emphasizeCurrentModel(dataToLongTermAverageGraph(data, meta));
+    return graph;
+  }
+
+  const graphProps = _.pick(props,
+    'model_id', 'variable_id', 'experiment', 'contextMeta', 'area'
+  );
+
+  return (
+    <ContextGraph
+      {...graphProps}
+      getMetadata={getMetadata}
+      dataToGraphSpec={dataToGraphSpec}
+    />
+  );
+}

--- a/src/components/graphs/SingleTimeSliceGraph.js
+++ b/src/components/graphs/SingleTimeSliceGraph.js
@@ -5,7 +5,7 @@
  *   
  * Produced from the same data as SingleContextGraph, but shows a
  * single timestamp rather than comparing multiple long term 
- * averages. Whils this graph shows a strict subset of the data
+ * averages. While this graph shows a strict subset of the data
  * available in a Model Context Graph, its simplicity and narrowness 
  * makes it possible to use it as a sidebar or popup for 
  * providing context.
@@ -16,7 +16,10 @@ import _ from 'underscore';
 
 import { dataToLongTermAverageGraph } from '../../core/chart-generators';
 import { makeTimeSliceGraph } from '../../core/chart-transformers';
+import { selectPoint } from '../../core/chart-formatters';
+import {caseInsensitiveStringSearch} from '../../core/util';
 import ContextGraph from './ContextGraph';
+import { emphasizeSeries } from './graph-helpers';
 
 
 export default function SingleTimeSliceGraph(props) {
@@ -53,10 +56,7 @@ export default function SingleTimeSliceGraph(props) {
 
   function dataToGraphSpec(meta, data, selectedModelId) {
     let graph = dataToLongTermAverageGraph(data, meta);
-    graph.legend = _.isUndefined(graph.legend) ? {}: graph.legend;
-    graph.legend.position = "right";
-    
-    
+
     //select the median timestamp present in the future.
     let timestamps = graph.data.columns.find(function(series) {return series[0] === 'x'});
     let futureTimestamps = [];
@@ -68,35 +68,11 @@ export default function SingleTimeSliceGraph(props) {
     }
     futureTimestamps.sort();
     let selectedTimestamp = futureTimestamps[Math.ceil((futureTimestamps.length - 1) / 2)];
-    
+
     graph = makeTimeSliceGraph(selectedTimestamp, graph);
-    console.log(`timestamps: ${futureTimestamps} ${selectedTimestamp}`);
+    graph.size = {width: 150}; //adjust as needed to make a sidebar.
+    graph = emphasizeSeries(graph, selectedModelId);
 
-    // Convert `data` (described by `meta`) to a graph specification compatible
-    // with `DataGraph`.
-
-//    const emphasizeCurrentModel = function(graph) {
-      // Classify data series by which model generated them
-//      const makeModelSegmentor = function (selectedModelOutput, otherModelOutput) {
-//        return function(dataseries) {
-//          return dataseries[0].search(selectedModelId) !== -1 ?
-//            selectedModelOutput :
-//            otherModelOutput;
-//        };
-//      };
-
-//      graph = assignColoursByGroup(graph, makeModelSegmentor(1, 0));
-//      graph = fadeSeriesByRank(graph, makeModelSegmentor(1, 0.35));
-//      graph = hideSeriesInLegend(graph, makeModelSegmentor(false, true));
-//      graph = sortSeriesByRank(graph, makeModelSegmentor(1, 0));
-
-      //simplify graph by turning off tooltip and missing data gaps
-//      graph.line.connectNull = true;
-//      graph.tooltip = { show: false };
-//      return graph;
-//    };
-
-//    return emphasizeCurrentModel(dataToLongTermAverageGraph(data, meta));
     return graph;
   }
 

--- a/src/components/graphs/graph-helpers.js
+++ b/src/components/graphs/graph-helpers.js
@@ -1,4 +1,9 @@
 import _ from 'underscore';
+import {
+  assignColoursByGroup, fadeSeriesByRank,
+  hideSeriesInLegend, sortSeriesByRank
+  } from '../../core/chart-formatters';
+import { caseInsensitiveStringSearch } from '../../core/util';
 
 
 function areAllPropsValid(
@@ -149,6 +154,29 @@ function shouldLoadData(props, displayMessage) {
   return true;
 }
 
+function emphasizeSeries(graph, seriesName) {
+  // De-emphasizes all non-selected series in a graph specification.
+  // Every data series that does not have seriesName in its name will
+  // be assigned the same low-saturation colour, removed from the legend,
+  // and placed on a lower z-axis.
+  // Used by graphs that whose purpose is to provide context for a
+  // particular dataset: (SingleTimeSliceGraph, SingleContextGraph).
+  // Classify data series by which model generated them
+  const makeSegmentor = function (selectedOutput, otherOutput) {
+    return function(dataseries) {
+      return caseInsensitiveStringSearch(dataseries[0], seriesName) ?
+        selectedOutput :
+        otherOutput;
+    };
+  };
+
+  graph = assignColoursByGroup(graph, makeSegmentor(1, 0));
+  graph = fadeSeriesByRank(graph, makeSegmentor(1, 0.35));
+  graph = hideSeriesInLegend(graph, makeSegmentor(false, true));
+  graph = sortSeriesByRank(graph, makeSegmentor(1, 0));
+
+  return graph;
+}
 
 export {
   multiYearMeanSelected,
@@ -160,4 +188,5 @@ export {
   noDataMessageGraphSpec,
   blankGraphSpec,
   shouldLoadData,
+  emphasizeSeries,
 };

--- a/src/core/__tests__/chart-transformer-tests.js
+++ b/src/core/__tests__/chart-transformer-tests.js
@@ -112,3 +112,29 @@ describe('addAnomalyTooltipFormatter', function () {
   });
 });
 
+describe('makeTimeSliceGraph', function () {
+  it('rejects non-existent timestamps', function () {
+    let graph = cg.dataToLongTermAverageGraph([mockAPI.tasmaxData]);
+    const func = function () {ct.makeTimeSliceGraph("3000-01-15", graph)};
+    expect(func).toThrow();
+  });
+  it('generates a monthly timeslice', function () {
+    const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
+        mockAPI.monthlyTasmaxTimeseries,
+        mockAPI.seasonalTasmaxTimeseries,
+        mockAPI.annualTasmaxTimeseries);
+    const timeSliceGraph = ct.makeTimeSliceGraph("March", graph);
+    for(let c of timeSliceGraph.data.columns) {
+      expect(c.length).toBe(2);
+    }
+  });
+  it('generates a yearly timeslice', function () {
+    let graph = cg.dataToLongTermAverageGraph([mockAPI.tasmaxData]);
+    const timeSliceGraph = ct.makeTimeSliceGraph("1997-01-15", graph);
+    for(let c of timeSliceGraph.data.columns) {
+      expect(c.length).toBe(2);
+    }
+    expect(timeSliceGraph.axis.x.type).toBe("category");
+  });
+});
+

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -284,6 +284,33 @@ function addAnomalyTooltipFormatter (oldFormatter, baseSeries) {
   return newTooltipValueFormatter;
 };
 
+/***************************************************************************
+ * 1. makeTimeSliceGraph and its helper functions
+ ***************************************************************************/
+/*
+ * Given a timeseries graph and a string matching a timestamp in that graph,
+ * returns a new graph containing only data present at that particular moment.
+ */
+
+var makeTimeSliceGraph = function(timestamp, graph) {
+  let slicedData = [];
+  let timestamps = graph.data.columns.find(function(series) {return series[0] === 'x'});
+  let sliceIndex = timestamps.indexOf(timestamp);
+  
+  if(sliceIndex === -1) {
+    throw new Error("Error: invalid timestamp");
+  }
+  
+  for(let i = 0; i < graph.data.columns.length; i++) {
+    let series = graph.data.columns[i];
+    slicedData.push([series[0], series[sliceIndex]]);
+  }
+
+  graph.data.columns = slicedData;
+  return graph;
+}
+
 module.exports = { makeVariableResponseGraph, makeAnomalyGraph,
+    makeTimeSliceGraph,
     //exported only for testing purposes:
     getAxisTextForVariable};

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -298,15 +298,30 @@ var makeTimeSliceGraph = function(timestamp, graph) {
   let sliceIndex = timestamps.indexOf(timestamp);
   
   if(sliceIndex === -1) {
-    throw new Error("Error: invalid timestamp");
-  }
-  
-  for(let i = 0; i < graph.data.columns.length; i++) {
-    let series = graph.data.columns[i];
-    slicedData.push([series[0], series[sliceIndex]]);
+    throw new Error("Error: invalid timestamp selected");
   }
 
+  for(let i = 0; i < graph.data.columns.length; i++) {
+    let series = graph.data.columns[i];
+    if(!_.isUndefined(series[sliceIndex]) && series[0] !== 'x'){
+      slicedData.push([series[0], series[sliceIndex]]);
+    }
+  }
+
+  //sort the data series by value, to make matching with the legend easier
+  slicedData.sort((a, b) => {return b[1] - a[1]});
+
   graph.data.columns = slicedData;
+
+  //remove timeseries-related formatting
+  let date = new Date(timestamp);
+  graph.axis.x = {
+      type: 'category',
+      categories: [date.getFullYear()]
+  };
+  graph.data.x = undefined;
+  graph.tooltip = {show: false};
+
   return graph;
 }
 

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -290,13 +290,34 @@ function addAnomalyTooltipFormatter (oldFormatter, baseSeries) {
 /*
  * Given a timeseries graph and a string matching a timestamp in that graph,
  * returns a new graph containing only data present at that particular moment.
+ *
+ * Can generate a timeslice from a C3 graph specification with an x-axis of
+ * either "timeseries" (like a Long Term Average graph) or "category" (like an
+ * Annual Cycle graph) type, but not from a graph with an "indexed" type x axis.
  */
 
-var makeTimeSliceGraph = function(timestamp, graph) {
+function makeTimeSliceGraph (timestamp, graph) {
   let slicedData = [];
-  let timestamps = graph.data.columns.find(function(series) {return series[0] === 'x'});
-  let sliceIndex = timestamps.indexOf(timestamp);
+  let timestamps = [];
+  let sliceIndex = -1;
+
+  if(graph.axis.x.type == "timeseries") {
+    //x-axis has a series of dates
+    timestamps = graph.data.columns.find(function(series) {return series[0] === 'x'});
+  }
+  else if(graph.axis.x.type == "category") {
+    //x-axis is text, most likely month names
+    timestamps = graph.axis.x.categories;
+  }
+  else {
+    throw new Error("Error: timeslice graph must be generated from a timeseries");
+  }
+
+  if(_.isUndefined(timestamps)) {
+    throw new Error("Error: time information missing from source graph");
+  }
   
+  sliceIndex = timestamps.indexOf(timestamp);
   if(sliceIndex === -1) {
     throw new Error("Error: invalid timestamp selected");
   }


### PR DESCRIPTION
This PR builds on (and includes) some of the changes to graph generation made in the [Add A Future Annual Cycle Graph PR](https://github.com/pacificclimate/climate-explorer-frontend/pull/146), so that one should be merged first. It benefits from, but is not strictly dependent on, the [Pass Only Needed Data To Context Graphs PR](https://github.com/pacificclimate/climate-explorer-frontend/pull/148).

Creates a vertical "stick plot" showing the values output by various models for identical inputs (variable, emissions scenario, date) as a way give a user a sense of where in the consensus the particular model they are viewing falls.

It's currently displaying as a stand-alone graph, which almost certainly isn't what we'll want to do with it long term. We'll want to use it as a sidebar to provide context to some viewer displaying data from a single model.
![sidebar](https://user-images.githubusercontent.com/4512605/39012575-a3e42dbc-43c9-11e8-8944-2d5a5aa5d044.png)

