### PR TITLE
Fix #159, make sure timeseries are correlated

### DIFF
--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -70,19 +70,26 @@ function makeVariableResponseGraph (x, y, graph) {
   const yseries = _.filter(graph.data.columns, series => seriesNameContains(series, y));
     
   let tuples = [];
-  
+  let seriesMatched = false;
   for(let dependent of xseries) {
     //Try to match each dependent variable series with an independent variable series
     let independent = _.find(yseries, series => {
       return series[0].toLowerCase().replace(y.toLowerCase(), x.toLowerCase()) === 
         dependent[0].toLowerCase();
       });
-    for(let d = 1; d < dependent.length; d++) {
-      if(!_.isNull(dependent[d]) && !_.isNull(independent[d])) {
-        tuples.push([independent[d], dependent[d]]);
+    if(independent) {
+      seriesMatched = true;
+      for(let d = 1; d < dependent.length; d++) {
+        if(!_.isNull(dependent[d]) && !_.isNull(independent[d])) {
+          tuples.push([independent[d], dependent[d]]);
+        }
       }
     }
   }
+  if(!seriesMatched) {
+    throw new Error("Unable to correlate variables");
+  }
+  
   //sort by x value, preperatory to putting on the graph.
   tuples.sort((a, b) => a[0] - b[0]);  
   


### PR DESCRIPTION
Fixes an error generating the Variable Response graph for cases where the same data was not available for both variables and correlation between the two variables couldn't be established. 

**Old behaviour**: cryptic error message if any single data series could not be correlated
**New behaviour**: quietly drop unmatchable dataseries, but throw a descriptive error if _no_ data can be correlated