### PR TITLE
Use correct scenario string for downscaled data queries to multistat

### DIFF
--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -8,7 +8,6 @@
  * provided by this mixin.
  * 
  * Provides functions to:
- * - fetch data from the backend API
  * - initialize data state on component loading
  * - export data to csv or xls file
  * - filter and manipulate data
@@ -16,7 +15,6 @@
 
 import _ from 'underscore';
 import urljoin from 'url-join';
-import axios from 'axios';
 import {exportDataToWorksheet, 
         generateDataCellsFromC3Graph} from '../../core/export';
 import {validateLongTermAverageData,
@@ -77,32 +75,6 @@ var ModalMixin = {
   //Returns the metadata object that corresponds to a unique_id
   getMetadata: function (id, meta = this.props.meta) {
     return _.find(meta, function(m) {return m.unique_id === id;} );
-  },
-    
-  /*
-   * Filters data from any call to the API that returns an object with
-   * individual values keyed to unique_ids. It returns a new object
-   * that contains only results from datasets whose metadata matches the
-   * attributes passed to the filter argument.
-   * 
-   * This is a temporary stopgap until this issue is solved:
-   * https://github.com/pacificclimate/climate-explorer-backend/issues/61
-   * FIXME: remove this function and calls to it when issue 61 is solved.
-   */
-  filterAPIResults: function(data, filter, metadata = this.props.meta) {
-    var filtered = {};
-      
-    for(let id in data) {
-      var qualified = true;
-      var metad = this.getMetadata(id, metadata);
-      for(let att in filter) {
-        qualified = filter[att] == metad[att] ? qualified : false;
-        }
-      if(qualified) {
-        filtered[id] = data[id];
-      }
-    }
-    return filtered;
   },
 
   //Used to render uninitialized stats tables

--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -74,56 +74,39 @@ var ModalMixin = {
     return data;
   },
 
-  // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/124
-  //Fetches and validates data from a call to the backend's
-  //"multistat" API endpoint
-  getStatsPromise: function (props, timeidx) {
-    return axios({
-      baseURL: urljoin(CE_BACKEND_URL, 'multistats'),
-      params: {
-        ensemble_name: props.ensemble_name,
-        model: props.model_id,
-        variable: props.variable_id,
-        emission: props.experiment,
-        area: props.area || null,
-        time: timeidx,
+  //Returns the metadata object that corresponds to a unique_id
+  getMetadata: function (id, meta = this.props.meta) {
+    return _.find(meta, function(m) {return m.unique_id === id;} );
+  },
+    
+  /*
+   * Filters data from any call to the API that returns an object with
+   * individual values keyed to unique_ids. It returns a new object
+   * that contains only results from datasets whose metadata matches the
+   * attributes passed to the filter argument.
+   * 
+   * This is a temporary stopgap until this issue is solved:
+   * https://github.com/pacificclimate/climate-explorer-backend/issues/61
+   * FIXME: remove this function and calls to it when issue 61 is solved.
+   */
+  filterAPIResults: function(data, filter, metadata = this.props.meta) {
+    var filtered = {};
+      
+    for(let id in data) {
+      var qualified = true;
+      var metad = this.getMetadata(id, metadata);
+      for(let att in filter) {
+        qualified = filter[att] == metad[att] ? qualified : false;
+        }
+      if(qualified) {
+        filtered[id] = data[id];
       }
-    }).then(validateStatsData);
+    }
+    return filtered;
   },
 
-    //Returns the metadata object that corresponds to a unique_id
-    getMetadata: function (id, meta = this.props.meta) {
-      return _.find(meta, function(m) {return m.unique_id === id;} );
-    },
-    
-    /*
-     * Filters data from any call to the API that returns an object with 
-     * individual values keyed to unique_ids. It returns a new object 
-     * that contains only results from datasets whose metadata matches the 
-     * attributes passed to the filter argument. 
-     * 
-     * This is a temporary stopgap until this issue is solved:
-     * https://github.com/pacificclimate/climate-explorer-backend/issues/61
-     * FIXME: remove this function and calls to it when issue 61 is solved.
-     */
-    filterAPIResults: function(data, filter, metadata = this.props.meta) {
-      var filtered = {};
-      
-      for(let id in data) {
-        var qualified = true;
-        var metad = this.getMetadata(id, metadata);
-        for(let att in filter) {
-          qualified = filter[att] == metad[att] ? qualified : false;
-          }
-        if(qualified) {
-          filtered[id] = data[id];
-        }
-      }
-      return filtered;
-    },
-
-    //Used to render uninitialized stats tables
-    blankStatsData: []
+  //Used to render uninitialized stats tables
+  blankStatsData: []
 };
 
 export default ModalMixin;

--- a/src/components/data-controllers/MotiDataController/MotiDataController.js
+++ b/src/components/data-controllers/MotiDataController/MotiDataController.js
@@ -29,12 +29,14 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { Button, ControlLabel } from 'react-bootstrap';
 
-import { parseBootstrapTableData } from '../../../core/util';
+import { parseBootstrapTableData, validateStatsData } from '../../../core/util';
 import DataGraph from '../../graphs/DataGraph/DataGraph';
 import DataTable from '../../DataTable/DataTable';
 import DataControllerMixin from '../../DataControllerMixin';
 import {timeseriesToAnnualCycleGraph,
         timeseriesToTimeseriesGraph} from '../../../core/chart';
+import { getStats } from '../../../data-services/ce-backend';
+
 import _ from 'underscore';
 
 import AnnualCycleGraph from '../../graphs/AnnualCycleGraph';
@@ -108,7 +110,7 @@ export default createReactClass({
     
     //Load stats table
     this.setStatsTableNoDataMessage("Loading Data");
-    var myStatsPromise = this.getStatsPromise(props, this.state.dataTableTimeOfYear);
+    var myStatsPromise = getStats(props, this.state.dataTableTimeOfYear).then(validateStatsData);
 
     myStatsPromise.then(response => {
       //This portal doesn't offer users a choice of what time of year to display

--- a/src/components/data-controllers/MotiDataController/MotiDataController.js
+++ b/src/components/data-controllers/MotiDataController/MotiDataController.js
@@ -110,14 +110,11 @@ export default createReactClass({
     
     //Load stats table
     this.setStatsTableNoDataMessage("Loading Data");
-    var myStatsPromise = getStats(props, this.state.dataTableTimeOfYear).then(validateStatsData);
+    var myStatsPromise = getStats(props, this.state.dataTableTimeOfYear, "yearly").then(validateStatsData);
 
     myStatsPromise.then(response => {
-      //This portal doesn't offer users a choice of what time of year to display
-      //stats for. It always shows annual stats.
-      var stats = this.filterAPIResults(response.data, {timescale: "yearly"}, props.meta);
       this.setState({
-        statsData: parseBootstrapTableData(this.injectRunIntoStats(stats), props.meta),
+        statsData: parseBootstrapTableData(this.injectRunIntoStats(response.data), props.meta),
       });
     }).catch(error => {
       this.displayError(error, this.setStatsTableNoDataMessage);

--- a/src/components/data-controllers/SingleDataController/SingleDataController.js
+++ b/src/components/data-controllers/SingleDataController/SingleDataController.js
@@ -35,7 +35,8 @@ import styles from './SingleDataController.css';
 
 import { parseBootstrapTableData,
          timeKeyToResolutionIndex,
-         resolutionIndexToTimeKey} from '../../../core/util';
+         resolutionIndexToTimeKey,
+         validateStatsData} from '../../../core/util';
 import DataTable from '../../DataTable/DataTable';
 import TimeOfYearSelector from '../../Selector/TimeOfYearSelector';
 import DataControllerMixin from '../../DataControllerMixin';
@@ -44,6 +45,7 @@ import SingleAnnualCycleGraph from '../../graphs/SingleAnnualCycleGraph';
 import SingleLongTermAveragesGraph from '../../graphs/SingleLongTermAveragesGraph';
 import SingleContextGraph from '../../graphs/SingleContextGraph';
 import SingleTimeSeriesGraph from '../../graphs/SingleTimeSeriesGraph';
+import { getStats } from '../../../data-services/ce-backend';
 
 // TODO: Remove DataControllerMixin and convert to class extension style when 
 // no more dependencies on DataControllerMixin remain
@@ -130,7 +132,7 @@ export default createReactClass({
 
     //load stats table
     this.setStatsTableNoDataMessage("Loading Data");
-    var myStatsPromise = this.getStatsPromise(props, timeidx);
+    var myStatsPromise = getStats(props, timeidx).then(validateStatsData);
 
     myStatsPromise.then(response => {
       //remove all results from datasets with the wrong timescale

--- a/src/components/data-controllers/SingleDataController/SingleDataController.js
+++ b/src/components/data-controllers/SingleDataController/SingleDataController.js
@@ -132,17 +132,14 @@ export default createReactClass({
 
     //load stats table
     this.setStatsTableNoDataMessage("Loading Data");
-    var myStatsPromise = getStats(props, timeidx).then(validateStatsData);
+    var myStatsPromise = getStats(props, timeidx, timeres).then(validateStatsData);
 
     myStatsPromise.then(response => {
-      //remove all results from datasets with the wrong timescale
-      var stats = this.filterAPIResults(response.data, 
-          {timescale: timeres}, props.meta);
-      if(_.allKeys(stats).length > 0) {
+      if(_.allKeys(response.data).length > 0) {
         this.setState({
           dataTableTimeOfYear: timeidx,
           dataTableTimeScale: timeres,
-          statsData: parseBootstrapTableData(this.injectRunIntoStats(stats), props.meta),
+          statsData: parseBootstrapTableData(this.injectRunIntoStats(response.data), props.meta),
         });
       }
       else {

--- a/src/data-services/ce-backend.js
+++ b/src/data-services/ce-backend.js
@@ -59,6 +59,42 @@ function getData(
   });
 }
 
+// TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/124
+function getStats (
+    { ensemble_name, model_id, variable_id, experiment, area }, timeidx
+) {
+  // Query the "multistats" API endpoint.
+  // Gets an object from each qualifying dataset file with the following
+  // information:
+  //  {
+  //   unique_ID: {
+  //      min
+  //      max
+  //      mean
+  //      median
+  //      stdev
+  //      ncells
+  //      units
+  //      time (median time represented by the dataset)
+  //      modtime (last time dataset was modified)
+  //    }
+  //  }
+  let queryExpString = guessExperimentFormatFromVariable(variable_id, experiment);
+  return axios({
+    baseURL: urljoin(CE_BACKEND_URL, 'multistats'),
+    params: {
+      ensemble_name: ensemble_name,
+      model: model_id,
+      variable: variable_id,
+      emission: queryExpString,
+      area: area || null,
+      time: timeidx,
+    }
+  });
+}
+
+
+
 // Downscaled GCM data has experiment strings like 'historical,rcp26'
 // while climdex data uses 'historical, rcp26'
 // These are regularized by AppMixin.updateMetadata(), but the 'data'
@@ -69,4 +105,4 @@ function guessExperimentFormatFromVariable(variable, experiment) {
 }
 
 
-export { getTimeMetadata, getTimeseries, getData };
+export { getTimeMetadata, getTimeseries, getData, getStats };

--- a/src/data-services/ce-backend.js
+++ b/src/data-services/ce-backend.js
@@ -59,9 +59,8 @@ function getData(
   });
 }
 
-// TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/124
 function getStats (
-    { ensemble_name, model_id, variable_id, experiment, area }, timeidx
+    { ensemble_name, model_id, variable_id, experiment, area }, timeidx, timeres
 ) {
   // Query the "multistats" API endpoint.
   // Gets an object from each qualifying dataset file with the following
@@ -79,16 +78,17 @@ function getStats (
   //      modtime (last time dataset was modified)
   //    }
   //  }
-  let queryExpString = guessExperimentFormatFromVariable(variable_id, experiment);
+  const emissionString = guessExperimentFormatFromVariable(variable_id, experiment);
   return axios({
     baseURL: urljoin(CE_BACKEND_URL, 'multistats'),
     params: {
       ensemble_name: ensemble_name,
       model: model_id,
       variable: variable_id,
-      emission: queryExpString,
+      emission: emissionString,
       area: area || null,
       time: timeidx,
+      timescale: timeres
     }
   });
 }


### PR DESCRIPTION
Downscaled datasets typically have emissions scenario strings of the form "`historical,rcp26`" as opposed to the "`historical, rcp26`" format used by climdex datasets. Climate explorer frontend was using the spaced format for all datafiles when querying the `multistat` API endpoint. This PR switches to the unspaced variant for downscaled datasets.

This is a short-term fix. Long term we'd like to [standardize emission strong formats in the backend](https://github.com/pacificclimate/climate-explorer-backend/issues/76).