### PR TITLE
Fix spreadsheet download format

### DIFF
--- a/src/components/data-controllers/MotiDataController/MotiDataController.js
+++ b/src/components/data-controllers/MotiDataController/MotiDataController.js
@@ -168,7 +168,7 @@ export default createReactClass({
               dataSpec={this.state.annualCycleDataSpec}
               onChangeDataset={this.updateAnnualCycleDataset}
               graphSpec={this.state.annualCycleData || this.blankGraph}
-              onExportXslx={this.exportAnnualCycle.bind(this, 'xlsx')}
+              onExportXlsx={this.exportAnnualCycle.bind(this, 'xlsx')}
               onExportCsv={this.exportAnnualCycle.bind(this, 'csv')}
             />
           ) : (

--- a/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
+++ b/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
@@ -135,7 +135,7 @@ export default class AnnualCycleGraph extends React.Component {
     );
   }
   
-  handleExportXslx = this.exportData.bind(this, 'xslx');
+  handleExportXlsx = this.exportData.bind(this, 'xlsx');
   handleExportCsv = this.exportData.bind(this, 'csv');
   
   // Lifecycle hooks
@@ -168,7 +168,7 @@ export default class AnnualCycleGraph extends React.Component {
           </Col>
           <Col lg={4} lgPush={1} md={6} mdPush={1} sm={6} smPush={1}>
             <ExportButtons
-              onExportXslx={this.handleExportXslx}
+              onExportXlsx={this.handleExportXlsx}
               onExportCsv={this.handleExportCsv}
             />
           </Col>

--- a/src/components/graphs/ExportButtons/ExportButtons.js
+++ b/src/components/graphs/ExportButtons/ExportButtons.js
@@ -7,7 +7,7 @@ import styles from './ExportButtons.css';
 
 export default class ExportButtons extends React.Component {
   static propTypes = {
-    onExportXslx: PropTypes.func.isRequired,
+    onExportXlsx: PropTypes.func.isRequired,
     onExportCsv: PropTypes.func.isRequired,
   };
 
@@ -15,7 +15,7 @@ export default class ExportButtons extends React.Component {
     return (
       <div>
         <ControlLabel className={styles.exportlabel}>Download Data</ControlLabel>
-        <Button onClick={this.props.onExportXslx}>XLSX</Button>
+        <Button onClick={this.props.onExportXlsx}>XLSX</Button>
         <Button onClick={this.props.onExportCsv}>CSV</Button>
       </div>
     );

--- a/src/components/graphs/ExportButtons/__tests__/smoke.js
+++ b/src/components/graphs/ExportButtons/__tests__/smoke.js
@@ -7,7 +7,7 @@ it('renders without crashing', () => {
   const div = document.createElement('div');
   ReactDOM.render(
     <ExportButtons
-      onExportXslx={noop}
+      onExportXlsx={noop}
       onExportCsv={noop}
     />,
     div

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -116,7 +116,7 @@ export default class LongTermAveragesGraph extends React.Component {
     );
   }
 
-  handleExportXslx = this.exportData.bind(this, 'xslx');
+  handleExportXlsx = this.exportData.bind(this, 'xlsx');
   handleExportCsv = this.exportData.bind(this, 'csv');
 
   // Lifecycle hooks
@@ -147,7 +147,7 @@ export default class LongTermAveragesGraph extends React.Component {
           </Col>
           <Col>
             <ExportButtons
-              onExportXslx={this.handleExportXslx}
+              onExportXlsx={this.handleExportXlsx}
               onExportCsv={this.handleExportCsv}
             />
           </Col>

--- a/src/core/export.js
+++ b/src/core/export.js
@@ -101,7 +101,7 @@ var exportDataToWorksheet = function(datatype, metadata, data, format, selection
       );
       break;
 
-    case 'xslx':
+    case 'xlsx':
       var wbout = XLSX.write(wb, { bookType:'xlsx', bookSST:false, type: 'binary'});
       out_data = new Blob(
         [xml_to_binary_string(wbout)],


### PR DESCRIPTION
File extension for downloading spreadsheets was inconsistently given as both `xlsx` and `xslx` across codebase. Standardized to the correct version, `xlsx`.