### PR TITLE
Show dataset selection in Data Map panel label

### DIFF
--- a/src/components/MapFooter/package.json
+++ b/src/components/MapFooter/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "MapFooter",
-  "version": "0.0.0",
-  "private": true,
-  "main": "./MapFooter.js"
-}

--- a/src/components/MapLegend/MapLegend.js
+++ b/src/components/MapLegend/MapLegend.js
@@ -8,25 +8,27 @@ import { sameYear, timestampToTimeOfYear } from '../../core/util';
 import { currentDataSpec } from '../map-controllers/map-helpers';
 
 
-class MapFooter extends React.Component {
+export default class MapLegend extends React.Component {
   static propTypes = {
+    model_id: PropTypes.string,
+    experiment: PropTypes.string,
     start_date: PropTypes.string,
     end_date: PropTypes.string,
     run: PropTypes.string,
     raster: PropTypes.shape({
       variableId: PropTypes.string,
       wmsTime: PropTypes.string,
-      times: PropTypes.object
+      times: PropTypes.object,
     }),
     isoline: PropTypes.shape({
       variableId: PropTypes.string,
       wmsTime: PropTypes.string,
-      times: PropTypes.object
+      times: PropTypes.object,
     }),
     annotated: PropTypes.shape({
       variableId: PropTypes.string,
       wmsTime: PropTypes.string,
-      times: PropTypes.object
+      times: PropTypes.object,
     }),
     hasValidComparand: PropTypes.bool,
   };
@@ -45,6 +47,12 @@ class MapFooter extends React.Component {
   }
 
   render() {
+    // When the props for this component don't have useful values,
+    // we want to display a less obnoxious result.
+    // The following test is minimal and sufficient for this condition.
+    if (!_.every(_.pick(this.props, 'model_id', 'start_date'))) {
+      return <span>Loading...</span>;
+    }
     return (
       <span>
         {`${this.props.model_id}; ${this.props.experiment};`}
@@ -61,5 +69,3 @@ class MapFooter extends React.Component {
     );
   }
 }
-
-export default MapFooter;

--- a/src/components/MapLegend/MapLegend.js
+++ b/src/components/MapLegend/MapLegend.js
@@ -3,8 +3,9 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import './MapFooter.css';
+import './MapLegend.css';
 import { sameYear, timestampToTimeOfYear } from '../../core/util';
+import { currentDataSpec } from '../map-controllers/map-helpers';
 
 
 class MapFooter extends React.Component {
@@ -44,20 +45,19 @@ class MapFooter extends React.Component {
   }
 
   render() {
-    let comparandText = "";
-    if(this.props.hasValidComparand) {
-      const comparand = this.props.isoline || this.props.annotated;
-      comparandText = ` ${comparand.wmsTime ? "vs." : " |"} ${this.timeAndVariable(comparand)}`;
-    }
     return (
-        <h5>
-          Dataset {`${this.props.start_date}-${this.props.end_date}`} {this.props.run}:
-          {' '}
-          {this.timeAndVariable(this.props.raster)}
-          {
-            this.props.hasValidComparand && comparandText
-          }
-        </h5>
+      <span>
+        {`${this.props.model_id}; ${this.props.experiment};`}
+        {` ${currentDataSpec(this.props)}:`}
+        {` ${this.timeAndVariable(this.props.raster)} (raster)`}
+        {
+          this.props.hasValidComparand ?
+            (this.props.variable_id === this.props.comparand_id ?
+              ' only' :
+              ` & ${this.timeAndVariable(this.props.isoline || this.props.annotated)} (isolines)`) :
+            ''
+        }
+      </span>
     );
   }
 }

--- a/src/components/MapLegend/__tests__/smoke.js
+++ b/src/components/MapLegend/__tests__/smoke.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import MapFooter from '../MapFooter';
+import MapFooter from '../';
 import { times } from '../../../test_support/data';
 
 it('renders without crashing', () => {

--- a/src/components/MapLegend/package.json
+++ b/src/components/MapLegend/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "MapLegend",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./MapLegend.js"
+}

--- a/src/components/data-presentation/MEVSummary/MEVSummary.js
+++ b/src/components/data-presentation/MEVSummary/MEVSummary.js
@@ -2,21 +2,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 
-export const MEVSummary = (
+export function MEVSummary(
   { model_id, experiment, variable_id, comparand_id, dual }
-) =>
-  (
+) {
+  // When the props for this component don't have useful values,
+  // we want to display a less obnoxious result.
+  // The following test is minimal and sufficient for this condition.
+  if (!model_id) {
+    return <span>Loading...</span>;
+  }
+  return (
     <span>
       {`${model_id} ${experiment}: ${variable_id} `}
       {
         dual ?
           (variable_id === comparand_id ?
             ' only' :
-            ` vs ${comparand_id}`) :
+            ` & ${comparand_id}`) :
           ''
       }
-  </span>
+    </span>
   );
+}
 
 MEVSummary.propTypes = {
   model_id: PropTypes.string.isRequired,

--- a/src/components/map-controllers/DualMapController/DualMapController.js
+++ b/src/components/map-controllers/DualMapController/DualMapController.js
@@ -30,7 +30,7 @@ import _ from 'underscore';
 
 import '../MapController.css';
 import DataMap from '../../DataMap';
-import MapFooter from '../../MapFooter';
+import MapLegend from '../../MapLegend';
 import MapSettings from '../../MapSettings';
 import StaticControl from '../../StaticControl';
 import GeoLoader from '../../GeoLoader';
@@ -50,7 +50,9 @@ import { MEVSummary } from '../../data-presentation/MEVSummary';
 // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/125
 export default class DualMapController extends React.Component {
   static propTypes = {
-    variable_id: PropTypes.string.isRequired,    
+    model_id: PropTypes.string.isRequired,
+    experiment: PropTypes.string.isRequired,
+    variable_id: PropTypes.string.isRequired,
     meta: PropTypes.array.isRequired,
     comparand_id: PropTypes.string,
     comparandMeta: PropTypes.array,
@@ -251,6 +253,12 @@ export default class DualMapController extends React.Component {
   }
 
   render() {
+    const mapLegend = (<MapLegend
+      {...this.props}
+      {...this.state}
+      hasValidComparand={hasValidData('comparand', this.props)}
+    />);
+
     return (
       <Panel>
         <Panel.Heading>
@@ -260,13 +268,7 @@ export default class DualMapController extends React.Component {
                 {mapPanelLabel}
               </Col>
               <Col lg={10}>
-                <MEVSummary
-                  className={styles.mevSummary} {...this.props} dual
-                />
-                {': '}
-                { this.state.run }
-                {' '}
-                { this.state.start_date }-{ this.state.end_date }
+                {mapLegend}
               </Col>
             </Row>
 
@@ -318,7 +320,7 @@ export default class DualMapController extends React.Component {
                     meta={this.props.meta}
                     comparandMeta={this.props.comparandMeta}
 
-                    dataSpec={currentDataSpec.bind(this)()}
+                    dataSpec={currentDataSpec(this.state)}
                     onDataSpecChange={this.updateDataSpec}
 
                     raster={{
@@ -340,10 +342,7 @@ export default class DualMapController extends React.Component {
                 </StaticControl>
 
                 <StaticControl position='bottomleft'>
-                  <MapFooter
-                    {...this.state}
-                    hasValidComparand={hasValidData('comparand', this.props)}
-                  />
+                  {mapLegend}
                 </StaticControl>
 
               </DataMap>

--- a/src/components/map-controllers/PrecipMapController/PrecipMapController.js
+++ b/src/components/map-controllers/PrecipMapController/PrecipMapController.js
@@ -32,7 +32,7 @@ import _ from 'underscore';
 
 import '../MapController.css';
 import DataMap from '../../DataMap';
-import MapFooter from '../../MapFooter';
+import MapLegend from '../../MapLegend';
 import MapSettings from '../../MapSettings';
 import StaticControl from '../../StaticControl';
 import GeoLoader from '../../GeoLoader';
@@ -51,7 +51,9 @@ import { DualMEVSummary } from '../../data-presentation/MEVSummary';
 // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/125
 export default class PrecipMapController extends React.Component {
   static propTypes = {
-    variable_id: PropTypes.string.isRequired,    
+    model_id: PropTypes.string.isRequired,
+    experiment: PropTypes.string.isRequired,
+    variable_id: PropTypes.string.isRequired,
     meta: PropTypes.array.isRequired,
     comparand_id: PropTypes.string,
     comparandMeta: PropTypes.array,
@@ -227,6 +229,12 @@ export default class PrecipMapController extends React.Component {
   }
 
   render() {
+    const mapLegend = (<MapLegend
+      {...this.props}
+      {...this.state}
+      hasValidComparand={hasValidData('comparand', this.props)}
+    />);
+
     return (
       <Panel>
         <Panel.Heading>
@@ -236,11 +244,7 @@ export default class PrecipMapController extends React.Component {
                 {mapPanelLabel}
               </Col>
               <Col lg={10}>
-                <DualMEVSummary {...this.props} comparand_id='pr'/>
-                {': '}
-                { this.state.run }
-                {' '}
-                { this.state.start_date }-{ this.state.end_date }
+                {mapLegend}
               </Col>
             </Row>
           </Panel.Title>
@@ -281,7 +285,7 @@ export default class PrecipMapController extends React.Component {
                     meta={this.props.meta}
                     comparandMeta={this.props.comparandMeta}
 
-                    dataSpec={currentDataSpec.bind(this)()}
+                    dataSpec={currentDataSpec(this.state)}
                     onDataSpecChange={this.updateDataSpec}
 
                     raster={{
@@ -297,10 +301,7 @@ export default class PrecipMapController extends React.Component {
                 </StaticControl>
 
                 <StaticControl position='bottomleft'>
-                  <MapFooter
-                    {...this.state}
-                    hasValidComparand={hasValidData('comparand', this.props)}
-                  />
+                  {mapLegend}
                 </StaticControl>
 
               </DataMap>

--- a/src/components/map-controllers/SingleMapController/SingleMapController.js
+++ b/src/components/map-controllers/SingleMapController/SingleMapController.js
@@ -27,7 +27,7 @@ import _ from 'underscore';
 
 import '../MapController.css';
 import DataMap from '../../DataMap';
-import MapFooter from '../../MapFooter';
+import MapLegend from '../../MapLegend';
 import MapSettings from '../../MapSettings';
 import StaticControl from '../../StaticControl';
 import GeoLoader from '../../GeoLoader';
@@ -47,7 +47,9 @@ import { MEVSummary } from '../../data-presentation/MEVSummary';
 // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/125
 export default class SingleMapController extends React.Component {
   static propTypes = {
-    variable_id: PropTypes.string.isRequired,    
+    model_id: PropTypes.string.isRequired,
+    experiment: PropTypes.string.isRequired,
+    variable_id: PropTypes.string.isRequired,
     meta: PropTypes.array.isRequired,
     area: PropTypes.object,
     onSetArea: PropTypes.func.isRequired,
@@ -69,7 +71,7 @@ export default class SingleMapController extends React.Component {
         palette: 'x-Occam',
         logscale: 'false',
         range: {},
-      }
+      },
     };
   }
 
@@ -210,7 +212,12 @@ export default class SingleMapController extends React.Component {
   }
 
   render() {
-    console.log('SingleMapController.props.meta', this.props.meta)
+    const mapLegend = (<MapLegend
+      {...this.props}
+      {...this.state}
+      hasValidComparand={false}
+    />);
+
     return (
       <Panel>
         <Panel.Heading>
@@ -220,13 +227,7 @@ export default class SingleMapController extends React.Component {
                 {mapPanelLabel}
               </Col>
               <Col lg={10}>
-                <MEVSummary
-                  className={styles.mevSummary} {...this.props}
-                />
-                {': '}
-                { this.state.run }
-                {' '}
-                { this.state.start_date }-{ this.state.end_date }
+                {mapLegend}
               </Col>
             </Row>
         </Panel.Title>
@@ -264,7 +265,7 @@ export default class SingleMapController extends React.Component {
                     title='Map Settings'
                     meta={this.props.meta}
 
-                    dataSpec={currentDataSpec.bind(this)()}
+                    dataSpec={currentDataSpec(this.state)}
                     onDataSpecChange={this.updateDataSpec}
 
                     raster={{
@@ -280,10 +281,7 @@ export default class SingleMapController extends React.Component {
                 </StaticControl>
 
                 <StaticControl position='bottomleft'>
-                  <MapFooter
-                    {...this.state}
-                    hasValidComparand={false}
-                  />
+                  {mapLegend}
                 </StaticControl>
 
               </DataMap>

--- a/src/components/map-controllers/map-helpers.js
+++ b/src/components/map-controllers/map-helpers.js
@@ -145,9 +145,9 @@ function selectIsolinePalette(params) {
  **************************************************************************/
 
 // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/118
-function currentDataSpec() {
+function currentDataSpec({ run, start_date, end_date }) {
   // Return encoding of currently selected dataspec
-  return `${this.state.run} ${this.state.start_date}-${this.state.end_date}`;
+  return `${run} ${start_date}-${end_date}`;
 }
 
 function updateLayerSimpleState(layerType, name, value) {
@@ -165,7 +165,7 @@ function updateLayerTime(layerType, timeIdx) {
   // and an index denoting the timestamp's position with the file
   this.setState((prevState) => ({
     [layerType]: {
-      ...prevState[layerType],
+      ...prevState[layerType],  // This should not be necessary
       timeIdx,
       wmsTime: prevState[layerType].times[timeIdx],
     },


### PR DESCRIPTION
Resolves #222 .

This PR makes the map legend (displayed on the map proper) and the Data Map panel label the same.

I'm leaving the legend on the map because if we restore map printing, then it will be useful to have it. It can be removed easily if it is genuinely unwanted.

The legend is somewhat modified from the original. It may be a little too verbose, but it contains complete information about the dataset selection, which the original label did not. It also contains an annotation as to which variable is the raster and which is the isolines. This may be an annotation too far.

The map legend and the (similar) model-emissions-variable summary titles now both display "Loading..." when there is no valid data to fill them out with. This is much better looking than a string full of "undefined" for this case, and it improves the user experience because it indicates what is actually happening.