### PR TITLE
Guidance, Part 5: Dataset context

### DIFF
--- a/src/components/app-controllers/DualAppController/DualAppController.js
+++ b/src/components/app-controllers/DualAppController/DualAppController.js
@@ -31,6 +31,9 @@ import AppMixin from '../../AppMixin';
 import g from '../../../core/geo';
 import DualMapController from '../../map-controllers/DualMapController';
 import VariableDescriptionSelector from '../../VariableDescriptionSelector';
+import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
+import DatasetsSummary from '../../data-presentation/DatasetsSummary';
+
 import _ from 'underscore';
 
 export default createReactClass({
@@ -87,66 +90,87 @@ export default createReactClass({
                                                           experiment: this.state.experiment });
     let comparandConstraints = _.pick(this.state, 'model_id', 'experiment');
     comparandConstraints.multi_year_mean = selectedVariable ? selectedVariable.multi_year_mean : true;
-    
+
+    const filteredMeta = this.getFilteredMeta();
+    const filteredComparandMeta = this.getFilteredMeta(this.state.comparand_id, this.state.comparand_name);
+
     return (
       <Grid fluid>
-        <Panel>
-          <Panel.Heading>
-            <Panel.Title>{datasetFilterPanelLabel}</Panel.Title>
-          </Panel.Heading>
-          <Panel.Body>
-            <Row>
-              <Col lg={2} md={2}>
-                <Selector
-                  label={modelSelectorLabel}
-                  onChange={this.updateSelection.bind(this, 'model_id')}
-                  items={modOptions}
-                  value={this.state.model_id}
-                />
-              </Col>
-              <Col lg={2} md={2}>
-                <Selector
-                  label={emissionScenarioSelectorLabel}
-                  onChange={this.updateSelection.bind(this, 'experiment')}
-                  items={expOptions}
-                  value={this.state.experiment}
-                />
-              </Col>
-              <Col lg={3} md={3}>
-                <VariableDescriptionSelector
-                  label={variable1SelectorLabel}
-                  onChange={this.handleSetVariable.bind(this, "variable")}
-                  meta={this.state.meta}
-                  constraints={{model_id: this.state.model_id, experiment: this.state.experiment}}
-                  value={_.pick(this.state, "variable_id", "variable_name")}
-                />
-              </Col>
-              <Col lg={3} md={3}>
-                <VariableDescriptionSelector
-                  label={variable2SelectorLabel}
-                  onChange={this.handleSetVariable.bind(this, "comparand")}
-                  meta={this.state.meta}
-                  constraints={comparandConstraints}
-                  value={{variable_id: this.state.comparand_id, variable_name: this.state.comparand_name}}
-                />
-              </Col>
-            </Row>
-          </Panel.Body>
-        </Panel>
         <Row>
-          <Col lg={6}>
+          <FullWidthCol>
+            <Panel>
+              <Panel.Heading>
+                <Panel.Title>{datasetFilterPanelLabel}</Panel.Title>
+              </Panel.Heading>
+              <Panel.Body>
+                <Row>
+                  <Col lg={2} md={2}>
+                    <Selector
+                      label={modelSelectorLabel}
+                      onChange={this.updateSelection.bind(this, 'model_id')}
+                      items={modOptions}
+                      value={this.state.model_id}
+                    />
+                  </Col>
+                  <Col lg={2} md={2}>
+                    <Selector
+                      label={emissionScenarioSelectorLabel}
+                      onChange={this.updateSelection.bind(this, 'experiment')}
+                      items={expOptions}
+                      value={this.state.experiment}
+                    />
+                  </Col>
+                  <Col lg={3} md={3}>
+                    <VariableDescriptionSelector
+                      label={variable1SelectorLabel}
+                      onChange={this.handleSetVariable.bind(this, "variable")}
+                      meta={this.state.meta}
+                      constraints={{model_id: this.state.model_id, experiment: this.state.experiment}}
+                      value={_.pick(this.state, "variable_id", "variable_name")}
+                    />
+                  </Col>
+                  <Col lg={3} md={3}>
+                    <VariableDescriptionSelector
+                      label={variable2SelectorLabel}
+                      onChange={this.handleSetVariable.bind(this, "comparand")}
+                      meta={this.state.meta}
+                      constraints={comparandConstraints}
+                      value={{variable_id: this.state.comparand_id, variable_name: this.state.comparand_name}}
+                    />
+                  </Col>
+                </Row>
+              </Panel.Body>
+            </Panel>
+          </FullWidthCol>
+        </Row>
+        <Row>
+          <FullWidthCol>
+            <DatasetsSummary
+              model_id={this.state.model_id}
+              experiment={this.state.experiment}
+              variable_id={this.state.variable_id}
+              comparand_id={this.state.comparand_id ? this.state.comparand_id : this.state.variable_id}
+              meta={filteredMeta}
+              comparandMeta={filteredComparandMeta}
+              dual
+              flowArrow='top'
+            />
+          </FullWidthCol>
+        </Row>
+        <Row>
+          <HalfWidthCol>
             <DualMapController
               variable_id={this.state.variable_id}
               model_id={this.state.model_id}
               experiment={this.state.experiment}
-              meta = {this.getFilteredMeta()}
+              meta={filteredMeta}
               comparand_id={this.state.comparand_id ? this.state.comparand_id : this.state.variable_id}
-              comparandMeta = {this.getFilteredMeta(this.state.comparand_id, this.state.comparand_name)}
+              comparandMeta={filteredComparandMeta}
               area={this.state.area}
               onSetArea={this.handleSetArea}
             />
-          </Col>
-          <Col lg={6}>
+          </HalfWidthCol>
+          <HalfWidthCol>
             <DualDataController
               ensemble_name={this.state.ensemble_name}
               model_id={this.state.model_id}
@@ -154,11 +178,12 @@ export default createReactClass({
               comparand_id={this.state.comparand_id ? this.state.comparand_id : this.state.variable_id}
               experiment={this.state.experiment}
               area={g.geojson(this.state.area).toWKT()}
-              meta = {this.getFilteredMeta()}
-              comparandMeta = {this.state.comparand_id ? this.getFilteredMeta(this.state.comparand_id, this.state.comparand_name) 
-                  : this.getFilteredMeta()}
+              meta={filteredMeta}
+              comparandMeta={
+                this.state.comparand_id ? filteredComparandMeta : filteredMeta
+              }
             />
-          </Col>
+          </HalfWidthCol>
         </Row>
       </Grid>
 

--- a/src/components/app-controllers/DualAppController/DualAppController.js
+++ b/src/components/app-controllers/DualAppController/DualAppController.js
@@ -36,6 +36,7 @@ import FilteredDatasetsSummary from '../../data-presentation/FilteredDatasetsSum
 
 import _ from 'underscore';
 import FlowArrow from '../../data-presentation/FlowArrow';
+import UnfilteredDatasetsSummary from '../../data-presentation/UnfilteredDatasetsSummary';
 
 export default createReactClass({
   displayName: 'DualAppController',
@@ -97,6 +98,18 @@ export default createReactClass({
 
     return (
       <Grid fluid>
+        <Row>
+          <FullWidthCol>
+            <UnfilteredDatasetsSummary meta={this.state.meta} />
+          </FullWidthCol>
+        </Row>
+
+        <Row>
+          <FullWidthCol>
+            <FlowArrow pullUp />
+          </FullWidthCol>
+        </Row>
+
         <Row>
           <FullWidthCol>
             <Panel>

--- a/src/components/app-controllers/DualAppController/DualAppController.js
+++ b/src/components/app-controllers/DualAppController/DualAppController.js
@@ -32,7 +32,7 @@ import g from '../../../core/geo';
 import DualMapController from '../../map-controllers/DualMapController';
 import VariableDescriptionSelector from '../../VariableDescriptionSelector';
 import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
-import DatasetsSummary from '../../data-presentation/DatasetsSummary';
+import FilteredDatasetsSummary from '../../data-presentation/FilteredDatasetsSummary';
 
 import _ from 'underscore';
 import FlowArrow from '../../data-presentation/FlowArrow';
@@ -153,7 +153,7 @@ export default createReactClass({
 
         <Row>
           <FullWidthCol>
-            <DatasetsSummary
+            <FilteredDatasetsSummary
               model_id={this.state.model_id}
               experiment={this.state.experiment}
               variable_id={this.state.variable_id}

--- a/src/components/app-controllers/DualAppController/DualAppController.js
+++ b/src/components/app-controllers/DualAppController/DualAppController.js
@@ -35,6 +35,7 @@ import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
 import DatasetsSummary from '../../data-presentation/DatasetsSummary';
 
 import _ from 'underscore';
+import FlowArrow from '../../data-presentation/FlowArrow';
 
 export default createReactClass({
   displayName: 'DualAppController',
@@ -143,6 +144,13 @@ export default createReactClass({
             </Panel>
           </FullWidthCol>
         </Row>
+
+        <Row>
+          <FullWidthCol>
+            <FlowArrow pullUp />
+          </FullWidthCol>
+        </Row>
+
         <Row>
           <FullWidthCol>
             <DatasetsSummary
@@ -156,6 +164,16 @@ export default createReactClass({
             />
           </FullWidthCol>
         </Row>
+
+        <Row>
+          <HalfWidthCol>
+            <FlowArrow pullUp />
+          </HalfWidthCol>
+          <HalfWidthCol>
+            <FlowArrow pullUp />
+          </HalfWidthCol>
+        </Row>
+
         <Row>
           <HalfWidthCol>
             <DualMapController

--- a/src/components/app-controllers/DualAppController/DualAppController.js
+++ b/src/components/app-controllers/DualAppController/DualAppController.js
@@ -153,7 +153,6 @@ export default createReactClass({
               meta={filteredMeta}
               comparandMeta={filteredComparandMeta}
               dual
-              flowArrow='top'
             />
           </FullWidthCol>
         </Row>

--- a/src/components/app-controllers/PrecipAppController/PrecipAppController.js
+++ b/src/components/app-controllers/PrecipAppController/PrecipAppController.js
@@ -36,6 +36,7 @@ import DatasetsSummary from '../../data-presentation/DatasetsSummary';
 
 
 import _ from 'underscore';
+import FlowArrow from '../../data-presentation/FlowArrow';
 
 export default createReactClass({
   displayName: 'PrecipAppController',
@@ -113,6 +114,13 @@ export default createReactClass({
             </Panel>
           </FullWidthCol>
         </Row>
+
+        <Row>
+          <FullWidthCol>
+            <FlowArrow pullUp />
+          </FullWidthCol>
+        </Row>
+
         <Row>
           <FullWidthCol>
             <DatasetsSummary
@@ -125,6 +133,15 @@ export default createReactClass({
               dual
             />
           </FullWidthCol>
+        </Row>
+
+        <Row>
+          <HalfWidthCol>
+            <FlowArrow pullUp />
+          </HalfWidthCol>
+          <HalfWidthCol>
+            <FlowArrow pullUp />
+          </HalfWidthCol>
         </Row>
 
         <Row>

--- a/src/components/app-controllers/PrecipAppController/PrecipAppController.js
+++ b/src/components/app-controllers/PrecipAppController/PrecipAppController.js
@@ -31,8 +31,11 @@ import {
 import AppMixin from '../../AppMixin';
 import g from '../../../core/geo';
 import PrecipMapController from '../../map-controllers/PrecipMapController';
+import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
+import DatasetsSummary from '../../data-presentation/DatasetsSummary';
+
+
 import _ from 'underscore';
-import { DualMEVSummary } from '../../data-presentation/MEVSummary/MEVSummary';
 
 export default createReactClass({
   displayName: 'PrecipAppController',
@@ -63,68 +66,93 @@ export default createReactClass({
     const modOptions = this.getMetadataItems('model_id');
     const expOptions = this.markDisabledMetadataItems(this.getMetadataItems('experiment'),
         this.getFilteredMetadataItems('experiment', {model_id: this.state.model_id}));
-    
+
+    const filteredMeta = this.getFilteredMeta();
+
+    const comparand_id = 'pr';
+    const comparand_name = 'Precipitation';
+    const filteredComparandMeta = this.getFilteredMeta(comparand_id, comparand_name);
+
     return (
       <Grid fluid>
-        <Panel>
-          <Panel.Heading>
-            <Panel.Title>{datasetFilterPanelLabel}</Panel.Title>
-          </Panel.Heading>
-          <Panel.Body>
-            <Row>
-              <Col lg={2} md={2}>
-                <Selector
-                  label={modelSelectorLabel}
-                  onChange={this.updateSelection.bind(this, 'model_id')}
-                  items={modOptions}
-                  value={this.state.model_id}
-                />
-              </Col>
-                <Col lg={2} md={2}>
-                <Selector
-                  label={emissionScenarioSelectorLabel}
-                  onChange={this.updateSelection.bind(this, 'experiment')}
-                  items={expOptions}
-                  value={this.state.experiment}
-                />
-              </Col>
-              <Col lg={4} md={4}>
-                <VariableDescriptionSelector
-                  label={variableSelectorLabel}
-                  onChange={this.handleSetVariable.bind(this, "variable")}
-                  meta={_.filter(this.state.meta, m=> {return m.variable_id != "pr"})}
-                  constraints={_.pick(this.state, "model_id", "experiment")}
-                  value={_.pick(this.state, "variable_id", "variable_name")}
-                />
-              </Col>
-            </Row>
-          </Panel.Body>
-        </Panel>
         <Row>
-          <Col lg={6}>
+          <FullWidthCol>
+            <Panel>
+              <Panel.Heading>
+                <Panel.Title>{datasetFilterPanelLabel}</Panel.Title>
+              </Panel.Heading>
+              <Panel.Body>
+                <Row>
+                  <Col lg={2} md={2}>
+                    <Selector
+                      label={modelSelectorLabel}
+                      onChange={this.updateSelection.bind(this, 'model_id')}
+                      items={modOptions}
+                      value={this.state.model_id}
+                    />
+                  </Col>
+                    <Col lg={2} md={2}>
+                    <Selector
+                      label={emissionScenarioSelectorLabel}
+                      onChange={this.updateSelection.bind(this, 'experiment')}
+                      items={expOptions}
+                      value={this.state.experiment}
+                    />
+                  </Col>
+                  <Col lg={4} md={4}>
+                    <VariableDescriptionSelector
+                      label={variableSelectorLabel}
+                      onChange={this.handleSetVariable.bind(this, "variable")}
+                      meta={_.filter(this.state.meta, m=> {return m.variable_id != "pr"})}
+                      constraints={_.pick(this.state, "model_id", "experiment")}
+                      value={_.pick(this.state, "variable_id", "variable_name")}
+                    />
+                  </Col>
+                </Row>
+              </Panel.Body>
+            </Panel>
+          </FullWidthCol>
+        </Row>
+        <Row>
+          <FullWidthCol>
+            <DatasetsSummary
+              model_id={this.state.model_id}
+              experiment={this.state.experiment}
+              variable_id={this.state.variable_id}
+              comparand_id={comparand_id}
+              meta={filteredMeta}
+              comparandMeta={filteredComparandMeta}
+              dual
+              flowArrow='top'
+            />
+          </FullWidthCol>
+        </Row>
+
+        <Row>
+          <HalfWidthCol>
             <PrecipMapController
               model_id={this.state.model_id}
               variable_id={this.state.variable_id}
               experiment={this.state.experiment}
-              meta = {this.getFilteredMeta()}
-              comparand_id={"pr"}
-              comparandMeta = {this.getFilteredMeta("pr", "Precipitation")}
+              meta = {filteredMeta}
+              comparand_id={comparand_id}
+              comparandMeta = {filteredComparandMeta}
               area={this.state.area}
               onSetArea={this.handleSetArea}
             />
-          </Col>
-          <Col lg={6}>
+          </HalfWidthCol>
+          <HalfWidthCol>
             <DualDataController
               ensemble_name={this.state.ensemble_name}
               model_id={this.state.model_id}
               variable_id={this.state.variable_id}
-              comparand_id='pr'
+              comparand_id={comparand_id}
               experiment={this.state.experiment}
               area={g.geojson(this.state.area).toWKT()}
-              meta = {this.getFilteredMeta()}
-              comparandMeta = {this.getFilteredMeta("pr")}
+              meta = {filteredMeta}
+              comparandMeta = {filteredComparandMeta}
             />
-          </Col>
+          </HalfWidthCol>
         </Row>
       </Grid>
 

--- a/src/components/app-controllers/PrecipAppController/PrecipAppController.js
+++ b/src/components/app-controllers/PrecipAppController/PrecipAppController.js
@@ -37,6 +37,7 @@ import FilteredDatasetsSummary from '../../data-presentation/FilteredDatasetsSum
 
 import _ from 'underscore';
 import FlowArrow from '../../data-presentation/FlowArrow';
+import UnfilteredDatasetsSummary from '../../data-presentation/UnfilteredDatasetsSummary';
 
 export default createReactClass({
   displayName: 'PrecipAppController',
@@ -76,6 +77,18 @@ export default createReactClass({
 
     return (
       <Grid fluid>
+        <Row>
+          <FullWidthCol>
+            <UnfilteredDatasetsSummary meta={this.state.meta} />
+          </FullWidthCol>
+        </Row>
+
+        <Row>
+          <FullWidthCol>
+            <FlowArrow pullUp />
+          </FullWidthCol>
+        </Row>
+
         <Row>
           <FullWidthCol>
             <Panel>

--- a/src/components/app-controllers/PrecipAppController/PrecipAppController.js
+++ b/src/components/app-controllers/PrecipAppController/PrecipAppController.js
@@ -32,7 +32,7 @@ import AppMixin from '../../AppMixin';
 import g from '../../../core/geo';
 import PrecipMapController from '../../map-controllers/PrecipMapController';
 import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
-import DatasetsSummary from '../../data-presentation/DatasetsSummary';
+import FilteredDatasetsSummary from '../../data-presentation/FilteredDatasetsSummary';
 
 
 import _ from 'underscore';
@@ -123,7 +123,7 @@ export default createReactClass({
 
         <Row>
           <FullWidthCol>
-            <DatasetsSummary
+            <FilteredDatasetsSummary
               model_id={this.state.model_id}
               experiment={this.state.experiment}
               variable_id={this.state.variable_id}

--- a/src/components/app-controllers/PrecipAppController/PrecipAppController.js
+++ b/src/components/app-controllers/PrecipAppController/PrecipAppController.js
@@ -123,7 +123,6 @@ export default createReactClass({
               meta={filteredMeta}
               comparandMeta={filteredComparandMeta}
               dual
-              flowArrow='top'
             />
           </FullWidthCol>
         </Row>

--- a/src/components/app-controllers/SingleAppController/SingleAppController.js
+++ b/src/components/app-controllers/SingleAppController/SingleAppController.js
@@ -27,6 +27,7 @@ import AppMixin from '../../AppMixin';
 import g from '../../../core/geo';
 import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
 import DatasetsSummary from '../../data-presentation/DatasetsSummary';
+import FlowArrow from '../../data-presentation/FlowArrow';
 
 export default createReactClass({
   displayName: 'SingleAppController',
@@ -103,6 +104,13 @@ export default createReactClass({
             </Panel>
           </FullWidthCol>
         </Row>
+
+        <Row>
+          <FullWidthCol>
+            <FlowArrow pullUp />
+          </FullWidthCol>
+        </Row>
+
         <Row>
           <FullWidthCol>
             <DatasetsSummary
@@ -113,6 +121,16 @@ export default createReactClass({
             />
           </FullWidthCol>
         </Row>
+
+        <Row>
+          <HalfWidthCol>
+            <FlowArrow pullUp />
+          </HalfWidthCol>
+          <HalfWidthCol>
+            <FlowArrow pullUp />
+          </HalfWidthCol>
+        </Row>
+
         <Row>
           <HalfWidthCol>
             <SingleMapController

--- a/src/components/app-controllers/SingleAppController/SingleAppController.js
+++ b/src/components/app-controllers/SingleAppController/SingleAppController.js
@@ -28,6 +28,7 @@ import g from '../../../core/geo';
 import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
 import FilteredDatasetsSummary from '../../data-presentation/FilteredDatasetsSummary';
 import FlowArrow from '../../data-presentation/FlowArrow';
+import UnfilteredDatasetsSummary from '../../data-presentation/UnfilteredDatasetsSummary';
 
 export default createReactClass({
   displayName: 'SingleAppController',
@@ -66,6 +67,18 @@ export default createReactClass({
 
     return (
       <Grid fluid>
+        <Row>
+          <FullWidthCol>
+            <UnfilteredDatasetsSummary meta={this.state.meta} />
+          </FullWidthCol>
+        </Row>
+
+        <Row>
+          <FullWidthCol>
+            <FlowArrow pullUp />
+          </FullWidthCol>
+        </Row>
+
         <Row>
           <FullWidthCol>
             <Panel>

--- a/src/components/app-controllers/SingleAppController/SingleAppController.js
+++ b/src/components/app-controllers/SingleAppController/SingleAppController.js
@@ -25,6 +25,8 @@ import {
 
 import AppMixin from '../../AppMixin';
 import g from '../../../core/geo';
+import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
+import DatasetsSummary from '../../data-presentation/DatasetsSummary';
 
 export default createReactClass({
   displayName: 'SingleAppController',
@@ -56,56 +58,74 @@ export default createReactClass({
     var expOptions = this.markDisabledMetadataItems(this.getMetadataItems('experiment'),
         this.getFilteredMetadataItems('experiment', { model_id: this.state.model_id }));
 
+    const filteredMeta = this.getFilteredMeta();
+
     // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/122
     // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/125
+
     return (
       <Grid fluid>
-        <Panel>
-          <Panel.Heading>
-            <Panel.Title>{datasetFilterPanelLabel}</Panel.Title>
-          </Panel.Heading>
-          <Panel.Body>
-            <Row>
-              <Col lg={2} md={2}>
-                <Selector
-                  label={modelSelectorLabel}
-                  onChange={this.updateSelection.bind(this, 'model_id')}
-                  items={modOptions}
-                  value={this.state.model_id}
-                />
-              </Col>
-              <Col lg={2} md={2}>
-                <Selector
-                  label={emissionScenarioSelectorLabel}
-                  onChange={this.updateSelection.bind(this, 'experiment')}
-                  items={expOptions}
-                  value={this.state.experiment}
-                />
-              </Col>
-              <Col lg={4} md={4}>
-                <VariableDescriptionSelector
-                  label={variableSelectorLabel}
-                  onChange={this.handleSetVariable.bind(this, 'variable')}
-                  meta={this.state.meta}
-                  constraints={{ model_id: this.state.model_id }}
-                  value={_.pick(this.state, 'variable_id', 'variable_name')}
-                />
-              </Col>
-            </Row>
-          </Panel.Body>
-        </Panel>
         <Row>
-          <Col lg={6}>
-            <SingleMapController
-              variable_id={this.state.variable_id}
+          <FullWidthCol>
+            <Panel>
+              <Panel.Heading>
+                <Panel.Title>{datasetFilterPanelLabel}</Panel.Title>
+              </Panel.Heading>
+              <Panel.Body>
+                <Row>
+                  <Col lg={2} md={2}>
+                    <Selector
+                      label={modelSelectorLabel}
+                      onChange={this.updateSelection.bind(this, 'model_id')}
+                      items={modOptions}
+                      value={this.state.model_id}
+                    />
+                  </Col>
+                  <Col lg={2} md={2}>
+                    <Selector
+                      label={emissionScenarioSelectorLabel}
+                      onChange={this.updateSelection.bind(this, 'experiment')}
+                      items={expOptions}
+                      value={this.state.experiment}
+                    />
+                  </Col>
+                  <Col lg={4} md={4}>
+                    <VariableDescriptionSelector
+                      label={variableSelectorLabel}
+                      onChange={this.handleSetVariable.bind(this, 'variable')}
+                      meta={this.state.meta}
+                      constraints={{ model_id: this.state.model_id }}
+                      value={_.pick(this.state, 'variable_id', 'variable_name')}
+                    />
+                  </Col>
+                </Row>
+              </Panel.Body>
+            </Panel>
+          </FullWidthCol>
+        </Row>
+        <Row>
+          <FullWidthCol>
+            <DatasetsSummary
               model_id={this.state.model_id}
               experiment={this.state.experiment}
-              meta = {this.getFilteredMeta()}
+              variable_id={this.state.variable_id}
+              meta = {filteredMeta}
+              flowArrow='top'
+            />
+          </FullWidthCol>
+        </Row>
+        <Row>
+          <HalfWidthCol>
+            <SingleMapController
+              model_id={this.state.model_id}
+              experiment={this.state.experiment}
+              variable_id={this.state.variable_id}
+              meta = {filteredMeta}
               area={this.state.area}
               onSetArea={this.handleSetArea}
             />
-          </Col>
-          <Col lg={6}>
+          </HalfWidthCol>
+          <HalfWidthCol>
             <SingleDataController
               ensemble_name={this.state.ensemble_name}
               model_id={this.state.model_id}
@@ -113,10 +133,10 @@ export default createReactClass({
               comparand_id={this.state.comparand_id ? this.state.comparand_id : this.state.variable_id}
               experiment={this.state.experiment}
               area={g.geojson(this.state.area).toWKT()}
-              meta = {this.getFilteredMeta()}
+              meta = {filteredMeta}
               contextMeta={this.getModelContextMetadata()} //to generate Model Context graph
             />
-          </Col>
+          </HalfWidthCol>
         </Row>
       </Grid>
 

--- a/src/components/app-controllers/SingleAppController/SingleAppController.js
+++ b/src/components/app-controllers/SingleAppController/SingleAppController.js
@@ -110,7 +110,6 @@ export default createReactClass({
               experiment={this.state.experiment}
               variable_id={this.state.variable_id}
               meta = {filteredMeta}
-              flowArrow='top'
             />
           </FullWidthCol>
         </Row>

--- a/src/components/app-controllers/SingleAppController/SingleAppController.js
+++ b/src/components/app-controllers/SingleAppController/SingleAppController.js
@@ -26,7 +26,7 @@ import {
 import AppMixin from '../../AppMixin';
 import g from '../../../core/geo';
 import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
-import DatasetsSummary from '../../data-presentation/DatasetsSummary';
+import FilteredDatasetsSummary from '../../data-presentation/FilteredDatasetsSummary';
 import FlowArrow from '../../data-presentation/FlowArrow';
 
 export default createReactClass({
@@ -113,7 +113,7 @@ export default createReactClass({
 
         <Row>
           <FullWidthCol>
-            <DatasetsSummary
+            <FilteredDatasetsSummary
               model_id={this.state.model_id}
               experiment={this.state.experiment}
               variable_id={this.state.variable_id}

--- a/src/components/data-presentation/DatasetsSummary/DatasetsSummary.js
+++ b/src/components/data-presentation/DatasetsSummary/DatasetsSummary.js
@@ -5,7 +5,6 @@ import Accordion from '../../guidance-tools/Accordion';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 import { MEVSummary } from '../MEVSummary/MEVSummary';
 import { filteredDatasetSummaryPanelLabel } from '../../guidance-content/info/InformationItems';
-import FlowArrow from '../FlowArrow';
 
 import _ from 'underscore';
 import { HalfWidthCol } from '../../layout/rb-derived-components';
@@ -20,13 +19,11 @@ export default class DatasetsSummary extends React.Component {
     meta: PropTypes.array.isRequired,
     comparandMeta: PropTypes.array.isRequired,
     dual: PropTypes.bool.isRequired,
-    flowArrow: PropTypes.oneOf('none top bottom'.split()).isRequired,
   };
 
   static defaultProps = {
     dual: false,
     comparandMeta: null,
-    flowArrow: 'none',
   };
 
   render() {
@@ -119,10 +116,6 @@ export default class DatasetsSummary extends React.Component {
 
     return (
       <Accordion>
-        {
-          this.props.flowArrow === 'top' &&
-          <FlowArrow position={this.props.flowArrow}/>
-        }
         <Accordion.Item
           eventKey={2}
           title={
@@ -173,10 +166,6 @@ export default class DatasetsSummary extends React.Component {
             }
           </Row>
         </Accordion.Item>
-        {
-          this.props.flowArrow === 'bottom' &&
-          <FlowArrow position={this.props.flowArrow}/>
-        }
       </Accordion>
     );
   }

--- a/src/components/data-presentation/DatasetsSummary/DatasetsSummary.js
+++ b/src/components/data-presentation/DatasetsSummary/DatasetsSummary.js
@@ -8,6 +8,7 @@ import { filteredDatasetSummaryPanelLabel } from '../../guidance-content/info/In
 import FlowArrow from '../FlowArrow';
 
 import _ from 'underscore';
+import { HalfWidthCol } from '../../layout/rb-derived-components';
 
 
 export default class DatasetsSummary extends React.Component {
@@ -116,8 +117,6 @@ export default class DatasetsSummary extends React.Component {
       </BootstrapTable>
     );
 
-    const colWidth = this.props.dual ? 6 : 12;
-
     return (
       <Accordion>
         {
@@ -152,22 +151,25 @@ export default class DatasetsSummary extends React.Component {
           }
         >
           <Row>
-            <Col lg={colWidth}>
-              <p>
-                Variable 1 ({this.props.variable_id}){': '}
-                {this.props.meta.length} datasets
-              </p>
+            <HalfWidthCol>
+              {
+                this.props.dual &&
+                <p>
+                  Variable 1 ({this.props.variable_id}){': '}
+                  {this.props.meta.length} datasets
+                </p>
+              }
               <DataTable data={dataForTable}/>
-            </Col>
+            </HalfWidthCol>
             {
               this.props.dual &&
-              <Col lg={12 - colWidth}>
+              <HalfWidthCol>
                 <p>
                   Variable 2 ({this.props.comparand_id}){': '}
                   {this.props.comparandMeta.length} datasets
                 </p>
                 <DataTable data={comparandDataForTable}/>
-              </Col>
+              </HalfWidthCol>
             }
           </Row>
         </Accordion.Item>

--- a/src/components/data-presentation/DatasetsSummary/DatasetsSummary.js
+++ b/src/components/data-presentation/DatasetsSummary/DatasetsSummary.js
@@ -1,0 +1,181 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Row, Col, Glyphicon } from 'react-bootstrap';
+import Accordion from '../../guidance-tools/Accordion';
+import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
+import { MEVSummary } from '../MEVSummary/MEVSummary';
+import { filteredDatasetSummaryPanelLabel } from '../../guidance-content/info/InformationItems';
+import FlowArrow from '../FlowArrow';
+
+import _ from 'underscore';
+
+
+export default class DatasetsSummary extends React.Component {
+  static propTypes = {
+    model_id: PropTypes.string.isRequired,
+    experiment: PropTypes.string.isRequired,
+    variable_id: PropTypes.string.isRequired,
+    comparand_id: PropTypes.string,
+    meta: PropTypes.array.isRequired,
+    comparandMeta: PropTypes.array.isRequired,
+    dual: PropTypes.bool.isRequired,
+    flowArrow: PropTypes.oneOf('none top bottom'.split()).isRequired,
+  };
+
+  static defaultProps = {
+    dual: false,
+    comparandMeta: null,
+    flowArrow: 'none',
+  };
+
+  render() {
+    const metaToKeyedData = (m) => ({
+      key: `${m.ensemble_member} ${m.start_date}-${m.end_date}`,
+      ...m,
+    });
+
+    const keyedDataToTableRowData = (data, key) => {
+      const { ensemble_member, start_date, end_date } = data[0];
+      let row = {
+        id: key,
+        ensemble_member,
+        start_date: `${start_date}-01-01`,
+        end_date: `${end_date}-12-31`,
+      };
+      for (const d of data) {
+        row[d.timescale] = 'Yes';
+      }
+      return row;
+    };
+
+    const keyedData = this.props.meta.map(metaToKeyedData);
+    console.log('keyedData', keyedData)
+    const keyedComparandData =
+      this.props.comparandMeta &&
+      this.props.comparandMeta.map(metaToKeyedData);
+    console.log('keyedComparandData', keyedComparandData)
+
+    const dataGroupedByKey = _.groupBy(keyedData, 'key');
+    console.log('dataGroupedByKey', dataGroupedByKey)
+    const comparandDataGroupedByKey =
+      keyedComparandData &&
+      _.groupBy(keyedComparandData, 'key');
+    console.log('comparandDataGroupedByKey', comparandDataGroupedByKey)
+
+    const dataForTable = _.map(dataGroupedByKey, keyedDataToTableRowData);
+    const comparandDataForTable =
+      comparandDataGroupedByKey &&
+      _.map(comparandDataGroupedByKey, keyedDataToTableRowData);
+
+    const DataTable = ({ data }) => (
+      <BootstrapTable
+        data={data}
+      >
+        <TableHeaderColumn
+          dataField='id' isKey
+          width={'15%'}
+        >
+          Label in selectors
+        </TableHeaderColumn>
+        <TableHeaderColumn
+          dataField='ensemble_member'
+          width={'10%'}
+        >
+          Model Run
+        </TableHeaderColumn>
+        <TableHeaderColumn
+          dataField='start_date'
+          width={'10%'}
+        >
+          Start Date
+        </TableHeaderColumn>
+        <TableHeaderColumn
+          dataField='end_date'
+          width={'10%'}
+        >
+          End Date
+        </TableHeaderColumn>
+        <TableHeaderColumn
+          dataField='yearly'
+          width={'10%'}
+        >
+          Yearly?
+        </TableHeaderColumn>
+        <TableHeaderColumn
+          dataField='seasonal'
+          width={'10%'}
+        >
+          Seasonal?
+        </TableHeaderColumn>
+        <TableHeaderColumn
+          dataField='monthly'
+          width={'10%'}
+        >
+          Monthly?
+        </TableHeaderColumn>
+      </BootstrapTable>
+    );
+
+    const colWidth = this.props.dual ? 6 : 12;
+
+    return (
+      <Accordion>
+        {
+          this.props.flowArrow === 'top' &&
+          <FlowArrow position={this.props.flowArrow}/>
+        }
+        <Accordion.Item
+          eventKey={2}
+          title={
+            <Row>
+              <Col lg={2}>
+                {filteredDatasetSummaryPanelLabel}
+              </Col>
+              <Col lg={10}>
+                <MEVSummary
+                  model_id={this.props.model_id}
+                  experiment={this.props.experiment}
+                  variable_id={this.props.variable_id}
+                  comparand_id={this.props.comparand_id}
+                  dual={this.props.dual}
+                />
+                {' '}<Glyphicon glyph='arrow-right'/>{' '}
+                <span>{this.props.meta.length} datasets</span>
+                {
+                  this.props.dual &&
+                  <span>
+                    {' + '}{this.props.comparandMeta.length} datasets
+                  </span>
+                }
+              </Col>
+            </Row>
+          }
+        >
+          <Row>
+            <Col lg={colWidth}>
+              <p>
+                Variable 1 ({this.props.variable_id}){': '}
+                {this.props.meta.length} datasets
+              </p>
+              <DataTable data={dataForTable}/>
+            </Col>
+            {
+              this.props.dual &&
+              <Col lg={12 - colWidth}>
+                <p>
+                  Variable 2 ({this.props.comparand_id}){': '}
+                  {this.props.comparandMeta.length} datasets
+                </p>
+                <DataTable data={comparandDataForTable}/>
+              </Col>
+            }
+          </Row>
+        </Accordion.Item>
+        {
+          this.props.flowArrow === 'bottom' &&
+          <FlowArrow position={this.props.flowArrow}/>
+        }
+      </Accordion>
+    );
+  }
+}

--- a/src/components/data-presentation/DatasetsSummary/__tests__/smoke.js
+++ b/src/components/data-presentation/DatasetsSummary/__tests__/smoke.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import DatasetsSummary from '../DatasetsSummary';
+import { noop } from 'underscore';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <DatasetsSummary/>,
+    div
+  );
+});

--- a/src/components/data-presentation/DatasetsSummary/package.json
+++ b/src/components/data-presentation/DatasetsSummary/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "DatasetsSummary",
-  "version": "0.0.0",
-  "private": true,
-  "main": "./DatasetsSummary.js"
-}

--- a/src/components/data-presentation/DatasetsSummary/package.json
+++ b/src/components/data-presentation/DatasetsSummary/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "DatasetsSummary",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./DatasetsSummary.js"
+}

--- a/src/components/data-presentation/FilteredDatasetsSummary/FilteredDatasetsSummary.js
+++ b/src/components/data-presentation/FilteredDatasetsSummary/FilteredDatasetsSummary.js
@@ -17,13 +17,12 @@ export default class FilteredDatasetsSummary extends React.Component {
     variable_id: PropTypes.string.isRequired,
     comparand_id: PropTypes.string,
     meta: PropTypes.array.isRequired,
-    comparandMeta: PropTypes.array.isRequired,
+    comparandMeta: PropTypes.array,
     dual: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {
     dual: false,
-    comparandMeta: null,
   };
 
   render() {

--- a/src/components/data-presentation/FilteredDatasetsSummary/FilteredDatasetsSummary.js
+++ b/src/components/data-presentation/FilteredDatasetsSummary/FilteredDatasetsSummary.js
@@ -10,7 +10,7 @@ import _ from 'underscore';
 import { HalfWidthCol } from '../../layout/rb-derived-components';
 
 
-export default class DatasetsSummary extends React.Component {
+export default class FilteredDatasetsSummary extends React.Component {
   static propTypes = {
     model_id: PropTypes.string.isRequired,
     experiment: PropTypes.string.isRequired,

--- a/src/components/data-presentation/FilteredDatasetsSummary/__tests__/smoke.js
+++ b/src/components/data-presentation/FilteredDatasetsSummary/__tests__/smoke.js
@@ -2,11 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import FilteredDatasetsSummary from '../';
 import { noop } from 'underscore';
+import { meta } from '../../../../test_support/data';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
   ReactDOM.render(
-    <FilteredDatasetsSummary/>,
+    <FilteredDatasetsSummary
+      model_id={'GFDL-ESM2G'}
+      experiment={'historical,rcp26'}
+      variable_id={'tasmax'}
+      meta={meta}
+    />,
     div
   );
 });

--- a/src/components/data-presentation/FilteredDatasetsSummary/__tests__/smoke.js
+++ b/src/components/data-presentation/FilteredDatasetsSummary/__tests__/smoke.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import DatasetsSummary from '../DatasetsSummary';
+import FilteredDatasetsSummary from '../';
 import { noop } from 'underscore';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
   ReactDOM.render(
-    <DatasetsSummary/>,
+    <FilteredDatasetsSummary/>,
     div
   );
 });

--- a/src/components/data-presentation/FilteredDatasetsSummary/package.json
+++ b/src/components/data-presentation/FilteredDatasetsSummary/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "FilteredDatasetsSummary",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./FilteredDatasetsSummary.js"
+}

--- a/src/components/data-presentation/FlowArrow/FlowArrow.css
+++ b/src/components/data-presentation/FlowArrow/FlowArrow.css
@@ -1,0 +1,10 @@
+.flowArrow.top {
+    margin-top: -1.3em;
+    margin-bottom: 0em;
+}
+
+.flowArrow.bottom {
+    margin-top: 0em;
+    margin-bottom: -1.5em;
+}
+

--- a/src/components/data-presentation/FlowArrow/FlowArrow.css
+++ b/src/components/data-presentation/FlowArrow/FlowArrow.css
@@ -8,3 +8,7 @@
     margin-bottom: -1.5em;
 }
 
+.flowArrow span.icon {
+    font-size: 1.2em;
+}
+

--- a/src/components/data-presentation/FlowArrow/FlowArrow.css
+++ b/src/components/data-presentation/FlowArrow/FlowArrow.css
@@ -1,11 +1,8 @@
-.flowArrow.top {
-    margin-top: -1.3em;
-    margin-bottom: 0em;
+.flowArrow {
 }
 
-.flowArrow.bottom {
-    margin-top: 0em;
-    margin-bottom: -1.5em;
+.pullUp {
+    margin-top: -20px;
 }
 
 .flowArrow span.icon {

--- a/src/components/data-presentation/FlowArrow/FlowArrow.js
+++ b/src/components/data-presentation/FlowArrow/FlowArrow.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Row, Glyphicon } from 'react-bootstrap';
+import { Row } from 'react-bootstrap';
 import { FullWidthCol } from '../../layout/rb-derived-components';
 import classnames from 'classnames';
 
@@ -10,7 +10,7 @@ import css from './FlowArrow.css';
 const FlowArrow = ({ position }) => (
   <Row className={classnames(css.flowArrow, css[position])}>
     <FullWidthCol className='text-center'>
-      <Glyphicon glyph='arrow-down'/>
+      <span className={css.icon}>{'⇣'}</span>
     </FullWidthCol>
   </Row>
 );

--- a/src/components/data-presentation/FlowArrow/FlowArrow.js
+++ b/src/components/data-presentation/FlowArrow/FlowArrow.js
@@ -1,26 +1,25 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Row } from 'react-bootstrap';
-import { FullWidthCol } from '../../layout/rb-derived-components';
 import classnames from 'classnames';
 
 import css from './FlowArrow.css';
 
 
-const FlowArrow = ({ position }) => (
-  <Row className={classnames(css.flowArrow, css[position])}>
-    <FullWidthCol className='text-center'>
+const FlowArrow = ({ pullUp }) => (
+  <div className={classnames(
+      css.flowArrow, { [css.pullUp]: pullUp }, 'text-center'
+    )}
+  >
       <span className={css.icon}>{'⇣'}</span>
-    </FullWidthCol>
-  </Row>
+  </div>
 );
 
 FlowArrow.propTypes = {
-  position: PropTypes.oneOf('top bottom'.split()).isRequired,
+  pullUp: PropTypes.bool.isRequired,
 };
 
 FlowArrow.defaultProps = {
-  position: 'none',
+  pullUp: false,
 };
 
 export default FlowArrow;

--- a/src/components/data-presentation/FlowArrow/FlowArrow.js
+++ b/src/components/data-presentation/FlowArrow/FlowArrow.js
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Row, Glyphicon } from 'react-bootstrap';
+import { FullWidthCol } from '../../layout/rb-derived-components';
+import classnames from 'classnames';
+
+import css from './FlowArrow.css';
+
+
+const FlowArrow = ({ position }) => (
+  <Row className={classnames(css.flowArrow, css[position])}>
+    <FullWidthCol className='text-center'>
+      <Glyphicon glyph='arrow-down'/>
+    </FullWidthCol>
+  </Row>
+);
+
+FlowArrow.propTypes = {
+  position: PropTypes.oneOf('top bottom'.split()).isRequired,
+};
+
+FlowArrow.defaultProps = {
+  position: 'none',
+};
+
+export default FlowArrow;

--- a/src/components/data-presentation/FlowArrow/__tests__/smoke.js
+++ b/src/components/data-presentation/FlowArrow/__tests__/smoke.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import FlowArrow from '../FlowArrow';
+import { noop } from 'underscore';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <FlowArrow/>,
+    div
+  );
+});

--- a/src/components/data-presentation/FlowArrow/package.json
+++ b/src/components/data-presentation/FlowArrow/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "FlowArrow",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./FlowArrow.js"
+}

--- a/src/components/data-presentation/UnfilteredDatasetsSummary/UnfilteredDatasetsSummary.js
+++ b/src/components/data-presentation/UnfilteredDatasetsSummary/UnfilteredDatasetsSummary.js
@@ -1,0 +1,92 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Row, Col } from 'react-bootstrap';
+import Accordion from '../../guidance-tools/Accordion';
+import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
+import { unfilteredDatasetSummaryPanelLabel } from '../../guidance-content/info/InformationItems';
+
+import _ from 'underscore';
+import { QuarterWidthCol } from '../../layout/rb-derived-components';
+
+
+export default class UnfilteredDatasetsSummary extends React.Component {
+  static propTypes = {
+    meta: PropTypes.array.isRequired,
+  };
+
+  render() {
+    function countsByGroup(meta, grouper) {
+      const groupedByPropName = _.groupBy(meta, grouper);
+      const countsByPropValue = _.map(groupedByPropName, (group, key) => (
+        { key, count: group.length }
+      ));
+      return countsByPropValue;
+    }
+
+    function startEndRunGrouper(item) {
+      return `${item.start_date}-${item.end_date} ${item.ensemble_member}`;
+    }
+
+    const CountsTable = ({ title, grouper }) => (
+      <BootstrapTable
+        data={countsByGroup(this.props.meta, grouper)}
+      >
+        <TableHeaderColumn
+          dataField='key' isKey
+          width={'50%'}
+        >
+          {title}
+        </TableHeaderColumn>
+        <TableHeaderColumn
+          dataField='count'
+          width={'50%'}
+          dataAlign='right'
+        >
+          Number of datasets
+        </TableHeaderColumn>
+      </BootstrapTable>
+    );
+
+    return (
+      <Accordion>
+        <Accordion.Item
+          eventKey={2}
+          title={
+            <Row>
+              <Col lg={2}>
+                {unfilteredDatasetSummaryPanelLabel}
+              </Col>
+              <Col lg={10}>
+                {this.props.meta.length} datasets total
+              </Col>
+            </Row>
+          }
+        >
+          <h5>Dataset counts by ...</h5>
+          <Row>
+            <QuarterWidthCol>
+              <CountsTable grouper='model_id' title='Model'/>
+            </QuarterWidthCol>
+            <QuarterWidthCol>
+              <CountsTable grouper='experiment' title='Emissions Scenario'/>
+            </QuarterWidthCol>
+            <QuarterWidthCol>
+              <CountsTable grouper='variable_id' title='Variable'/>
+            </QuarterWidthCol>
+          </Row>
+          <Row>
+            <QuarterWidthCol>
+              <CountsTable grouper={startEndRunGrouper} title='Start Yr - End Yr Run'/>
+            </QuarterWidthCol>
+            <QuarterWidthCol>
+              <CountsTable grouper='timescale' title='Timsescale'/>
+            </QuarterWidthCol>
+            <QuarterWidthCol>
+              <CountsTable grouper='multi_year_mean' title='Multi-Year Mean'/>
+            </QuarterWidthCol>
+          </Row>
+        </Accordion.Item>
+      </Accordion>
+    );
+  }
+}

--- a/src/components/data-presentation/UnfilteredDatasetsSummary/__tests__/smoke.js
+++ b/src/components/data-presentation/UnfilteredDatasetsSummary/__tests__/smoke.js
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import UnfilteredDatasetsSummary from '../';
 import { noop } from 'underscore';
+import { meta } from '../../../../test_support/data';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
   ReactDOM.render(
-    <UnfilteredDatasetsSummary/>,
+    <UnfilteredDatasetsSummary
+      meta={meta}
+    />,
     div
   );
 });

--- a/src/components/data-presentation/UnfilteredDatasetsSummary/__tests__/smoke.js
+++ b/src/components/data-presentation/UnfilteredDatasetsSummary/__tests__/smoke.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import UnfilteredDatasetsSummary from '../';
+import { noop } from 'underscore';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <UnfilteredDatasetsSummary/>,
+    div
+  );
+});

--- a/src/components/data-presentation/UnfilteredDatasetsSummary/package.json
+++ b/src/components/data-presentation/UnfilteredDatasetsSummary/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "UnfilteredDatasetsSummary",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./UnfilteredDatasetsSummary.js"
+}

--- a/src/components/guidance-tools/Accordion.js
+++ b/src/components/guidance-tools/Accordion.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Panel, PanelGroup } from 'react-bootstrap';
 
+let idNum = 0;
+const nextId = () => `accordion-${idNum++}`;
+
 const AccordionItem = ({ eventKey, title, children }) => (
   <Panel eventKey={eventKey}>
     <Panel.Heading>
@@ -15,7 +18,10 @@ const AccordionItem = ({ eventKey, title, children }) => (
 );
 
 const Accordion = ({ children }) => (
-  <PanelGroup accordion>
+  <PanelGroup
+    accordion
+    id={nextId()}
+  >
     {children}
   </PanelGroup>
 );

--- a/src/components/layout/rb-derived-components.js
+++ b/src/components/layout/rb-derived-components.js
@@ -6,3 +6,9 @@ export const FullWidthCol = ({ children, ...rest }) =>
 
 export const HalfWidthCol = ({ children, ...rest }) =>
   <Col lg={6} md={6} sm={12} {...rest}>{children}</Col>;
+
+export const ThirdWidthCol = ({ children, ...rest }) =>
+  <Col lg={4} md={12} sm={12} {...rest}>{children}</Col>;
+
+export const QuarterWidthCol = ({ children, ...rest }) =>
+  <Col lg={3} md={12} sm={12} {...rest}>{children}</Col>;


### PR DESCRIPTION
Issue #173 Guidance
Part 5: Provide context information about datasets available and selected in the app (cherry picked from humongous PR #174)

This PR adds the following items to the UI:

- All Datasets Summary panel: Summarizes all datasets available before user filter selection in this portal. Presently just shows counts of various datasets categorized by different criteria, e.g., model, emissions, variable.

- Filtered Datasets Summary panel: Summarizes all datasets that are available in the various data presentations (map, graphs, table). Lists datasets in the same arrangement that the Dataset selector in each presentation offers, and gives a little more information about what they contain.

- Data flow arrows: Attempts to show the progress of dataset filtering and display from all available datasets (as summarized in All Datasets Summary), though user filtering, and into the individual data presentations. Each arrow presents an "input set" of datasets that is either filtered or presented by the item it points at. It is hard to do this perfectly, since the Data Graphs and Statistical Summary table are stacked vertically in the same column, and an arrow placed above the Statistical Summary would suggest (incorrectly) that it takes data from the Data Graphs (when in fact it takes data from the set of filtered datasets). Any suggestion on this would be welcome. My first thought to disambiguate this would be to place a label above that particular arrow reading something like "from filtered datasets."