### PR TITLE
Improve anomaly graph UI

### DIFF
--- a/src/components/data-controllers/SingleDataController/SingleDataController.js
+++ b/src/components/data-controllers/SingleDataController/SingleDataController.js
@@ -53,7 +53,7 @@ import { getStats } from '../../../data-services/ce-backend';
 import AnomalyAnnualCycleGraph from '../../graphs/AnomalyAnnualCycleGraph';
 import SingleTimeSliceGraph from '../../graphs/SingleTimeSliceGraph';
 import {
-  singleAnnualCycleTabLabel, futureAnomalyTabLabel,
+  singleAnnualCycleTabLabel, changeFromBaselineTabLabel,
   singleLtaTabLabel, modelContextTabLabel, snapshotTabLabel,
   timeSeriesTabLabel, statsTableLabel,
   graphsPanelLabel,
@@ -178,7 +178,7 @@ export default createReactClass({
       { title: singleAnnualCycleTabLabel, graph: SingleAnnualCycleGraph },
       { title: singleLtaTabLabel, graph: SingleLongTermAveragesGraph },
       { title: modelContextTabLabel, graph: SingleContextGraph },
-      { title: futureAnomalyTabLabel, graph: AnomalyAnnualCycleGraph },
+      { title: changeFromBaselineTabLabel, graph: AnomalyAnnualCycleGraph },
       { title: snapshotTabLabel, graph: SingleTimeSliceGraph },
     ],
     notMym: [

--- a/src/components/data-controllers/SingleDataController/SingleDataController.js
+++ b/src/components/data-controllers/SingleDataController/SingleDataController.js
@@ -17,6 +17,12 @@
  *  - a SingleContextGraph similar to the Long Term Average graph, but with
  *    a separate line for each model and simplified presentation.
  *
+ *  - an AnomalyAnnualCycleGraph displaying future data as delta from a
+ *    "baseline" climatology (usually 1981 - 2010)
+ *
+ *  - a SingleTimeSliceGraph, which compares all available models
+ *    at a single timestamp.
+ *
  * If the selected dataset is not a multi year mean:
  *  - a freeform SingleTimeSeriesGraph showing each time point available.
  *

--- a/src/components/graphs/AnomalyAnnualCycleGraph.js
+++ b/src/components/graphs/AnomalyAnnualCycleGraph.js
@@ -78,7 +78,7 @@ export default function AnomalyAnnualCycleGraph(props) {
     // Select the lowest starting year as the base series for the anomaly graph
     let seriesNames = _.without(graph.data.columns.map(series => _.first(series)), 'x');
     seriesNames.sort();
-    graph = makeAnomalyGraph(seriesNames[0], graph);
+    graph = makeAnomalyGraph(seriesNames[0], props.variable_id, graph);
     return graph;
   }
 

--- a/src/components/graphs/AnomalyAnnualCycleGraph.js
+++ b/src/components/graphs/AnomalyAnnualCycleGraph.js
@@ -3,7 +3,7 @@
  * 
  * Given a data specification (model_id, experiment, variable_id),
  * provides functions to help generate a graph specification contrasting
- * current (2010-2039) and future (2040-2069, 2070-2099) Annual Cycle data:
+ * a baseline historical climatology and future Annual Cycle data:
  * 
  *   - getMetadata locates metadata for multiple three climatology periods
  *   - dataToGraphSpec formats a graph to shade the climatology periods
@@ -29,7 +29,6 @@ export default function AnomalyAnnualCycleGraph(props) {
     //returns metadata for all datasets whose start year is greater 
     //than start, and whose end year is less than end.
     //the interval is exclusive. optionally leave either endpoint undefined.
-    console.log(`${start} ${end}`);
     return _.filter(props.meta, md => {
       return md.model_id === props.model_id &&
       md.experiment === props.experiment &&
@@ -57,7 +56,6 @@ export default function AnomalyAnnualCycleGraph(props) {
     let historicalMetadatas = getDateRangeMetadatas(undefined, currentYear());
     const end_date = _.max(_.pluck(historicalMetadatas, "end_date"));
     historicalMetadatas = _.where(historicalMetadatas, {"end_date": end_date});
-    console.log(`historical end date: ${end_date}`);
     
     //pick the highest-resolution dataset available for that climatology
     const baselineMetadata = _.findWhere(historicalMetadatas, {timescale: "monthly"})
@@ -71,7 +69,7 @@ export default function AnomalyAnnualCycleGraph(props) {
     else {
       let anomalyMetadatas = getDateRangeMetadatas(baselineMetadata.start_date, undefined);
       anomalyMetadatas = _.where(anomalyMetadatas, {timescale: baselineMetadata.timescale});
-      return anomalyMetadatas.concat(baselineMetadata);
+      return [baselineMetadata].concat(anomalyMetadatas);
     }
   }
 

--- a/src/components/graphs/AnomalyAnnualCycleGraph.js
+++ b/src/components/graphs/AnomalyAnnualCycleGraph.js
@@ -26,7 +26,8 @@ import AnnualCycleGraph from './AnnualCycleGraph';
 export default function AnomalyAnnualCycleGraph(props) {
   
   function getDateRangeMetadatas(start = undefined, end = undefined) {
-    //returns metadata for all datasets whose start year is greater 
+    // returns metadata for all datasets whose model, experiment, and variable 
+    // match the values specified in props, and whose start year is greater 
     //than start, and whose end year is less than end.
     //the interval is exclusive. optionally leave either endpoint undefined.
     return _.filter(props.meta, md => {

--- a/src/components/guidance-content/info/InformationItems.js
+++ b/src/components/guidance-content/info/InformationItems.js
@@ -524,7 +524,7 @@ export const modelContextTabLabel = (
   </LabelWithInfo>
 );
 
-export const futureAnomalyTabLabel = (
+export const changeFromBaselineTabLabel = (
   <LabelWithInfo label='Change from Baseline'>
     <p>
       Annual cycle graphs showing the anomaly

--- a/src/components/guidance-content/info/InformationItems.js
+++ b/src/components/guidance-content/info/InformationItems.js
@@ -527,19 +527,18 @@ export const modelContextTabLabel = (
 export const changeFromBaselineTabLabel = (
   <LabelWithInfo label='Change from Baseline'>
     <p>
-      Annual cycle graphs showing the anomaly
-      (difference from values in baseline period)
-      for averages over variable values over future periods
-      (2040-2069, 2070-2099).
-      Baseline is 2010-2039 period.
+      Annual cycle graphs showing the difference from values in baseline period
+      for averages over variable values the future periods
+      2010-2039, 2040-2069, and 2070-2099.
+      Baseline is the average over the period 1981-2010.
     </p>
     <p>
-      Absolute values are shown in upper graphs (including baseline).
+      Absolute values, including baseline, are shown in upper graphs.
       Scale for absolute values is on left-hand vertical axis.
     </p>
     <p>
-      Anomaly values are shown in lower graphs.
-      Scale for anomaly values is on right-hand vertical axis.
+      Change from baseline, expressed as percentages, are shown in lower graphs.
+      Scale for % change values is on right-hand vertical axis.
     </p>
     <p>{annualCycleGraphDefn}</p>
     <p>{spatialAveragingDefn}</p>

--- a/src/core/__tests__/chart-transformer-tests.js
+++ b/src/core/__tests__/chart-transformer-tests.js
@@ -90,11 +90,25 @@ describe('makeAnomalyGraph', function() {
         mockAPI.monthlyTasmaxTimeseries,
         mockAPI.seasonalTasmaxTimeseries, 
         mockAPI.annualTasmaxTimeseries);
-    const anomalyGraph = ct.makeAnomalyGraph("Monthly Mean", graph);
+    const anomalyGraph = ct.makeAnomalyGraph("Monthly Mean", "tasmax", graph);
     expect(anomalyGraph.data.columns.length).toBe(5);
     expect(validate.allDefinedObject(anomalyGraph)).toBe(true);
     expect(validate.allDefinedArray(anomalyGraph.data.columns)).toBe(true);
     expect(anomalyGraph.axis.y2).toBeDefined();
+  });
+});
+
+describe('percentageChange', function() {
+  it('calculates the percentage different between two values', function () {
+    expect(ct.percentageChange(2, 3)).toBe(50);
+    expect(ct.percentageChange(4, 2)).toBe(-50);
+    expect(ct.percentageChange(-2, -3)).toBe(-50);
+    expect(ct.percentageChange(-4, -2)).toBe(50);
+  });
+  it('returns null when calculating percent change from 0', function () {
+    expect(ct.percentageChange(0, 0)).toBeNull();
+    expect(ct.percentageChange(0, 2)).toBeNull();
+    expect(ct.percentageChange(0, -1)).toBeNull();
   });
 });
 
@@ -105,10 +119,14 @@ describe('addAnomalyTooltipFormatter', function () {
       mockAPI.seasonalTasmaxTimeseries, 
       mockAPI.annualTasmaxTimeseries);
   const oldTooltipFormat = graph.tooltip.format.value;
-  const anomalyGraph = ct.makeAnomalyGraph("Monthly Mean", graph);
+  const anomalyGraph = ct.makeAnomalyGraph("Monthly Mean", "tasmax", graph);
   const newTooltipFormat = anomalyGraph.tooltip.format.value;
   expect(oldTooltipFormat(-18, 0, "Monthly Mean", 1)).toBe("-18 degC");
   expect(newTooltipFormat(-18, 0, "Monthly Mean", 1)).toBe("-18 degC (+0.81)");
+  });
+  xit('displays anomaly as a percentage for precipitation', function () {
+    //this functionality relies on reading the variable config yaml, not yet
+    //available for testing.
   });
 });
 

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -216,17 +216,17 @@ function makeAnomalyGraph (base, graph) {
       let newSeries = [];
       newSeries.push(`${seriesName} Anomaly`);
       for(let j = 1; j < oldSeries.length; j++){
-        newSeries.push(oldSeries[j] - baseSeries[j]);
+        newSeries.push(percentageChange(baseSeries[j], oldSeries[j]));
       }
       graph.data.columns.push(newSeries);
       graph.data.axes[seriesName] = 'y';
       graph.data.axes[`${seriesName} Anomaly`] = 'y2';
-      graph.data.types[`${seriesName} Anomaly`] = "line";
+      graph.data.types[`${seriesName} Anomaly`] = oldSeries[0] === base? "line" : "bar";
     }
   }
   graph.axis.y2.label = {};
   graph.axis.y2.label.position = 'outer-middle';
-  graph.axis.y2.label.text = `${getAxisTextForVariable(graph, baseSeries[0])} anomaly from ${baseSeries[0]}`;
+  graph.axis.y2.label.text = `${getAxisTextForVariable(graph, baseSeries[0])} percentage change from ${baseSeries[0]}`;
   graph.axis.y2.tick = {};
   graph.axis.y2.tick.format = graph.axis.y.tick.format;
   
@@ -271,6 +271,10 @@ function makeAnomalyGraph (base, graph) {
   return graph;
 };
 
+function percentageChange(a, b) {
+  return 100 * (b - a) / a;
+}
+
 /*
  * Helper function for makeAnomalyGraph: takes an existing tool tip number
  * formatting function, and adds a wrapper which appends the anomaly from
@@ -283,9 +287,9 @@ function addAnomalyTooltipFormatter (oldFormatter, baseSeries) {
       return undefined; 
     }
     else {
-      const anomaly = value - baseSeries[index + 1];
+      const anomaly = percentageChange(baseSeries[index+1], value);
       const sign = anomaly >= 0 ? "+" : "";
-      return nominal + " (" + sign + anomaly.toPrecision(2) + ")";
+      return nominal + " (" + sign + anomaly.toPrecision(2) + "%)";
     }
   };
   return newTooltipValueFormatter;

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -14,10 +14,14 @@
  *  
  *  - makeAnomalyGraph: using one of the existing data series as the base, 
  *    adds additional data series representing the difference between the
- *    base series and each other data series (including itself)
+ *    base series and each other data series
+ *
+ *  - makeTimeSliceGraph: accepts a graph showing one or more timeseries
+ *    and a timestamp, returns a simplified narrow vertical graph showing
+ *    only that timestamp. Intended for use as a sidebar.
  ***************************************************************************/
 import _ from 'underscore';
-import {caseInsensitiveStringSearch} from './util';
+import {caseInsensitiveStringSearch, getVariableOptions} from './util';
 import {fixedPrecision} from './chart-generators';
 import {assignColoursByGroup, hideSeriesInTooltip,
         hideSeriesInLegend, padYAxis,
@@ -177,20 +181,30 @@ function getAxisTextForVariable (graph, variable) {
  ***************************************************************************/
 /*
  * Graph transformation function that accepts a graph containing one or more
- * timeseries associated with a single axis, and the name of one of the 
- * timeseries to use as a base. Adds a secondary y axis, graphing a data series
- * showing the difference (anomaly) between each of the original series and the
- * base series. (Including the base series itself, shown as a flat line.)
- * 
- * The anomaly series will have the same hue, but somewhat desaturated colour 
- * as the original series they represent.They will not appear in legends or 
+ * timeseries associated with a single axis, the name of the displayed variable,
+ * and the name of one of the timeseries to use as a base.
+ *
+ * Adds a secondary y axis, graphing a data series showing the difference
+ * (anomaly) between each of the original series and the base series.
+ *
+ * The anomaly series will have the same hue, but somewhat desaturated colour
+ * as the original series they represent.They will not appear in legends or
  * tooltips, but their name (if needed for further graph manipulation)
  * will be "[original name] Anomaly."
- * 
+ *
  * This is intended to display change over time on a single graph.
+ *
+ * The variable argument should be left undefined if multiple
+ * variables are shown on the graph.
  */
 
-function makeAnomalyGraph (base, graph) {
+function makeAnomalyGraph (base, variable_id, graph) {
+
+  //anomalies for some variables are typically expressed as percentages.
+  //if this is a single variable graph, check the variable configuration 
+  //to see if this is one of them; if so, display percentages on the chart.
+  const displayPercent = !_.isUndefined(variable_id) &&
+                         getVariableOptions(variable_id, "percentageAnomalies");
   
   if(!_.isUndefined(graph.axis.y2)) {
     throw new Error("Error: Cannot calculate anomalies for multiple data types.");
@@ -200,6 +214,7 @@ function makeAnomalyGraph (base, graph) {
   if(_.isUndefined(baseSeries)) {
     throw new Error("Error: Invalid base data for anomaly calculation.");
   }
+  const baseSeriesName = baseSeries[0];
   
   const origLength = graph.data.columns.length;
   graph.data.axes = {};
@@ -216,7 +231,11 @@ function makeAnomalyGraph (base, graph) {
       let newSeries = [];
       newSeries.push(`${seriesName} Anomaly`);
       for(let j = 1; j < oldSeries.length; j++){
-        newSeries.push(percentageChange(baseSeries[j], oldSeries[j]));
+        newSeries.push(
+          displayPercent ?
+            percentageChange(baseSeries[j], oldSeries[j]) :
+            oldSeries[j] - baseSeries[j]
+        );
       }
       graph.data.columns.push(newSeries);
       graph.data.axes[seriesName] = 'y';
@@ -226,7 +245,9 @@ function makeAnomalyGraph (base, graph) {
   }
   graph.axis.y2.label = {};
   graph.axis.y2.label.position = 'outer-middle';
-  graph.axis.y2.label.text = `${getAxisTextForVariable(graph, baseSeries[0])} percentage change from ${baseSeries[0]}`;
+  graph.axis.y2.label.text = displayPercent ?
+      `% change from ${baseSeriesName}` :
+      `change in ${getAxisTextForVariable(graph, baseSeriesName)} from ${baseSeriesName}`;
   graph.axis.y2.tick = {};
   graph.axis.y2.tick.format = graph.axis.y.tick.format;
   
@@ -259,7 +280,7 @@ function makeAnomalyGraph (base, graph) {
   graph = fadeSeriesByRank(graph, anomalyRanker);
   
   //show anomalies with nominal values in tooltip:
-  graph.tooltip.format.value = addAnomalyTooltipFormatter(graph.tooltip.format.value, baseSeries);
+  graph.tooltip.format.value = addAnomalyTooltipFormatter(graph.tooltip.format.value, baseSeries, displayPercent);
   
   //move the two sets of data apart for less confusing visuals
   graph = padYAxis(graph, 'y2', 'top', 1.1);
@@ -271,25 +292,40 @@ function makeAnomalyGraph (base, graph) {
   return graph;
 };
 
+/*
+ * Helper function for makeAnomalyGraph: returns the percent difference
+ * of two values.
+ */
 function percentageChange(a, b) {
-  return 100 * (b - a) / a;
+  if (a === 0) {
+    //this shouldn't happen, as percentage changes are only used for
+    //whitelisted variables like precip, which should always have a > 0.
+    //but if it does (bad data), return null, which will make the graph
+    //skip this data point.
+    return null;
+  }
+  return 100 * (b - a) / Math.abs(a);
 }
 
 /*
  * Helper function for makeAnomalyGraph: takes an existing tool tip number
  * formatting function, and adds a wrapper which appends the anomaly from
- * the specified base series.
+ * the specified base series, either as a percent or nominal value.
  */
-function addAnomalyTooltipFormatter (oldFormatter, baseSeries) {  
+function addAnomalyTooltipFormatter (oldFormatter, baseSeries, displayPercent) {  
   const newTooltipValueFormatter = function(value, ratio, id, index) {
     let nominal = oldFormatter(value, ratio, id, index);
     if(_.isUndefined(nominal)) { //this series doesn't display in tooltip.
       return undefined; 
     }
     else {
-      const anomaly = percentageChange(baseSeries[index+1], value);
+      const anomaly = displayPercent ?
+          percentageChange(baseSeries[index+1], value) :
+          value - baseSeries[index+1];
       const sign = anomaly >= 0 ? "+" : "";
-      return nominal + " (" + sign + anomaly.toPrecision(2) + "%)";
+      const percent = displayPercent ? "%" : "";
+      const anomPrint = _.isNull(anomaly) ? "-" : anomaly.toPrecision(2);
+      return nominal + " (" + sign + anomPrint + percent +")";
     }
   };
   return newTooltipValueFormatter;
@@ -360,4 +396,4 @@ function makeTimeSliceGraph (timestamp, graph) {
 module.exports = { makeVariableResponseGraph, makeAnomalyGraph,
     makeTimeSliceGraph,
     //exported only for testing purposes:
-    getAxisTextForVariable};
+    getAxisTextForVariable, percentageChange};

--- a/variable-options.yaml
+++ b/variable-options.yaml
@@ -20,8 +20,15 @@
 #        NCWMS PALETTE (see options here: http://goo.gl/J4Q5PD )
 #        the default colour scheme used to show this variable
 #        on a map. (default: seq-Greys)
+#   - percentageAnomalies
+#        BOOLEAN
+#        if true, projected anomalies for this variables will
+#        be expressed as percentages, not nominal values, in
+#        graphs and tables that display anomalies
+#        (default: false)
 ################################################################
 
+#GCM output variables
 tasmin:
   decimalPrecision: 1
   
@@ -31,15 +38,12 @@ tasmax:
 pr:
   overrideLogarithmicScale: true
   defaultRasterPalette: seq-Greens
+  percentageAnomalies: true
   #decimalPrecision: 0
   #Note: in an ideal universe, pr would be measured in millimeters with 0
-  #decimal places, but right now our pr data is in kg m-2 d-1 instead.
+  #decimal places, but our pr data is in kg m-2 d-1 instead.
 
-
-#Decimal places are unhelpful for climdex values measured in days; a 
-#100.56 day growing season isn't a useful level of precision. Round
-#all day based climdex values except tropical nights to a whole number
-#of days.
+#CLIMDEX variables
 altcddETCCDI:
   decimalPrecision: 0
 
@@ -70,6 +74,15 @@ gslETCCDI:
 idETCCDI:
   decimalPrecision: 0
 
+prcptotETCCDI:
+  percentageAnomalies: true
+
+rx1dayETCCDI:
+  percentageAnomalies: true  
+
+rx5dayETCCDI:
+  percentageAnomalies: true
+
 r1mmETCCDI:
   decimalPrecision: 0
 
@@ -78,6 +91,15 @@ r10mmETCCDI:
 
 r20mmETCCDI:
   decimalPrecision: 0
+  
+r95pETCCDI:
+  percentageAnomalies: true
+
+r99pETCCDI:
+  percentageAnomalies: true
+
+sdiiETCCDI:
+  percentageAnomalies: true
 
 suETCCDI:
   decimalPrecision: 0


### PR DESCRIPTION
This PR attempts to make the anomaly graph more user friendly by:

1. Changing the display name from "Future Anomaly" to "Change from Baseline"
2. Using percentages for variables for which anomalies are traditionally give in percentages (precipitation) and displaying those percentage changes as a bar graph
3. Using a historical base period, specifically, the most recent climatology that does not include the present year.
4. More succinct axis names

This graph is the most information dense graph we're using, and I've previously reworked a couple times to try and improve readability. I hope this is an improvement.