### PR TITLE
Display datasets with no monthly values in the Long Term Averages graph

### DIFF
--- a/src/components/Selector/TimeOfYearSelector.js
+++ b/src/components/Selector/TimeOfYearSelector.js
@@ -49,7 +49,7 @@ class TimeOfYearSelector extends React.Component {
   render() {
     var timesofyear = [];
     function addTimeRange(start, end) {
-      for (const index = start; index <= end; index++) {
+      for (let index = start; index <= end; index++) {
         timesofyear.push([index, timeKeyToTimeOfYear(index)]);
       }
     }

--- a/src/components/Selector/TimeOfYearSelector.js
+++ b/src/components/Selector/TimeOfYearSelector.js
@@ -1,7 +1,7 @@
 /******************************************************************
  * TimeOfYearSelector.js - dropdown for user to select time of year
  *
- * This selector offer a choice of 12 months, 4 seasons, and annual
+ * This selector offer a choice of 12 months, 4 seasonal, and annual
  * to the user. Internally, the available times are keyed with a
  * numerical index, which is passed as a key to any provided
  * callback function.
@@ -36,31 +36,34 @@ class TimeOfYearSelector extends React.Component {
   static propTypes = {
     onChange: PropTypes.any, // Using 'function' logs warnings
     value: PropTypes.any,
-    hideMonths: PropTypes.bool,
-    hideSeasons: PropTypes.bool,
-    hideYears: PropTypes.bool,
+    monthly: PropTypes.bool,
+    seasonal: PropTypes.bool,
+    yearly: PropTypes.bool,
     inlineLabel: PropTypes.bool,
   };
 
   static defaultProps = {
     inlineLabel: false,
+    monthly: true,
+    seasonal: true,
+    yearly: true,
   };
 
   render() {
-    var timesofyear = [];
+    let timesofyear = [];
     function addTimeRange(start, end) {
       for (let index = start; index <= end; index++) {
         timesofyear.push([index, timeKeyToTimeOfYear(index)]);
       }
     }
 
-    if (!this.props.hideMonths) {
+    if (this.props.monthly) {
       addTimeRange(0, 11);
     }
-    if (!this.props.hideSeasons){
+    if (this.props.seasonal) {
       addTimeRange(12, 15);
     }
-    if (!this.props.hideYears){
+    if (this.props.yearly) {
       addTimeRange(16, 16);
     }
 

--- a/src/components/Selector/TimeOfYearSelector.js
+++ b/src/components/Selector/TimeOfYearSelector.js
@@ -20,6 +20,9 @@
  *
  * Those three functions provide a standard ordering and encoding for
  * the TimeOfYearSelector component.
+ *
+ * Optionally, the hideMonths, hideSeasons, and hideYears props may
+ * be passed to surpress some of the options.
  ******************************************************************/
 
 import PropTypes from 'prop-types';
@@ -33,6 +36,9 @@ class TimeOfYearSelector extends React.Component {
   static propTypes = {
     onChange: PropTypes.any, // Using 'function' logs warnings
     value: PropTypes.any,
+    hideMonths: PropTypes.bool,
+    hideSeasons: PropTypes.bool,
+    hideYears: PropTypes.bool,
     inlineLabel: PropTypes.bool,
   };
 
@@ -41,10 +47,21 @@ class TimeOfYearSelector extends React.Component {
   };
 
   render() {
-
     var timesofyear = [];
-    for (var index = 0; index < 17; index++) {
-      timesofyear.push([index, timeKeyToTimeOfYear(index)]);
+    function addTimeRange(start, end) {
+      for (const index = start; index <= end; index++) {
+        timesofyear.push([index, timeKeyToTimeOfYear(index)]);
+      }
+    }
+
+    if (!this.props.hideMonths) {
+      addTimeRange(0, 11);
+    }
+    if (!this.props.hideSeasons){
+      addTimeRange(12, 15);
+    }
+    if (!this.props.hideYears){
+      addTimeRange(16, 16);
     }
 
     return (

--- a/src/components/Selector/TimeOfYearSelector.js
+++ b/src/components/Selector/TimeOfYearSelector.js
@@ -1,7 +1,7 @@
 /******************************************************************
  * TimeOfYearSelector.js - dropdown for user to select time of year
  *
- * This selector offer a choice of 12 months, 4 seasonal, and annual
+ * This selector offer a choice of 12 months, 4 seasons, and annual
  * to the user. Internally, the available times are keyed with a
  * numerical index, which is passed as a key to any provided
  * callback function.
@@ -21,8 +21,8 @@
  * Those three functions provide a standard ordering and encoding for
  * the TimeOfYearSelector component.
  *
- * Optionally, the hideMonths, hideSeasons, and hideYears props may
- * be passed to surpress some of the options.
+ * Optionally, the monthly, seasonal, and yearly props may
+ * be passed to show (true) or hide (false) some of the options.
  ******************************************************************/
 
 import PropTypes from 'prop-types';
@@ -36,9 +36,9 @@ class TimeOfYearSelector extends React.Component {
   static propTypes = {
     onChange: PropTypes.any, // Using 'function' logs warnings
     value: PropTypes.any,
-    monthly: PropTypes.bool,
-    seasonal: PropTypes.bool,
-    yearly: PropTypes.bool,
+    monthly: PropTypes.bool,  // Show month options
+    seasonal: PropTypes.bool, // Show season options
+    yearly: PropTypes.bool,   // Show annual option
     inlineLabel: PropTypes.bool,
   };
 

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -99,25 +99,21 @@ export default class LongTermAveragesGraph extends React.Component {
 
   timeResolutions() {
     const timeResolutions = _.pluck(this.props.meta, 'timescale');
-    const monthlyData = _.contains(timeResolutions, 'monthly');
-    const seasonalData = _.contains(timeResolutions, 'seasonal');
-    const yearlyData = _.contains(timeResolutions, 'yearly');
-
     return {
-      monthlyData,
-      seasonalData,
-      yearlyData,
+      monthly: _.contains(timeResolutions, 'monthly'),
+      seasonal: _.contains(timeResolutions, 'seasonal'),
+      yearly: _.contains(timeResolutions, 'yearly'),
     };
   }
 
-  defaultTimeOfYear({ monthlyData, seasonalData, yearlyData }) {
-    if (monthlyData) {
+  defaultTimeOfYear({ monthly, seasonal, yearly }) {
+    if (monthly) {
       return 0;  // January
     }
-    if (seasonalData) {
+    if (seasonal) {
       return 12;  // Winter
     }
-    if (yearlyData) {
+    if (yearly) {
       return 16;  // Annual
     }
     return undefined;
@@ -183,7 +179,6 @@ export default class LongTermAveragesGraph extends React.Component {
   }
 
   render() {
-    const timeResolutions = this.timeResolutions();
     return (
       <React.Fragment>
         <Row>
@@ -191,9 +186,7 @@ export default class LongTermAveragesGraph extends React.Component {
             <TimeOfYearSelector
               value={this.state.timeOfYear}
               onChange={this.handleChangeTimeOfYear}
-              hideMonths={!timeResolutions.monthlyData}
-              hideSeasons={!timeResolutions.seasonalData}
-              hideYear={!timeResolutions.yearlyData}
+              {...this.timeResolutions()}
               inlineLabel
             />
           </Col>

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -56,22 +56,25 @@ export default class LongTermAveragesGraph extends React.Component {
   constructor(props) {
     super(props);
 
-    const timeResolutions = _.pluck(props.meta, "timescale");
+    const timeResolutions = _.pluck(props.meta, 'timescale');
+    const monthlyData = _.contains(timeResolutions, 'monthly');
+    const seasonalData = _.contains(timeResolutions, 'seasonal');
+    const annualData = _.contains(timeResolutions, 'yearly');
+    
     //default to Annual, but use higher resolution if available.
     let timeOfYear = 16; //Annual
-    if(_.contains(timeResolutions, "monthly")) {
+    if (monthlyData) {
       timeOfYear = 0; //January
-    }
-    else if(_.contains(timeResolutions, "seasonal")) {
+    } else if (seasonalData) {
       timeOfYear = 12; //Winter
     }
 
     this.state = {
-      timeOfYear: timeOfYear,
+      timeOfYear,
       graphSpec: blankGraphSpec,
-      monthlyData: _.contains(timeResolutions, "monthly"),
-      seasonalData: _.contains(timeResolutions, "seasonal"),
-      annualData: _.contains(timeResolutions, "yearly")
+      monthlyData,
+      seasonalData,
+      annualData,
     };
   }
 

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -16,6 +16,7 @@ import {
 } from '../graph-helpers';
 import {
   timeKeyToResolutionIndex,
+  timeKeyToTimeOfYear,
   validateLongTermAverageData,
 } from '../../../core/util';
 import { getData } from '../../../data-services/ce-backend';
@@ -55,9 +56,22 @@ export default class LongTermAveragesGraph extends React.Component {
   constructor(props) {
     super(props);
 
+    const timeResolutions = _.pluck(props.meta, "timescale");
+    //default to Annual, but use higher resolution if available.
+    let timeOfYear = 16; //Annual
+    if(_.contains(timeResolutions, "monthly")) {
+      timeOfYear = 0; //January
+    }
+    else if(_.contains(timeResolutions, "seasonal")) {
+      timeOfYear = 12; //Winter
+    }
+
     this.state = {
-      timeOfYear: 0,
+      timeOfYear: timeOfYear,
       graphSpec: blankGraphSpec,
+      monthlyData: _.contains(timeResolutions, "monthly"),
+      seasonalData: _.contains(timeResolutions, "seasonal"),
+      annualData: _.contains(timeResolutions, "yearly")
     };
   }
 
@@ -143,6 +157,9 @@ export default class LongTermAveragesGraph extends React.Component {
             <TimeOfYearSelector
               value={this.state.timeOfYear}
               onChange={this.handleChangeTimeOfYear}
+              hideMonths={!this.state.monthlyData}
+              hideSeasons={!this.state.seasonalData}
+              hideYear={!this.state.yearlyData}
               inlineLabel
             />
           </Col>

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -17,6 +17,8 @@ import {
 import {
   timeKeyToResolutionIndex,
   validateLongTermAverageData,
+  timeResolutions,
+  defaultTimeOfYear,
 } from '../../../core/util';
 import { getData } from '../../../data-services/ce-backend';
 import { exportDataToWorksheet } from '../../../core/export';
@@ -79,28 +81,6 @@ export default class LongTermAveragesGraph extends React.Component {
     );
   }
 
-  timeResolutions() {
-    const timescales = _.pluck(this.props.meta, 'timescale');
-    return {
-      monthly: _.contains(timescales, 'monthly'),
-      seasonal: _.contains(timescales, 'seasonal'),
-      yearly: _.contains(timescales, 'yearly'),
-    };
-  }
-
-  defaultTimeOfYear({ monthly, seasonal, yearly }) {
-    if (monthly) {
-      return 0;  // January
-    }
-    if (seasonal) {
-      return 12;  // Winter
-    }
-    if (yearly) {
-      return 16;  // Annual
-    }
-    return undefined;
-  }
-
   loadGraph() {
     // Fetch data for graph, then convert it to a graph spec and set state
     // accordingly.
@@ -110,7 +90,7 @@ export default class LongTermAveragesGraph extends React.Component {
     }
 
     this.setState({
-      timeOfYear: this.defaultTimeOfYear(this.timeResolutions()),
+      timeOfYear: defaultTimeOfYear(timeResolutions(this.props.meta)),
     });
 
     const timeOfYearMetadatas =
@@ -168,7 +148,7 @@ export default class LongTermAveragesGraph extends React.Component {
             <TimeOfYearSelector
               value={this.state.timeOfYear}
               onChange={this.handleChangeTimeOfYear}
-              {...this.timeResolutions()}
+              {...timeResolutions(this.props.meta)}
               inlineLabel
             />
           </Col>

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -56,25 +56,25 @@ export default class LongTermAveragesGraph extends React.Component {
   constructor(props) {
     super(props);
 
-    const timeResolutions = _.pluck(props.meta, 'timescale');
-    const monthlyData = _.contains(timeResolutions, 'monthly');
-    const seasonalData = _.contains(timeResolutions, 'seasonal');
-    const annualData = _.contains(timeResolutions, 'yearly');
-    
-    //default to Annual, but use higher resolution if available.
-    let timeOfYear = 16; //Annual
-    if (monthlyData) {
-      timeOfYear = 0; //January
-    } else if (seasonalData) {
-      timeOfYear = 12; //Winter
-    }
+    // const timeResolutions = _.pluck(props.meta, 'timescale');
+    // const monthlyData = _.contains(timeResolutions, 'monthly');
+    // const seasonalData = _.contains(timeResolutions, 'seasonal');
+    // const yearlyData = _.contains(timeResolutions, 'yearly');
+    //
+    // //default to Annual, but use higher resolution if available.
+    // let timeOfYear = 16; //Annual
+    // if (monthlyData) {
+    //   timeOfYear = 0; //January
+    // } else if (seasonalData) {
+    //   timeOfYear = 12; //Winter
+    // }
 
     this.state = {
-      timeOfYear,
+      // timeOfYear,
       graphSpec: blankGraphSpec,
-      monthlyData,
-      seasonalData,
-      annualData,
+      // monthlyData,
+      // seasonalData,
+      // yearlyData,
     };
   }
 
@@ -105,12 +105,32 @@ export default class LongTermAveragesGraph extends React.Component {
       return;
     }
 
+    const timeResolutions = _.pluck(this.props.meta, 'timescale');
+    const monthlyData = _.contains(timeResolutions, 'monthly');
+    const seasonalData = _.contains(timeResolutions, 'seasonal');
+    const yearlyData = _.contains(timeResolutions, 'yearly');
+
+    //default to Annual, but use higher resolution if available.
+    let timeOfYear = 16; //Annual
+    if (monthlyData) {
+      timeOfYear = 0; //January
+    } else if (seasonalData) {
+      timeOfYear = 12; //Winter
+    }
+
     const timeOfYearMetadatas =
       this.props.getMetadata(this.state.timeOfYear)
         .filter(metadata => !!metadata);
     const dataPromises = timeOfYearMetadatas.map(metadata =>
       this.getAndValidateData(metadata)
     );
+
+    this.setState({
+      monthlyData,
+      seasonalData,
+      yearlyData,
+      timeOfYear,
+    });
 
     Promise.all(dataPromises).then(data => {
       this.setState({

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -16,7 +16,6 @@ import {
 } from '../graph-helpers';
 import {
   timeKeyToResolutionIndex,
-  timeKeyToTimeOfYear,
   validateLongTermAverageData,
 } from '../../../core/util';
 import { getData } from '../../../data-services/ce-backend';
@@ -56,25 +55,8 @@ export default class LongTermAveragesGraph extends React.Component {
   constructor(props) {
     super(props);
 
-    // const timeResolutions = _.pluck(props.meta, 'timescale');
-    // const monthlyData = _.contains(timeResolutions, 'monthly');
-    // const seasonalData = _.contains(timeResolutions, 'seasonal');
-    // const yearlyData = _.contains(timeResolutions, 'yearly');
-    //
-    // //default to Annual, but use higher resolution if available.
-    // let timeOfYear = 16; //Annual
-    // if (monthlyData) {
-    //   timeOfYear = 0; //January
-    // } else if (seasonalData) {
-    //   timeOfYear = 12; //Winter
-    // }
-
     this.state = {
-      // timeOfYear,
       graphSpec: blankGraphSpec,
-      // monthlyData,
-      // seasonalData,
-      // yearlyData,
     };
   }
 
@@ -98,11 +80,11 @@ export default class LongTermAveragesGraph extends React.Component {
   }
 
   timeResolutions() {
-    const timeResolutions = _.pluck(this.props.meta, 'timescale');
+    const timescales = _.pluck(this.props.meta, 'timescale');
     return {
-      monthly: _.contains(timeResolutions, 'monthly'),
-      seasonal: _.contains(timeResolutions, 'seasonal'),
-      yearly: _.contains(timeResolutions, 'yearly'),
+      monthly: _.contains(timescales, 'monthly'),
+      seasonal: _.contains(timescales, 'seasonal'),
+      yearly: _.contains(timescales, 'yearly'),
     };
   }
 

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -83,7 +83,8 @@ export default class LongTermAveragesGraph extends React.Component {
 
   loadGraph() {
     // Fetch data for graph, then convert it to a graph spec and set state
-    // accordingly.
+    // accordingly. Set default time of year appropriately for the data
+    // available.
 
     if (!shouldLoadData(this.props, this.displayNoDataMessage)) {
       return;

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -235,6 +235,28 @@ export function timeResolutionIndexToTimeOfYear(res, idx) {
   return `${res} ${idx}`;
 }
 
+export function timeResolutions(meta) {
+  const timescales = _.pluck(meta, 'timescale');
+  return {
+    monthly: _.contains(timescales, 'monthly'),
+    seasonal: _.contains(timescales, 'seasonal'),
+    yearly: _.contains(timescales, 'yearly'),
+  };
+}
+
+export function defaultTimeOfYear({ monthly, seasonal, yearly }) {
+  if (monthly) {
+    return 0;  // January
+  }
+  if (seasonal) {
+    return 12;  // Winter
+  }
+  if (yearly) {
+    return 16;  // Annual
+  }
+  return undefined;
+}
+
 /*
  * extendedDateToBasicDate: converts an ISO8601 extended-formatted date 
  * (like "1997-01-15T00:00:00Z") to an ISO8601 basic-formatted date 


### PR DESCRIPTION
Handles displaying a set of data with no monthly-resolution data on the Long Term Average graph, such as Heating Degree Days, which is only calculated on an annual basis.

Previously, the Long Term Average Graph default to displaying data from January; if there was no January data, a `long term data unavailable for this model` message was displayed. It now defaults to the first index of the highest time resolution, so either January, Winter, or Annual. If there's not data for any of those three, the error message will still appear.

Also added the props `hideMonths`, `hideSeasons`, and` hideYears` to the TimeOfYearSelector, allowing a component that wants a time selector to get one that contains only resolutions that are actually available in the data.