### PR TITLE
UI changes and bugfixes to support multiplle timeset types in one portal

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -26,17 +26,11 @@ class Header extends React.Component {
                 bsStyle='tabs'
                 justified
               >
-                <LinkContainer to='/climo/all_downscale_files'>
+                <LinkContainer to='/climo/ce_files'>
                   <NavItem eventKey={1}>Standard climatologies</NavItem>
                 </LinkContainer>
-                <LinkContainer to='/climo/all_CLIMDEX_files'>
-                  <NavItem eventKey={2}>ClimDEX climatologies</NavItem>
-                </LinkContainer>
-                <LinkContainer to='/compare/all_downscale_files'>
-                  <NavItem eventKey={3}>Standard comparison</NavItem>
-                </LinkContainer>
-                <LinkContainer to='/compare/all_CLIMDEX_files'>
-                  <NavItem eventKey={4}>ClimDEX comparison</NavItem>
+                <LinkContainer to='/compare/ce_files'>
+                  <NavItem eventKey={2}>Standard comparison</NavItem>
                 </LinkContainer>
                 <LinkContainer to='/precipitation/extreme_precipitation'>
                   <NavItem eventKey={4}>Extreme Precipitation</NavItem>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -27,10 +27,10 @@ class Header extends React.Component {
                 justified
               >
                 <LinkContainer to='/climo/ce_files'>
-                  <NavItem eventKey={1}>Standard climatologies</NavItem>
+                  <NavItem eventKey={1}>Single dataset</NavItem>
                 </LinkContainer>
                 <LinkContainer to='/compare/ce_files'>
-                  <NavItem eventKey={2}>Standard comparison</NavItem>
+                  <NavItem eventKey={2}>Compare datasets</NavItem>
                 </LinkContainer>
                 <LinkContainer to='/precipitation/extreme_precipitation'>
                   <NavItem eventKey={4}>Extreme Precipitation</NavItem>

--- a/src/components/MapFooter/MapFooter.js
+++ b/src/components/MapFooter/MapFooter.js
@@ -39,19 +39,23 @@ class MapFooter extends React.Component {
   }
   
   timeAndVariable({ times, wmsTime, variableId }) {
-    return `${this.timeOfYear(times, wmsTime)} ${variableId}`;
+    return wmsTime ? `${this.timeOfYear(times, wmsTime)} ${variableId}` :
+      `${variableId} not available for this time period`;
   }
 
   render() {
+    let comparandText = "";
+    if(this.props.hasValidComparand) {
+      const comparand = this.props.isoline || this.props.annotated;
+      comparandText = ` ${comparand.wmsTime ? "vs." : " |"} ${this.timeAndVariable(comparand)}`;
+    }
     return (
         <h5>
           Dataset {`${this.props.start_date}-${this.props.end_date}`} {this.props.run}:
           {' '}
           {this.timeAndVariable(this.props.raster)}
-          {' '}
           {
-            this.props.hasValidComparand &&
-            `vs. ${this.timeAndVariable(this.props.isoline || this.props.annotated)}`
+            this.props.hasValidComparand && comparandText
           }
         </h5>
     );

--- a/src/components/app-controllers/DualAppController/DualAppController.js
+++ b/src/components/app-controllers/DualAppController/DualAppController.js
@@ -68,13 +68,23 @@ export default createReactClass({
   // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/122
   // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/125
   render: function () {
-    //hierarchical data selection: model, then experiment, then variable(s)
+    //hierarchical data selection: model, then experiments (filtered by model),
+    // then variable (filtered by model and experiments),
+    // then comparison variable (filtered by model and experiment, must be MYM if var is.)
     var modOptions = this.getMetadataItems('model_id');
     var expOptions = this.markDisabledMetadataItems(this.getMetadataItems('experiment'),
         this.getFilteredMetadataItems('experiment', {model_id: this.state.model_id}));
     var varOptions = this.markDisabledMetadataItems(this.getVariableIdNameArray(),
         this.getFilteredMetadataItems('variable_id', {model_id: this.state.model_id, experiment: this.state.experiment}));
 
+    var selectedVariable = _.findWhere(this.state.meta, { model_id: this.state.model_id,
+                                                          variable_id: this.state.variable_id,
+                                                          experiment: this.state.experiment });
+    var selectedMYM = selectedVariable ? selectedVariable.multi_year_mean : true;
+    var compOptions = this.markDisabledMetadataItems(this.getVariableIdNameArray(),
+        this.getFilteredMetadataItems('variable_id', {model_id: this.state.model_id,
+                                                      experiment: this.state.experiment,
+                                                      multi_year_mean: selectedMYM}));
     return (
       <Grid fluid>
         <Row>
@@ -88,7 +98,7 @@ export default createReactClass({
             <Selector label={"Variable #1 (Colour blocks)"} onChange={this.updateSelection.bind(this, 'variable_id')} items={varOptions} value={this.state.variable_id}/>
           </Col>
           <Col lg={3} md={3}>
-            <Selector label={"Variable #2 (Isolines)"} onChange={this.updateSelection.bind(this, 'comparand_id')} items={varOptions} value={this.state.comparand_id ? this.state.comparand_id : this.state.variable_id}/>
+            <Selector label={"Variable #2 (Isolines)"} onChange={this.updateSelection.bind(this, 'comparand_id')} items={compOptions} value={this.state.comparand_id ? this.state.comparand_id : this.state.variable_id}/>
           </Col>
         </Row>
         <Row>

--- a/src/components/graphs/DualAnnualCycleGraph.js
+++ b/src/components/graphs/DualAnnualCycleGraph.js
@@ -108,7 +108,7 @@ export default function DualAnnualCycleGraph(props) {
   }
 
   const graphProps = _.pick(props,
-    'model_id', 'variable_id', 'experiment', 'meta', 'area'
+    'model_id', 'variable_id', 'comparand_id', 'experiment', 'meta', 'comparandMeta', 'area'
   );
 
   return (

--- a/src/components/graphs/DualLongTermAveragesGraph.js
+++ b/src/components/graphs/DualLongTermAveragesGraph.js
@@ -39,7 +39,7 @@ export default function DualLongTermAveragesGraph(props) {
   }
 
   const graphProps = _.pick(props,
-    'model_id', 'variable_id', 'experiment', 'meta', 'area'
+    'model_id', 'variable_id', 'comparand_id', 'experiment', 'meta', 'comparandMeta', 'area'
   );
 
   return (

--- a/src/components/graphs/DualTimeSeriesGraph.js
+++ b/src/components/graphs/DualTimeSeriesGraph.js
@@ -44,7 +44,7 @@ export default function DualTimeSeriesGraph(props) {
   }
 
   const graphProps = _.pick(props,
-    'model_id', 'variable_id', 'experiment', 'meta', 'area'
+    'model_id', 'variable_id', 'comparand_id', 'experiment', 'meta', 'comparandMeta', 'area'
   );
 
   return (

--- a/src/components/graphs/DualVariableResponseGraph.js
+++ b/src/components/graphs/DualVariableResponseGraph.js
@@ -69,7 +69,7 @@ export default function DualVariableResponseGraph(props) {
   }
 
   const graphProps = _.pick(props,
-    'model_id', 'variable_id', 'comparand_id', 'experiment', 'meta', 'area'
+    'model_id', 'variable_id', 'comparand_id', 'experiment', 'meta', 'comparandMeta', 'area'
   );
 
   return (

--- a/src/components/graphs/graph-helpers.js
+++ b/src/components/graphs/graph-helpers.js
@@ -20,7 +20,6 @@ function multiYearMeanSelected({ model_id, variable_id, experiment, meta }) {
   return selectedMetadata.multi_year_mean;
 }
 
-
 function hasComparand(props) {
   return !_.isUndefined(props.comparandMeta);
 }
@@ -135,7 +134,7 @@ function shouldLoadData(props, displayMessage) {
     { failCondition: isEnsembleLoading,
       message: 'Loading ensemble...' },
     { failCondition: p =>
-        hasComparand(p) && (isVariableMYM(p) !== isVariableMYM(p)),
+        hasComparand(p) && (isVariableMYM(p) !== isComparandMYM(p)),
       message:
         'Error: Cannot compare climatologies to nominal time value datasets.' },
   ];

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -626,7 +626,7 @@ function timeseriesToTimeseriesGraph (metadata, ...data) {
     //add the actual data to the graph
     let column = [timeseriesName];
 
-    for(let t in timestamps) {
+    for(let t of timestamps) {
       //assigns "null" for any timestamps missing from this series.
       //C3's behaviour toward null values is set by the line.connectNull attribute
       column.push(_.isUndefined(timeseries.data[t]) ? null : timeseries.data[t]);

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ class App extends React.Component {
           <Header />
         </div>
         <div>
-          {this.props.children || <SingleAppController ensemble_name="all_downscale_files"/>}
+          {this.props.children || <SingleAppController ensemble_name="ce_files"/>}
         </div>
         <div>
           <Footer />


### PR DESCRIPTION
Small changes and bugfixes that affect displaying climatology datasets and straight-time datasets in the same portal:
* switch to an ensemble containing both types of dataset
* rename tabs and get rid of extraneous ones
* fix a bug that affected timestamps on graph axes for non-climatology graphs
* fix a multiply copy-pasted bug that affected detecting whether a graph was attempting to display a climatology dataset and a nominal dataset together
* disable selecting a comparison variable of a different timeset type than the primary variable
* add some map handling of datasets with mismatched time types (error message in footer)

Issue #155, which affects variables with different variable descriptions depending indirectly on whether they are monthly climatologies or annual straight-time timesets, is complex enough to warrant its own pull request and will be handled separately.