### PR TITLE
Context graph bugfixes

### DIFF
--- a/src/components/graphs/ContextGraph/ContextGraph.js
+++ b/src/components/graphs/ContextGraph/ContextGraph.js
@@ -100,7 +100,8 @@ export default class ContextGraph extends React.Component {
       this.state.graphSpec &&
       this.state.graphSpec.data.columns.length > 0 &&
       nextProps.variable_id === this.props.variable_id &&
-      nextProps.experiment === this.props.experiment
+      nextProps.experiment === this.props.experiment &&
+      nextProps.area === this.props.area
     ) {
       this.setState({
         graphSpec: this.props.dataToGraphSpec(

--- a/src/components/graphs/SingleContextGraph.js
+++ b/src/components/graphs/SingleContextGraph.js
@@ -12,17 +12,25 @@ import ContextGraph from './ContextGraph';
 export default function SingleContextGraph(props) {
   function getMetadata() {
     const {
-      ensemble_name, experiment, variable_id, area, contextMeta,
+      ensemble_name, experiment, variable_id, area, contextMeta, model_id
     } = props;
 
     // Array of unique model_id's
     const uniqueContextModelIds = _.uniq(_.pluck(contextMeta, 'model_id'));
+
+    //we prefer the lowest possible time resolution for this graph, since it's
+    //used to provide broad context, not detailed data. But if the
+    //selected dataset doesn't have yearly data, use whatever resolution it has.
+    const model_metadata = _.where(contextMeta, {model_id: model_id, multi_year_mean: true});
+    const resolutions = _.unique(_.pluck(model_metadata, "timescale")).sort();
+    const timescale = resolutions[resolutions.length - 1]; 
+
     const baseMetadata = {
       ensemble_name,
       experiment,
       variable_id,
       area,
-      timescale: 'yearly',
+      timescale: timescale,
       timeidx: 0,
       multi_year_mean: true,
     };

--- a/src/components/graphs/SingleTimeSliceGraph.js
+++ b/src/components/graphs/SingleTimeSliceGraph.js
@@ -28,8 +28,15 @@ export default function SingleTimeSliceGraph(props) {
   //https://github.com/pacificclimate/climate-explorer-frontend/issues/139.
   function getMetadata() {
     const {
-      ensemble_name, experiment, variable_id, area, contextMeta,
+      ensemble_name, experiment, variable_id, area, contextMeta, model_id
     } = props;
+
+    //we prefer the lowest possible time resolution for this graph, since it's
+    //used to provide broad context, not detailed data. But if the
+    //selected dataset doesn't have yearly data, use whatever resolution it has.
+    const model_metadata = _.where(contextMeta, {model_id: model_id, multi_year_mean: true});
+    const resolutions = _.unique(_.pluck(model_metadata, "timescale")).sort();
+    const timescale = resolutions[resolutions.length - 1];
 
     // Array of unique model_id's
     const uniqueContextModelIds = _.uniq(_.pluck(contextMeta, 'model_id'));
@@ -38,7 +45,7 @@ export default function SingleTimeSliceGraph(props) {
       experiment,
       variable_id,
       area,
-      timescale: 'yearly',
+      timescale: timescale,
       timeidx: 0,
       multi_year_mean: true,
     };


### PR DESCRIPTION
Bugfixes to the context and snapshot graphs:

1. Previously, these graphs were always generated from annual-resolution data, which led to weirdness in the case of viewing a dataset that doesn't have annual data - the currently selected dataset wouldn't appear on its own context graph, which comes up for a handful of CLIMDEX indices. Now uses the lowest resolution available for the selected dataset.

2. Previously, if `model_id` was the only parameter changed, the graph would just redraw and reformat instead of fetching new backend data, but it didn't take into account whether the area changed. This has been fixed.