### PR TITLE
Support selecting a specific variable+description

### DIFF
--- a/src/components/IndexedSelector/IndexedSelector.js
+++ b/src/components/IndexedSelector/IndexedSelector.js
@@ -1,0 +1,71 @@
+/*************************************************************************************
+ * IndexedSelector.js - widget allowing choices of arbitrary data type
+ * 
+ * This selector accepts an array of things and a function that generates a unique text 
+ * string for each thing. It maintains an index of which item each text string refers
+ * to, and when a text string is selected, passing the original item to the callback function. 
+ * 
+ * Its props are:
+ *   - items: an array of items to be selected
+ *   - itemLabeler: function that generates a unique text string describing each item
+ *   - onChange: callback function which will receive an object
+ *   - label: text to display next to the dropdown
+ *   - value: the currently selected item
+ *   - itemsDisabled: an optional array of booleans whether each item is disabled
+ *   - disabled: optional boolean for whether to disable the whole selector
+ *   
+ * This is useful for creating selectors that offer combinations of parameters, such
+ * as start date, end date, and run. The parameters can be encoded as attribute-value
+ * pairs on objects passed to IndexedSelector. 
+ *************************************************************************************/
+
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import _ from 'underscore';
+import Selector from '../Selector/Selector';
+
+export default class IndexedSelector extends React.Component {
+  static propTypes = {
+    items: PropTypes.array,
+    itemLabeler: PropTypes.any,
+    label: PropTypes.string,
+    onChange: PropTypes.any,
+    value: PropTypes.any,
+    itemsDisabled: PropTypes.bool,
+    disabled: PropTypes.array
+  };
+  
+  //todo: handle empty items case.
+  componentWillReceiveProps(newProps) {
+    const disabled = newProps.itemsDisabled ? newProps.itemsDisabled : 
+      Array(newProps.items.length).fill(false);
+    this.update(newProps.value, newProps.items, newProps.itemLabeler, disabled);
+  }
+  
+  handleChange(index) {
+    this.props.onChange(this.props.items[index]);
+  }
+
+  update(value, items, itemLabeler, itemsDisabled) {
+    let menuItems = [];
+    for(let i = 0; i < items.length; i++) {
+      menuItems.push([i, itemLabeler(items[i]), itemsDisabled[i]])
+    }
+    
+    this.menuItems = menuItems;
+    this.displayString = _.isObject(value) ? itemLabeler(value) : value;
+  }
+  
+  render() {
+    return (
+      <Selector
+        label={this.props.label}
+        value={this.props.value}
+        items={this.menuItems}
+        onChange={this.handleChange.bind(this)}
+        disabled={this.props.disabled}
+      /> 
+    );
+  }
+}

--- a/src/components/IndexedSelector/IndexedSelector.js
+++ b/src/components/IndexedSelector/IndexedSelector.js
@@ -16,7 +16,7 @@
  *   
  * This is useful for creating selectors that offer combinations of parameters, such
  * as start date, end date, and run. The parameters can be encoded as attribute-value
- * pairs on objects passed to IndexedSelector. 
+ * pairs on objects passed to IndexedSelector as items. 
  *************************************************************************************/
 
 import PropTypes from 'prop-types';
@@ -36,7 +36,6 @@ export default class IndexedSelector extends React.Component {
     disabled: PropTypes.array
   };
   
-  //todo: handle empty items case.
   componentWillReceiveProps(newProps) {
     const disabled = newProps.itemsDisabled ? newProps.itemsDisabled : 
       Array(newProps.items.length).fill(false);
@@ -55,13 +54,23 @@ export default class IndexedSelector extends React.Component {
     
     this.menuItems = menuItems;
     this.displayString = _.isObject(value) ? itemLabeler(value) : value;
+    
+    if(_.isString(value)) {
+      this.value = value;
+    }
+    else if(value) {
+      this.value = itemLabeler(value);
+    }
+    else {
+      this.value = "Select an Item";
+    }
   }
   
   render() {
     return (
       <Selector
         label={this.props.label}
-        value={this.props.value}
+        value={this.value}
         items={this.menuItems}
         onChange={this.handleChange.bind(this)}
         disabled={this.props.disabled}

--- a/src/components/IndexedSelector/__tests__/IndexedSelector-test.js
+++ b/src/components/IndexedSelector/__tests__/IndexedSelector-test.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
+
+const IndexedSelector = require('../IndexedSelector');
+
+describe('IndexedSelector', function () {
+  it('renders without crashing', () => {
+    const superheroes = [{theme: "bat", gender: "male"}, {theme: "bat", gender: "female"},
+      {theme: "wonder", gender: "male"}, {theme: "wonder", gender: "female"}];
+    function heroNamer (hero) {
+      return `${hero.theme}${hero.gender == "male" ? "man" : "woman"}`;
+    } 
+    ReactDOM.render(
+        ( 
+            <IndexedSelector
+              items={superheroes}
+              itemLabeler={heroNamer}
+              label={"Select Hero"}
+              value={"aquaman"}
+            /> 
+        ), document.createElement('div')
+      );
+    });  
+//TODO: fix these nonfunctional tests
+  xit('generates labels for selectable objects', function () {
+    const trees = [{species: "arbutus", size: "small"}, {species: "redcedar", size: "huge"}];
+    function treeDescriber(tree) {
+      return `a ${tree.size} ${tree.species} tree`;
+    } 
+    var is = TestUtils.renderIntoDocument(
+        <IndexedSelector 
+          items={trees}
+          itemLabeler={treeDescriber}
+          label={"Tree Selector"}
+          value={"pick a tree"}
+        />
+    );
+    var listItems = TestUtils.scryRenderedDOMComponentsWithTag(is, 'li');
+    var listLabels = listItems.map(function(item) {
+      return item.textContent;
+    });
+    expect(listLabels).toEqual(['a small arbutus tree', 'a huge redcedar tree']);
+  });
+  
+  xit('passes the selected object to the callback', function () {
+    const pizzas = [{crust: "whole wheat", toppings: "cashews and green chiles"},
+      {crust: "gluten free", toppings: "eggplant parmesan"},
+      {crust: "white", toppings: "chanterelles and roasted garlic"}];
+    function pizzaDescriber (pizza) {
+      return `slice with ${pizza.toppings}`;
+    }
+    const dummyCallback = jest.genMockFunction();
+    let is = TestUtils.renderIntoDocument(
+        <IndexedSelector
+          items={pizzas}
+          itemLabeler={pizzaDescriber}
+          label={"Pizza selection"}
+          value={pizzas[2]}
+          onChange={dummyCallback}
+        />
+    );
+    const option = TestUtils.scryRenderedDOMComponentsWithTag(is, 'a')[1];
+    TestUtils.Simulate.click(option);
+    expect(dummyCallback).toBeCalledWith({crust: "whole wheat", toppings: "cashews and green chiles"});
+  });
+});

--- a/src/components/IndexedSelector/package.json
+++ b/src/components/IndexedSelector/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "IndexedSelector",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./IndexedSelector.js"
+}

--- a/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
+++ b/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
@@ -1,0 +1,81 @@
+/************************************************************************
+ * VariableDescriptionSelector.js - Variable Choice dropdown
+ * 
+ * This selector accepts an array of file metadata and a constraint object.
+ * It renders a dropdown menu allowing the user to select any variable that
+ * is present in at least on file that matches the constraints.
+ * Each variable is shown with a description.
+ * 
+ * Sometimes the same variable has different descriptions reflecting 
+ * different algorithms for calculating the variable, so it is necessary
+ * to keep track of which variable/description pair the user selects, not
+ * just the variable alone.
+ * 
+ * Props:
+ *   - meta: array of data file metadata
+ *   - onChange: callback function, will receive an object with "variable_id"
+ *       and "variable_name" attributes for the selection.
+ *   - value: currently selected variable and description
+ *   - constraints: an object specifying additional constraints on which
+ *       datasets (and their variables) should be considered, as attritbute:
+ *       values pairs that individual data file metadata must match.
+ *   - disabled: true to disable entire dropdown
+ *   - label: label to display beside the dropdown
+ ************************************************************************/
+import _ from 'underscore';
+import IndexedSelector from '../IndexedSelector';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class VariableDescriptionSelector extends React.Component {
+  static propTypes = {
+    meta: PropTypes.array,
+    onChange: PropTypes.any,
+    value: PropTypes.any,
+    constraints: PropTypes.any,
+    disabled: PropTypes.array
+  };
+  
+  componentWillReceiveProps(newProps) {
+    this.update(newProps.meta, newProps.constraints);
+  }
+  
+  //generate items for dropdown.
+  update(meta, constraints) {
+    function varDesList(meta, constraints) {
+      return _.uniq(_.map(_.where(meta, constraints), m=> {
+        return _.pick(m, "variable_id", "variable_name");
+      }), false, JSON.stringify);
+    } 
+    
+    const allVars = varDesList(meta, {});
+    const availableVars = varDesList(meta, constraints);
+    this.items = allVars;
+    this.itemsDisabled = _.map(allVars, v => {
+      for(let avail of availableVars) {
+        if (avail.variable_id === v.variable_id &&
+            avail.variable_name == v.variable_name) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
+  
+  itemLabeler(i) {
+    return `${i.variable_id} - ${i.variable_name}`;
+  }
+  
+  render() {
+    return (
+        <IndexedSelector
+          items={this.items}
+          itemsDisabled={this.itemsDisabled}
+          label={this.props.label ? this.props.label : "Select Variable"}
+          disabled={this.props.disabled}
+          value={this.props.value}
+          onChange={this.props.onChange}
+          itemLabeler={this.itemLabeler}
+        />);
+  }
+}

--- a/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
+++ b/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
@@ -33,7 +33,7 @@ export default class VariableDescriptionSelector extends React.Component {
     onChange: PropTypes.any,
     value: PropTypes.any,
     constraints: PropTypes.any,
-    disabled: PropTypes.array
+    disabled: PropTypes.boolean
   };
   
   componentWillReceiveProps(newProps) {

--- a/src/components/VariableDescriptionSelector/__tests__/VariableDescriptionSelector-smoke.js
+++ b/src/components/VariableDescriptionSelector/__tests__/VariableDescriptionSelector-smoke.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import VariableDescriptionSelector from '../VariableDescriptionSelector';
+import { noop } from 'underscore';
+import { meta } from '../../../test_support/data';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <VariableDescriptionSelector
+      meta={meta}
+      value={meta[0]}
+      onChange={noop}
+      constraints={{}}
+      disabled={false}
+    />,
+    div
+  );
+});

--- a/src/components/VariableDescriptionSelector/package.json
+++ b/src/components/VariableDescriptionSelector/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "VariableDescriptionSelector",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./VariableDescriptionSelector.js"
+}

--- a/src/components/app-controllers/MotiAppController/MotiAppController.js
+++ b/src/components/app-controllers/MotiAppController/MotiAppController.js
@@ -22,6 +22,7 @@ import { Grid, Row, Col } from 'react-bootstrap';
 import SingleMapController from '../../map-controllers/SingleMapController/SingleMapController';
 import MotiDataController from '../../data-controllers/MotiDataController';
 import Selector from '../../Selector';
+import VariableDescriptionSelector from '../../VariableDescriptionSelector';
 import AppMixin from '../../AppMixin';
 import g from "../../../core/geo";
 
@@ -47,8 +48,6 @@ export default createReactClass({
   // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/125
   render: function () {
     //hierarchical selections: model (implicit), then variable, then emission
-    var varOptions = this.markDisabledMetadataItems(this.getVariableIdNameArray(),
-        this.getFilteredMetadataItems('variable_id', {model_id: this.state.model_id}));
     var expOptions = this.markDisabledMetadataItems(this.getMetadataItems('experiment'),
         this.getFilteredMetadataItems('experiment', {model_id: this.state.model_id, variable_id: this.state.variable_id}));
 
@@ -56,10 +55,21 @@ export default createReactClass({
       <Grid fluid>
         <Row>
           <Col lg={4} md={4}>
-            <Selector label={"Variable Selection"} onChange={this.updateSelection.bind(this, 'variable_id')} items={varOptions} value={this.state.variable_id}/>
+            <VariableDescriptionSelector
+              label={"Variable Selection"}
+              onChange={this.handleSetVariable.bind(this, "variable")}
+              meta={this.state.meta}
+              constraints={{model_id: this.state.model_id}}
+              value={_.pick(this.state, "variable_id", "variable_name")} 
+            />
           </Col>
           <Col lg={4} md={4}>
-            <Selector label={"Emission Scenario Selection"} onChange={this.updateSelection.bind(this, 'experiment')} items={expOptions} value={this.state.experiment}/>
+            <Selector
+              label={"Emission Scenario Selection"}
+              onChange={this.updateSelection.bind(this, 'experiment')}
+              items={expOptions}
+              value={this.state.experiment}
+            />
           </Col>
           <Col lg={4} md={4} />
         </Row>
@@ -68,7 +78,7 @@ export default createReactClass({
             <div style={{ width: 890, height: 700 }}>
               <SingleMapController
                 variable_id={this.state.variable_id}
-                meta = {this.getfilteredMeta()}
+                meta = {this.getFilteredMeta()}
                 area={this.state.area}
                 onSetArea={this.handleSetArea}
               />
@@ -80,7 +90,7 @@ export default createReactClass({
               variable_id={this.state.variable_id}
               experiment={this.state.experiment}
               area={g.geojson(this.state.area).toWKT()}
-              meta = {this.getfilteredMeta()}
+              meta = {this.getFilteredMeta()}
             />
           </Col>
         </Row>

--- a/src/components/app-controllers/PrecipAppController/PrecipAppController.js
+++ b/src/components/app-controllers/PrecipAppController/PrecipAppController.js
@@ -22,6 +22,7 @@ import { Grid, Row, Col } from 'react-bootstrap';
 
 import DualDataController from '../../data-controllers/DualDataController/DualDataController';
 import Selector from '../../Selector';
+import VariableDescriptionSelector from '../../VariableDescriptionSelector';
 import AppMixin from '../../AppMixin';
 import g from '../../../core/geo';
 import PrecipMapController from '../../map-controllers/PrecipMapController';
@@ -56,21 +57,34 @@ export default createReactClass({
     const modOptions = this.getMetadataItems('model_id');
     const expOptions = this.markDisabledMetadataItems(this.getMetadataItems('experiment'),
         this.getFilteredMetadataItems('experiment', {model_id: this.state.model_id}));
-    let varOptions = this.markDisabledMetadataItems(this.getVariableIdNameArray(),
-        this.getFilteredMetadataItems('variable_id', {model_id: this.state.model_id, experiment: this.state.experiment}));
-    varOptions = _.filter(varOptions, function(option) {return option[0] != "pr"});
-
+    
     return (
       <Grid fluid>
         <Row>
           <Col lg={3} md={3}>
-            <Selector label={"Model Selection"} onChange={this.updateSelection.bind(this, 'model_id')} items={modOptions} value={this.state.model_id}/>
+            <Selector 
+              label={"Model Selection"}
+              onChange={this.updateSelection.bind(this, 'model_id')}
+              items={modOptions}
+              value={this.state.model_id}
+            />
           </Col>
             <Col lg={3} md={3}>
-            <Selector label={"Emission Scenario Selection"} onChange={this.updateSelection.bind(this, 'experiment')} items={expOptions} value={this.state.experiment}/>
+            <Selector
+              label={"Emission Scenario Selection"}
+              onChange={this.updateSelection.bind(this, 'experiment')}
+              items={expOptions}
+              value={this.state.experiment}
+            />
           </Col>
           <Col lg={3} md={3}>
-            <Selector label={"Variable Selection"} onChange={this.updateSelection.bind(this, 'variable_id')} items={varOptions} value={this.state.variable_id}/>
+            <VariableDescriptionSelector
+              label={"Variable Selection"}
+              onChange={this.handleSetVariable.bind(this, "variable")}
+              meta={_.filter(this.state.meta, m=> {return m.variable_id != "pr"})}
+              constraints={_.pick(this.state, "model_id", "experiment")}
+              value={_.pick(this.state, "variable_id", "variable_name")} 
+            />
           </Col>
         </Row>
         <Row>
@@ -78,9 +92,9 @@ export default createReactClass({
             <div style={{ width: 890, height: 700 }}>
               <PrecipMapController
                 variable_id={this.state.variable_id}
-                meta = {this.getfilteredMeta()}
+                meta = {this.getFilteredMeta()}
                 comparand_id={"pr"}
-                comparandMeta = {this.getfilteredMeta("pr")}
+                comparandMeta = {this.getFilteredMeta("pr", "Precipitation")}
                 area={this.state.area}
                 onSetArea={this.handleSetArea}
               />
@@ -94,8 +108,8 @@ export default createReactClass({
               comparand_id={"pr"}
               experiment={this.state.experiment}
               area={g.geojson(this.state.area).toWKT()}
-              meta = {this.getfilteredMeta()}
-              comparandMeta = {this.getfilteredMeta("pr")}
+              meta = {this.getFilteredMeta()}
+              comparandMeta = {this.getFilteredMeta("pr")}
             />
           </Col>
         </Row>

--- a/src/components/app-controllers/SingleAppController/SingleAppController.js
+++ b/src/components/app-controllers/SingleAppController/SingleAppController.js
@@ -17,6 +17,7 @@ import _ from 'underscore';
 import SingleMapController from '../../map-controllers/SingleMapController';
 import SingleDataController from '../../data-controllers/SingleDataController/SingleDataController';
 import Selector from '../../Selector';
+import VariableDescriptionSelector from '../../VariableDescriptionSelector';
 import AppMixin from '../../AppMixin';
 import g from '../../../core/geo';
 
@@ -47,8 +48,6 @@ export default createReactClass({
   render: function () {
     //hierarchical selection: model, then variable, then experiment
     var modOptions = this.getMetadataItems('model_id');
-    var varOptions = this.markDisabledMetadataItems(this.getVariableIdNameArray(),
-        this.getFilteredMetadataItems('variable_id', {model_id: this.state.model_id}));
     var expOptions = this.markDisabledMetadataItems(this.getMetadataItems('experiment'),
         this.getFilteredMetadataItems('experiment', {model_id: this.state.model_id, variable_id: this.state.variable_id}));
 
@@ -58,13 +57,29 @@ export default createReactClass({
       <Grid fluid>
         <Row>
           <Col lg={4} md={4}>
-            <Selector label={"Model Selection"} onChange={this.updateSelection.bind(this, 'model_id')} items={modOptions} value={this.state.model_id}/>
+            <Selector 
+              label={"Model Selection"} 
+              onChange={this.updateSelection.bind(this, 'model_id')} 
+              items={modOptions} 
+              value={this.state.model_id}
+            />
           </Col>
           <Col lg={4} md={4}>
-            <Selector label={"Variable Selection"} onChange={this.updateSelection.bind(this, 'variable_id')} items={varOptions} value={this.state.variable_id}/>
+            <VariableDescriptionSelector
+              label={"Variable Selection"}
+              onChange={this.handleSetVariable.bind(this, "variable")}
+              meta={this.state.meta}
+              constraints={{model_id: this.state.model_id}}
+              value={_.pick(this.state, "variable_id", "variable_name")} 
+            />
           </Col>
           <Col lg={4} md={4}>
-            <Selector label={"Emission Scenario Selection"} onChange={this.updateSelection.bind(this, 'experiment')} items={expOptions} value={this.state.experiment}/>
+            <Selector
+              label={"Emission Scenario Selection"}
+              onChange={this.updateSelection.bind(this, 'experiment')}
+              items={expOptions}
+              value={this.state.experiment}
+            />
           </Col>
         </Row>
         <Row>
@@ -72,7 +87,7 @@ export default createReactClass({
             <div style={{ width: 890, height: 700 }}>
               <SingleMapController
                 variable_id={this.state.variable_id}
-                meta = {this.getfilteredMeta()}
+                meta = {this.getFilteredMeta()}
                 area={this.state.area}
                 onSetArea={this.handleSetArea}
               />
@@ -86,7 +101,7 @@ export default createReactClass({
               comparand_id={this.state.comparand_id ? this.state.comparand_id : this.state.variable_id}
               experiment={this.state.experiment}
               area={g.geojson(this.state.area).toWKT()}
-              meta = {this.getfilteredMeta()}
+              meta = {this.getFilteredMeta()}
               contextMeta={this.getModelContextMetadata()} //to generate Model Context graph
             />
           </Col>


### PR DESCRIPTION
Six of the ETCCDI variables have two different descriptions in the database. Each variable has one description that says `Monthly [Minimum | Maximum] of [thing]` and one that says `Annual [Minimum | Maximum] of [thing]`. The descriptions, at least in the case of these six indices, actually matter: they indicate slightly different ways of calculating an annual version of a monthly index.

The yearly-resolution version of the variable that begins with Annual represents the single highest / lowest value of `[thing]` in a year. The yearly-resolution version of the variable that begins with Monthly represents the mean of twelve values, each of which represents the highest / lowest amount of` [thing]` in one month.

This PR:
- displays each unique variable-description pair in the variable selection dropdown
- keeps track of which description is associated with the variable the user selects
- changes the top level apps (via AppMixin) to filter datasets based on variable-description pairs instead of variable alone