### PR TITLE
Always display different variables with different vertical scales

### DIFF
--- a/src/components/graphs/DualAnnualCycleGraph.js
+++ b/src/components/graphs/DualAnnualCycleGraph.js
@@ -126,15 +126,12 @@ export default function DualAnnualCycleGraph(props) {
     if(hasTwoYAxes(graph)
         && props.comparand_id !== props.variable_id) {
       // see if either variable is listed as conflicting with the other
-      let overlap = false;
       const variableOverlaps = getVariableOptions(props.variable_id, "shiftAnnualCycle");
-      if(variableOverlaps && variableOverlaps.includes(props.comparand_id)) {
-        overlap = true;
-      }
       const comparandOverlaps = getVariableOptions(props.comparand_id, "shiftAnnualCycle");
-      if(comparandOverlaps && comparandOverlaps.includes(props.variable_id)) {
-        overlap = true;
-      }
+      
+      const overlap = (comparandOverlaps && comparandOverlaps.includes(props.variable_id))
+        || (variableOverlaps && variableOverlaps.includes(props.comparand_id));      
+      
       if(overlap) {
         // if the two data series have overlapping ranges and the same units,
         // set their y axes to the same range to avoid 
@@ -146,9 +143,7 @@ export default function DualAnnualCycleGraph(props) {
         // determine whether the data ranges overlap:
         const yRange = yAxisRange(graph, 'y');
         const y2Range = yAxisRange(graph, 'y2');
-        if (yAxisUnits(graph, 'y') === yAxisUnits(graph, 'y2') &&
-            (((yRange.min < y2Range.min) && (yRange.max > y2Range.min)) ||
-             ((yRange.min < y2Range.max) && (yRange.max > y2Range.max)))) {
+        if(!(yRange.max < y2Range.min || y2Range.max < yRange.min)) {
           // y axes will have the same range
           graph = matchYAxisRange(graph);
         }

--- a/src/components/graphs/DualAnnualCycleGraph.js
+++ b/src/components/graphs/DualAnnualCycleGraph.js
@@ -143,7 +143,8 @@ export default function DualAnnualCycleGraph(props) {
         // determine whether the data ranges overlap:
         const yRange = yAxisRange(graph, 'y');
         const y2Range = yAxisRange(graph, 'y2');
-        if(!(yRange.max < y2Range.min || y2Range.max < yRange.min)) {
+        if(yAxisUnits(graph, 'y') === yAxisUnits(graph, 'y2') &&
+           !(yRange.max < y2Range.min || y2Range.max < yRange.min)) {
           // y axes will have the same range
           graph = matchYAxisRange(graph);
         }

--- a/src/core/__tests__/chart-accessor-tests.js
+++ b/src/core/__tests__/chart-accessor-tests.js
@@ -11,59 +11,67 @@
 jest.dontMock('../chart-accessors');
 jest.dontMock('underscore');
 
-const ca = require('../chart-accessors');
-const cg = require('../chart-generators');
-const mockAPI = require('../__test_data__/sample-API-results');
+import {hasTwoYAxes,
+        checkYAxisValidity,
+        yAxisUnits,
+        yAxisRange} from '../chart-accessors';
+import {timeseriesToAnnualCycleGraph} from '../chart-generators';
+import {monthlyTasmaxTimeseries,
+        seasonalTasmaxTimeseries,
+        annualTasmaxTimeseries,
+        monthlyPrTimeseries,
+        metadataToArray} from '../__test_data__/sample-API-results';
+import _ from 'underscore';
 
 describe('hasTwoYAxes', function () {
-  const metadata = mockAPI.metadataToArray();
+  const metadata = metadataToArray();
   it('detects graphs that have only 1 y-axis', function () {
-    const graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
-        mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-    expect(ca.hasTwoYAxes(graph)).toBe(false);
+    const graph = timeseriesToAnnualCycleGraph(metadata, monthlyTasmaxTimeseries,
+        seasonalTasmaxTimeseries, annualTasmaxTimeseries);
+    expect(hasTwoYAxes(graph)).toBeFalsy();
   });
   it('detects graphs that have 2 y-axes', function () {
-    const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
-        mockAPI.monthlyTasmaxTimeseries,
-        mockAPI.monthlyPrTimeseries);
-    expect(ca.hasTwoYAxes(graph)).toBe(true);
+    const graph = timeseriesToAnnualCycleGraph(metadataToArray(),
+        monthlyTasmaxTimeseries,
+        monthlyPrTimeseries);
+    expect(hasTwoYAxes(graph)).toBeTruthy();
   });
 });
 
 describe('checkYAxisValidity', function () {
-  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
-      mockAPI.monthlyTasmaxTimeseries,
-      mockAPI.monthlyPrTimeseries);
+  const graph = timeseriesToAnnualCycleGraph(metadataToArray(),
+      monthlyTasmaxTimeseries,
+      monthlyPrTimeseries);
   it('does nothing for valid axes', function () {
-    let func = function () {ca.checkYAxisValidity(graph, 'y');};
+    let func = function () {checkYAxisValidity(graph, 'y');};
     expect(func).not.toThrow();
-    func = function () {ca.checkYAxisValidity(graph, 'y2');};
+    func = function () {checkYAxisValidity(graph, 'y2');};
     expect(func).not.toThrow();
   });
   it('throws an eror for invalid axes', function () {
-    let func = function () {ca.checkYAxisValidity(graph, 'banana');};
+    let func = function () {checkYAxisValidity(graph, 'banana');};
     expect(func).toThrow();
   });
 });
 
 describe('yAxisUnits', function () {
-  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
-      mockAPI.monthlyTasmaxTimeseries,
-      mockAPI.monthlyPrTimeseries);
+  const graph = timeseriesToAnnualCycleGraph(metadataToArray(),
+      monthlyTasmaxTimeseries,
+      monthlyPrTimeseries);
   it('returns the units associated with the y axis', function () {
-    expect(ca.yAxisUnits(graph, 'y')).toBe('degC');
-    expect(ca.yAxisUnits(graph, 'y2')).toBe('kg m-2 d-1');
+    expect(yAxisUnits(graph, 'y')).toBe('degC');
+    expect(yAxisUnits(graph, 'y2')).toBe('kg m-2 d-1');
   });
 });
 
 describe('yAxisRange', function () {
-  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
-      mockAPI.monthlyTasmaxTimeseries,
-      mockAPI.monthlyPrTimeseries);
+  const graph = timeseriesToAnnualCycleGraph(metadataToArray(),
+      monthlyTasmaxTimeseries,
+      monthlyPrTimeseries);
   it('calculates the min and max of data associated with a y-axis', function () {
-    expect(ca.yAxisRange(graph, 'y').min).toBe(-20.599000150601793);
-    expect(ca.yAxisRange(graph, 'y').max).toBe(15.835593959678455);
-    expect(ca.yAxisRange(graph, 'y2').min).toBe(0.7965349522694691);
-    expect(ca.yAxisRange(graph, 'y2').max).toBe(1.7647179206314954);
+    expect(yAxisRange(graph, 'y').min).toBe(_.min(monthlyTasmaxTimeseries.data));
+    expect(yAxisRange(graph, 'y').max).toBe(_.max(monthlyTasmaxTimeseries.data));
+    expect(yAxisRange(graph, 'y2').min).toBe(_.min(monthlyPrTimeseries.data));
+    expect(yAxisRange(graph, 'y2').max).toBe(_.max(monthlyPrTimeseries.data));
   });
 });

--- a/src/core/__tests__/chart-accessor-tests.js
+++ b/src/core/__tests__/chart-accessor-tests.js
@@ -1,0 +1,74 @@
+/* ***************************************************************
+ * chart-accessor-tests.js - tests for chart access functions
+ *
+ * One test (sometimes with multiple parts) for each function in
+ * chart-accessor-tests.js. The tests have the same names and are
+ * in the same order as the functions.
+ *
+ * test data from ../_test_data__/sample-API-results.js
+ *****************************************************************/
+
+jest.dontMock('../chart-accessors');
+jest.dontMock('underscore');
+
+const ca = require('../chart-accessors');
+const cg = require('../chart-generators');
+const mockAPI = require('../__test_data__/sample-API-results');
+
+describe('hasTwoYAxes', function () {
+  const metadata = mockAPI.metadataToArray();
+  it('detects graphs that have only 1 y-axis', function (){
+    const graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
+        mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
+    expect(ca.hasTwoYAxes(graph)).toBe(false);
+  });
+  it('detects graphs that have 2 y-axes', function () {
+    const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+        mockAPI.monthlyTasmaxTimeseries,
+        mockAPI.monthlyPrTimeseries);
+    expect(ca.hasTwoYAxes(graph)).toBe(true);
+  });
+});
+
+describe('checkYAxisValidity', function () {
+  const metadata = mockAPI.metadataToArray();
+  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+      mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.monthlyPrTimeseries);
+  it('does nothing for valid axes', function () {
+    let func = function () {ca.checkYAxisValidity(graph, 'y');};
+    expect(func).not.toThrow();
+    func = function () {ca.checkYAxisValidity(graph, 'y2');};
+    expect(func).not.toThrow();
+  });
+  it('throws an eror for invalid axes', function () {
+    let func = function () {ca.checkYAxisValidity(graph, 'banana');};
+    expect(func).toThrow();
+  });
+});
+
+describe('yAxisUnits', function () {
+  const metadata = mockAPI.metadataToArray();
+  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+      mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.monthlyPrTimeseries);
+  it('returns the units associated with the y axis', function () {
+    expect(ca.yAxisUnits(graph, 'y')).toBe('degC');
+    expect(ca.yAxisUnits(graph, 'y2')).toBe('kg m-2 d-1');
+  });
+});
+
+describe('yAxisRange', function () {
+  const metadata = mockAPI.metadataToArray();
+  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+      mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.monthlyPrTimeseries);
+  it('calculates the min and max of data associated with a y-axis', function () {
+    expect(ca.yAxisRange(graph, 'y').min).toBe(-20.599000150601793);
+    expect(ca.yAxisRange(graph, 'y').max).toBe(15.835593959678455);
+    expect(ca.yAxisRange(graph, 'y2').min).toBe(0.7965349522694691);
+    expect(ca.yAxisRange(graph, 'y2').max).toBe(1.7647179206314954);
+  });
+  
+});
+

--- a/src/core/__tests__/chart-accessor-tests.js
+++ b/src/core/__tests__/chart-accessor-tests.js
@@ -17,13 +17,13 @@ const mockAPI = require('../__test_data__/sample-API-results');
 
 describe('hasTwoYAxes', function () {
   const metadata = mockAPI.metadataToArray();
-  it('detects graphs that have only 1 y-axis', function (){
+  it('detects graphs that have only 1 y-axis', function () {
     const graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
         mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
     expect(ca.hasTwoYAxes(graph)).toBe(false);
   });
   it('detects graphs that have 2 y-axes', function () {
-    const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+    const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
         mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyPrTimeseries);
     expect(ca.hasTwoYAxes(graph)).toBe(true);
@@ -31,8 +31,7 @@ describe('hasTwoYAxes', function () {
 });
 
 describe('checkYAxisValidity', function () {
-  const metadata = mockAPI.metadataToArray();
-  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
       mockAPI.monthlyTasmaxTimeseries,
       mockAPI.monthlyPrTimeseries);
   it('does nothing for valid axes', function () {
@@ -48,8 +47,7 @@ describe('checkYAxisValidity', function () {
 });
 
 describe('yAxisUnits', function () {
-  const metadata = mockAPI.metadataToArray();
-  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
       mockAPI.monthlyTasmaxTimeseries,
       mockAPI.monthlyPrTimeseries);
   it('returns the units associated with the y axis', function () {
@@ -59,8 +57,7 @@ describe('yAxisUnits', function () {
 });
 
 describe('yAxisRange', function () {
-  const metadata = mockAPI.metadataToArray();
-  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+  const graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),
       mockAPI.monthlyTasmaxTimeseries,
       mockAPI.monthlyPrTimeseries);
   it('calculates the min and max of data associated with a y-axis', function () {
@@ -69,6 +66,4 @@ describe('yAxisRange', function () {
     expect(ca.yAxisRange(graph, 'y2').min).toBe(0.7965349522694691);
     expect(ca.yAxisRange(graph, 'y2').max).toBe(1.7647179206314954);
   });
-  
 });
-

--- a/src/core/__tests__/chart-formatter-tests.js
+++ b/src/core/__tests__/chart-formatter-tests.js
@@ -183,6 +183,19 @@ describe('padYAxis', function () {
   });
 });
 
+describe('matchYAxisRange', function () {
+  it('sets both y-axis of the graph to have the same range', function () {
+    const metadata = mockAPI.metadataToArray();
+    let graph = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
+        mockAPI.monthlyTasmaxTimeseries,
+        mockAPI.monthlyPrTimeseries);
+    
+    graph = cf.matchYAxisRange(graph);
+    expect(graph.axis.y.min).toEqual(graph.axis.y2.min);
+    expect(graph.axis.y.max).toEqual(graph.axis.y2.max);
+  });  
+});
+
 describe('hideTicksByRange', function () {
   const metadata = mockAPI.metadataToArray();
   let graph = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,

--- a/src/core/__tests__/chart-generator-tests.js
+++ b/src/core/__tests__/chart-generator-tests.js
@@ -13,31 +13,50 @@ jest.dontMock('../chart-generators');
 jest.dontMock('../util');
 jest.dontMock('underscore');
 
-const cg = require('../chart-generators');
-const validate = require('../__test_data__/test-validators');
-const mockAPI = require('../__test_data__/sample-API-results');
-
+import {formatYAxis,
+        fixedPrecision,
+        makePrecisionBySeries,
+        makeTooltipDisplayNumbersWithUnits,
+        timeseriesToAnnualCycleGraph,
+        getMonthlyData,
+        shortestUniqueTimeseriesNamingFunction,
+        dataToLongTermAverageGraph,
+        getAllTimestamps,
+        nameAPICallParametersFunction,
+        timeseriesToTimeseriesGraph} from '../chart-generators';
+import {allDefinedObject,
+        isRectangularArray,
+        allDefinedArray} from '../__test_data__/test-validators';
+import {monthlyTasmaxTimeseries,
+        seasonalTasmaxTimeseries,
+        annualTasmaxTimeseries,
+        monthlyTasminTimeseries,
+        monthlyPrTimeseries,
+        tasminData,
+        tasmaxData,
+        metadataToArray} from '../__test_data__/sample-API-results';
+        
 describe('formatYAxis', function () {
   it('formats a c3 y axis with units label', function () {
-    const axis = cg.formatYAxis('meters');
-    expect(validate.allDefinedObject(axis)).toBe(true);
+    const axis = formatYAxis('meters');
+    expect(allDefinedObject(axis)).toBe(true);
     expect(axis.label).toEqual({ text: 'meters', position: 'outer-middle' });
     expect(axis.show).toEqual(true);
-    expect(axis.tick.format(6.993)).toEqual(cg.fixedPrecision(6.993));
+    expect(axis.tick.format(6.993)).toEqual(fixedPrecision(6.993));
   });
 });
 
 describe('fixedPrecision', function () {
   it('formats a positive number for user display', function () {
-    const formatted = cg.fixedPrecision(6.22222);
+    const formatted = fixedPrecision(6.22222);
     expect(formatted).toEqual(6.22);
   });
   it('formats a negative number for user display', function () {
-    const formatted = cg.fixedPrecision(-6.3333);
+    const formatted = fixedPrecision(-6.3333);
     expect(formatted).toEqual(-6.33);
   });
   it('rounds a number for user display', function () {
-    const formatted = cg.fixedPrecision(6.9999);
+    const formatted = fixedPrecision(6.9999);
     expect(formatted).toEqual(7);
   });
 });
@@ -47,38 +66,38 @@ describe('makePrecisionBySeries', function () {
   // .yaml config file that isn't easily available during jest testing.
   // In non-test usage the file is transformed and made available by webpack.
   xit('reads the config file and applies its settings', function () {
-    const precision = cg.makePrecisionBySeries({ testseries: 'tasmin' });
+    const precision = makePrecisionBySeries({ testseries: 'tasmin' });
     expect(precision(4.777, 'testseries')).toEqual(4.8);
   });
   it('uses a default precision for unspecified variables', function () {
-    const precision = cg.makePrecisionBySeries({ testseries: 'tasmin' });
+    const precision = makePrecisionBySeries({ testseries: 'tasmin' });
     expect(precision(4.777, 'testseries')).toEqual(4.78);
   });
 });
 
 describe('makeTooltipDisplayNumbersWithUnits', function () {
   let axis = {};
-  axis.y = cg.formatYAxis('meters');
+  axis.y = formatYAxis('meters');
   let axes = {};
   const series1 = 'height';
   const series2 = 'depth';
   axes[series1] = 'y';
   let tooltipFunction;
   it('displays unit labels when there is a single data series', function () {
-    tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
+    tooltipFunction = makeTooltipDisplayNumbersWithUnits(axes, axis);
     expect(tooltipFunction(5, 0, series1, 0)).toEqual('5 meters');
   });
   it('displays unit labels when there are multiple data series', function () {
     axes[series2] = 'y';
-    tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
+    tooltipFunction = makeTooltipDisplayNumbersWithUnits(axes, axis);
     expect(tooltipFunction(6.22, 0, series1, 0)).toEqual('6.22 meters');
     expect(tooltipFunction(7.8, 0, series2, 0)).toEqual('7.8 meters');
   });
   it('displays unit labels when there are multiple unit types', function () {
     const series3 = 'weight';
-    axis.y2 = cg.formatYAxis('kilograms');
+    axis.y2 = formatYAxis('kilograms');
     axes[series3] = 'y2';
-    tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
+    tooltipFunction = makeTooltipDisplayNumbersWithUnits(axes, axis);
     expect(tooltipFunction(9.73, 0, series1, 0)).toEqual('9.73 meters');
     expect(tooltipFunction(-2.4, 0, series2, 0)).toEqual('-2.4 meters');
     expect(tooltipFunction(100000, 0, series3, 0)).toEqual('100000 kilograms');
@@ -86,19 +105,19 @@ describe('makeTooltipDisplayNumbersWithUnits', function () {
 });
 
 describe('timeseriesToAnnualCycleGraph', function () {
-  const metadata = mockAPI.metadataToArray();
+  const metadata = metadataToArray();
   it('rejects data sets with too many units', function () {
-    let fakeData = JSON.parse(JSON.stringify(mockAPI.monthlyTasminTimeseries));
+    let fakeData = JSON.parse(JSON.stringify(monthlyTasminTimeseries));
     fakeData.units = 'meters';
-    const func = function () {
-      cg.timeseriesToAnnualCycleGraph(metadata, fakeData,
-          mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyPrTimeseries);
+    function func () {
+      timeseriesToAnnualCycleGraph(metadata, fakeData,
+          monthlyTasmaxTimeseries, monthlyPrTimeseries);
     };
     expect(func).toThrow();
   });
   it('displays a single timeseries', function () {
-    const c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
-    expect(validate.allDefinedObject(c)).toBe(true);
+    const c = timeseriesToAnnualCycleGraph(metadata, monthlyTasmaxTimeseries);
+    expect(allDefinedObject(c)).toBe(true);
     expect(c.data.columns.length).toEqual(1);
     expect(c.data.columns[0].length).toEqual(13);
     expect(c.axis.x).toBeDefined();
@@ -106,21 +125,21 @@ describe('timeseriesToAnnualCycleGraph', function () {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays monthly, seasonal, and annual timeseries together', function () {
-    const c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
-        mockAPI.seasonalTasmaxTimeseries, mockAPI.annualTasmaxTimeseries);
-    expect(validate.allDefinedObject(c)).toBe(true);
-    expect(validate.isRectangularArray(c.data.columns, 3, 13)).toBe(true);
-    expect(validate.allDefinedArray(c.data.columns)).toBe(true);
+    const c = timeseriesToAnnualCycleGraph(metadata, monthlyTasmaxTimeseries,
+        seasonalTasmaxTimeseries, annualTasmaxTimeseries);
+    expect(allDefinedObject(c)).toBe(true);
+    expect(isRectangularArray(c.data.columns, 3, 13)).toBe(true);
+    expect(allDefinedArray(c.data.columns)).toBe(true);
     expect(c.axis.x).toBeDefined();
     expect(c.axis.y).toBeDefined();
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays two different variables at once', function () {
-    const c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
-        mockAPI.monthlyTasminTimeseries);
-    expect(validate.allDefinedObject(c)).toBe(true);
-    expect(validate.isRectangularArray(c.data.columns, 2, 13)).toBe(true);
-    expect(validate.allDefinedArray(c.data.columns)).toBe(true);
+    const c = timeseriesToAnnualCycleGraph(metadata, monthlyTasmaxTimeseries,
+        monthlyTasminTimeseries);
+    expect(allDefinedObject(c)).toBe(true);
+    expect(isRectangularArray(c.data.columns, 2, 13)).toBe(true);
+    expect(allDefinedArray(c.data.columns)).toBe(true);
     expect(c.axis.x).toBeDefined();
     expect(c.axis.y).toBeDefined();
     expect(c.axis.y2).toBeDefined();
@@ -133,28 +152,28 @@ describe('getMonthlyData', function () {
     for (let i = 0; i < 17; i++) {
       seventeen[Date(i)] = i * 3;
     }
-    const tooMany = function () {cg.getMonthlyData(seventeen);};
+    const tooMany = function () {getMonthlyData(seventeen);};
     expect(tooMany).toThrow();
   });
   it('rejects data with inconsistent time resolution', function () {
     const inconsistent = function () {
-      cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, 'yearly');
+      getMonthlyData(monthlyTasmaxTimeseries.data, 'yearly');
     };
     expect(inconsistent).toThrow();
   });
   it('processes a monthly timeseries', function () {
-    const processed = cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, 'monthly');
+    const processed = getMonthlyData(monthlyTasmaxTimeseries.data, 'monthly');
     expect(processed.length).toEqual(12);
     expect(processed[5]).toEqual(11.841563876512202);
     expect(processed[11]).toEqual(-16.96361296358877);
   });
   it('processes a seasonal timeseries', function () {
-    const processed = cg.getMonthlyData(mockAPI.seasonalTasmaxTimeseries.data, 'seasonal');
+    const processed = getMonthlyData(seasonalTasmaxTimeseries.data, 'seasonal');
     expect(processed.length).toEqual(12);
     expect(processed[0]).toEqual(processed[11]);
   });
   it('processes an annual timeseries', function () {
-    const processed = cg.getMonthlyData(mockAPI.annualTasmaxTimeseries.data, 'yearly');
+    const processed = getMonthlyData(annualTasmaxTimeseries.data, 'yearly');
     expect(processed.length).toEqual(12);
     expect(processed[0]).toEqual(processed[7]);
     expect(processed[4]).toEqual(processed[11]);
@@ -162,31 +181,31 @@ describe('getMonthlyData', function () {
 });
 
 describe('shortestUniqueTimeseriesNamingFunction', function () {
-  const metadata = mockAPI.metadataToArray();
+  const metadata = metadataToArray();
   it('rejects identical time series', function () {
     const minimalMetadata = [{ unique_id: 'foo', md: 'bar' }, { unique_id: 'baz', md: 'bar' }];
     const minimalData = [{ id: 'foo' }, { id: 'baz' }];
-    const func = function () {
-      cg.shortestUniqueTimeseriesNamingFunction(minimalMetadata, minimalData);
+    function func () {
+      shortestUniqueTimeseriesNamingFunction(minimalMetadata, minimalData);
     };
     expect(func).toThrow();
   });
   it('uses a a default naming scheme for a single data series', function () {
-    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata,
-        [mockAPI.monthlyTasmaxTimeseries]);
+    const nameFunction = shortestUniqueTimeseriesNamingFunction(metadata,
+        [monthlyTasmaxTimeseries]);
     expect(nameFunction(metadata[0])).toEqual('Monthly Mean');
   });
   it('names series by time resolution', function () {
-    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata,
-        [mockAPI.monthlyTasmaxTimeseries, mockAPI.seasonalTasmaxTimeseries,
-          mockAPI.annualTasmaxTimeseries]);
+    const nameFunction = shortestUniqueTimeseriesNamingFunction(metadata,
+        [monthlyTasmaxTimeseries, seasonalTasmaxTimeseries,
+          annualTasmaxTimeseries]);
     expect(nameFunction(metadata[0])).toEqual('Monthly Mean');
     expect(nameFunction(metadata[1])).toEqual('Seasonal Mean');
     expect(nameFunction(metadata[2])).toEqual('Yearly Mean');
   });
   it('names series by variable', function () {
-    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata,
-        [mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyTasminTimeseries]);
+    const nameFunction = shortestUniqueTimeseriesNamingFunction(metadata,
+        [monthlyTasmaxTimeseries, monthlyTasminTimeseries]);
     expect(nameFunction(metadata[0])).toEqual('Tasmax Mean');
     expect(nameFunction(metadata[3])).toEqual('Tasmin Mean');
   });
@@ -194,14 +213,14 @@ describe('shortestUniqueTimeseriesNamingFunction', function () {
 
 describe('dataToLongTermAverageGraph', function () {
   it('rejects datasets with missing metadata', function () {
-    const func = function () {
-      cg.dataToLongTermAverageGraph(
-        [mockAPI.tasmaxData, mockAPI.tasminData]);};
+    function func () {
+      dataToLongTermAverageGraph(
+        [tasmaxData, tasminData]);};
     expect(func).toThrow();
   });
   it('graphs a single data series', function () {
-    const c = cg.dataToLongTermAverageGraph([mockAPI.tasmaxData]);
-    expect(validate.allDefinedObject(c)).toBe(true);
+    const c = dataToLongTermAverageGraph([tasmaxData]);
+    expect(allDefinedObject(c)).toBe(true);
     expect(c.data.columns.length).toEqual(2);
     expect(c.data.columns[0].length).toEqual(7);
     expect(c.axis.x).toBeDefined();
@@ -211,12 +230,12 @@ describe('dataToLongTermAverageGraph', function () {
   it('graphs two data series', function () {
     const tasmaxQuery = { variable_id: 'tasmax', model_id: 'bcc-csm1-1-m' };
     const tasminQuery = { variable_id: 'tasmin', model_id: 'bcc-csm1-1-m' };
-    const c = cg.dataToLongTermAverageGraph(
-        [mockAPI.tasmaxData, mockAPI.tasminData],
+    const c = dataToLongTermAverageGraph(
+        [tasmaxData, tasminData],
         [tasmaxQuery, tasminQuery]);
-    expect(validate.allDefinedObject(c)).toBe(true);
-    expect(validate.isRectangularArray(c.data.columns, 3, 7)).toBe(true);
-    expect(validate.allDefinedArray(c.data.columns)).toBe(true);
+    expect(allDefinedObject(c)).toBe(true);
+    expect(isRectangularArray(c.data.columns, 3, 7)).toBe(true);
+    expect(allDefinedArray(c.data.columns)).toBe(true);
     expect(c.axis.x).toBeDefined();
     expect(c.axis.y).toBeDefined();
     expect(c.axis.y2).toBeDefined();
@@ -225,9 +244,9 @@ describe('dataToLongTermAverageGraph', function () {
     const tasmaxQuery = { variable_id: 'tasmax', model_id: 'bcc-csm1-1-m' };
     const tasminQuery = { variable_id: 'tasmin', model_id: 'bcc-csm1-1-m' };
     const prQuery = { variable_id: 'pr', model_id: 'bcc-csm1-1-m' };
-    const func = function () {
-      cg.dataToLongTermAverageGraph(
-        [mockAPI.tasmaxData, mockAPI.tasminData, mockAPI.prData],
+    function func () {
+      dataToLongTermAverageGraph(
+        [tasmaxData, tasminData, prData],
         [tasmaxQuery, tasminQuery, prQuery]);
     };
     expect(func).toThrow();
@@ -236,40 +255,40 @@ describe('dataToLongTermAverageGraph', function () {
 
 describe('getAllTimestamps', function () {
   it('throws an error if there is no data', function () {
-    const func = function () {cg.getAllTimestamps([]);};
+    function func () {getAllTimestamps([]);};
     expect(func).toThrow();
   });
   it('throws an error if there are no available timestamps', function () {
-    const func = function () {cg.getAllTimestamps([{ r1p1i1: { data: {} } }]);};
+    function func () {getAllTimestamps([{ r1p1i1: { data: {} } }]);};
     expect(func).toThrow();
   });
   it('returns timestamps associated with a data API call', function () {
-    const stamps = cg.getAllTimestamps([mockAPI.tasmaxData]);
+    const stamps = getAllTimestamps([tasmaxData]);
     expect(stamps.length).toBe(6);
   });
   it('combines timestamps from multiple data API calls', function () {
-    let fakeData = JSON.parse(JSON.stringify(mockAPI.tasminData));
+    let fakeData = JSON.parse(JSON.stringify(tasminData));
     fakeData.r1i1p1.data = { '1990-04-01T00:00:00Z': 20, '1997-01-15T00:00:00Z': 0 };
-    const stamps = cg.getAllTimestamps([mockAPI.tasmaxData, fakeData]);
+    const stamps = getAllTimestamps([tasmaxData, fakeData]);
     expect(stamps.length).toBe(7);
   });
   it('extracts timestamps from timeseries API calls', function () {
-    const stamps = cg.getAllTimestamps([mockAPI.monthlyTasmaxTimeseries,
-      mockAPI.seasonalTasmaxTimeseries]);
+    const stamps = getAllTimestamps([monthlyTasmaxTimeseries,
+      seasonalTasmaxTimeseries]);
     expect(stamps.length).toBe(16);
   });
 });
 
 describe('nameAPICallParametersFunction', function () {
   it('refuses identical data sets', function () {
-    const func = function () {
-      cg.nameAPICallParametersFunction(
+    function func () {
+      nameAPICallParametersFunction(
         [{ variable: 'foo' }, { variable: 'foo' }]);};
     expect(func).toThrow();
   });
   it('refuses data sets calculated over different areas', function () {
-    const func = function () {
-      cg.nameAPICallParametersFunction(
+    function func () {
+      nameAPICallParametersFunction(
         [{ area: 'POLYGON+((-114,+-113,+-103,+-104+63,+-114+63))' },
          { area: 'POLYGON+((-115,+-113,+-103,+-105+63,+-115+63))' }]);};
     expect(func).toThrow();
@@ -277,26 +296,26 @@ describe('nameAPICallParametersFunction', function () {
   it('assigns distinct names to data sets', function () {
     const tasmaxQuery = { variable_id: 'tasmax', model_id: 'bcc-csm1-1-m' };
     const tasminQuery = { variable_id: 'tasmin', model_id: 'bcc-csm1-1-m' };
-    const nameFunction = cg.nameAPICallParametersFunction([tasmaxQuery, tasminQuery]);
+    const nameFunction = nameAPICallParametersFunction([tasmaxQuery, tasminQuery]);
     expect(nameFunction('r1i1p1', tasmaxQuery)).toBe('tasmax r1i1p1');
     expect(nameFunction('r1i1p1', tasminQuery)).toBe('tasmin r1i1p1');
   });
 });
 
 describe('timeseriesToTimeSeriesGraph', function () {
-  const metadata = mockAPI.metadataToArray();
+  const metadata = metadataToArray();
   it('rejects data sets with too many units', function () {
-    let fakeData = JSON.parse(JSON.stringify(mockAPI.monthlyTasminTimeseries));
+    let fakeData = JSON.parse(JSON.stringify(monthlyTasminTimeseries));
     fakeData.units = 'meters';
-    const func = function () {
-      cg.timeseriesToTimeseriesGraph(metadata, fakeData,
-          mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyPrTimeseries);
+    function func () {
+      timeseriesToTimeseriesGraph(metadata, fakeData,
+          monthlyTasmaxTimeseries, monthlyPrTimeseries);
     };
     expect(func).toThrow();
   });
   it('displays a single timeseries', function () {
-    const c = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
-    expect(validate.allDefinedObject(c)).toBe(true);
+    const c = timeseriesToTimeseriesGraph(metadata, monthlyTasmaxTimeseries);
+    expect(allDefinedObject(c)).toBe(true);
     expect(c.data.columns[0][0]).toMatch('x');
     expect(c.data.columns.length).toEqual(2);
     expect(c.data.columns[0].length).toEqual(13);
@@ -305,12 +324,12 @@ describe('timeseriesToTimeSeriesGraph', function () {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('displays two timeseries with different units', function () {
-    const c = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
-        mockAPI.monthlyPrTimeseries);
-    expect(validate.allDefinedObject(c)).toBe(true);
+    const c = timeseriesToTimeseriesGraph(metadata, monthlyTasmaxTimeseries,
+        monthlyPrTimeseries);
+    expect(allDefinedObject(c)).toBe(true);
     expect(c.data.columns[0][0]).toMatch('x');
-    expect(validate.isRectangularArray(c.data.columns, 3, 13)).toBe(true);
-    expect(validate.allDefinedArray(c.data.columns)).toBe(true);
+    expect(isRectangularArray(c.data.columns, 3, 13)).toBe(true);
+    expect(allDefinedArray(c.data.columns)).toBe(true);
     expect(c.axis.x).toBeDefined();
     expect(c.axis.y).toBeDefined();
     expect(c.axis.y2).toBeDefined();

--- a/src/core/__tests__/chart-generator-tests.js
+++ b/src/core/__tests__/chart-generator-tests.js
@@ -1,27 +1,27 @@
-/*****************************************************************
+/* ***************************************************************
  * chart-generator-tests.js - tests for chart generation functions
- * 
- * One test (sometimes with multiple parts) for each function in 
+ *
+ * One test (sometimes with multiple parts) for each function in
  * chart-generator-tests.js. The tests have the same names and are
- * in the same order as the functions. 
- * 
+ * in the same order as the functions.
+ *
  * test data from ./sample-API-results.js
  * validation functions from ./test-validators.js
- *******************************************************/
+ *****************************************************************/
 
 jest.dontMock('../chart-generators');
 jest.dontMock('../util');
 jest.dontMock('underscore');
 
-const cg = require('../chart-generators'); 
+const cg = require('../chart-generators');
 const validate = require('../__test_data__/test-validators');
 const mockAPI = require('../__test_data__/sample-API-results');
 
-describe ('formatYAxis', function () {
+describe('formatYAxis', function () {
   it('formats a c3 y axis with units label', function () {
-    const axis = cg.formatYAxis("meters");
+    const axis = cg.formatYAxis('meters');
     expect(validate.allDefinedObject(axis)).toBe(true);
-    expect(axis.label).toEqual({"text": "meters", "position": "outer-middle"});
+    expect(axis.label).toEqual({ text: 'meters', position: 'outer-middle' });
     expect(axis.show).toEqual(true);
     expect(axis.tick.format(6.993)).toEqual(cg.fixedPrecision(6.993));
   });
@@ -32,7 +32,7 @@ describe('fixedPrecision', function () {
     const formatted = cg.fixedPrecision(6.22222);
     expect(formatted).toEqual(6.22);
   });
-  it('formats a negative number for user display', function() {
+  it('formats a negative number for user display', function () {
     const formatted = cg.fixedPrecision(-6.3333);
     expect(formatted).toEqual(-6.33);
   });
@@ -43,58 +43,58 @@ describe('fixedPrecision', function () {
 });
 
 describe('makePrecisionBySeries', function () {
-  //this test fails and is skipped because it relies on an external 
-  //.yaml config file that isn't easily available during jest testing. 
-  //In non-test usage the file is transformed and made available by webpack.
-  xit('reads the config file and applies its settings', function() {
-    const precision = cg.makePrecisionBySeries({"testseries": "tasmin"});
-    expect(precision(4.777, "testseries")).toEqual(4.8);
+  // this test fails and is skipped because it relies on an external
+  // .yaml config file that isn't easily available during jest testing.
+  // In non-test usage the file is transformed and made available by webpack.
+  xit('reads the config file and applies its settings', function () {
+    const precision = cg.makePrecisionBySeries({ testseries: 'tasmin' });
+    expect(precision(4.777, 'testseries')).toEqual(4.8);
   });
   it('uses a default precision for unspecified variables', function () {
-    const precision = cg.makePrecisionBySeries({"testseries": "tasmin"});
-    expect(precision(4.777, "testseries")).toEqual(4.78);
+    const precision = cg.makePrecisionBySeries({ testseries: 'tasmin' });
+    expect(precision(4.777, 'testseries')).toEqual(4.78);
   });
 });
 
 describe('makeTooltipDisplayNumbersWithUnits', function () {
   let axis = {};
-  axis.y = cg.formatYAxis("meters");
+  axis.y = cg.formatYAxis('meters');
   let axes = {};
-  const series1 = "height";
-  const series2 = "depth";
-  axes[series1] = "y";
+  const series1 = 'height';
+  const series2 = 'depth';
+  axes[series1] = 'y';
   let tooltipFunction;
   it('displays unit labels when there is a single data series', function () {
     tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
-    expect(tooltipFunction(5, 0, series1, 0)).toEqual("5 meters");
+    expect(tooltipFunction(5, 0, series1, 0)).toEqual('5 meters');
   });
   it('displays unit labels when there are multiple data series', function () {
-    axes[series2] = "y";
+    axes[series2] = 'y';
     tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
-    expect(tooltipFunction(6.22, 0, series1, 0)).toEqual("6.22 meters");
-    expect(tooltipFunction(7.8, 0, series2, 0)).toEqual("7.8 meters");
+    expect(tooltipFunction(6.22, 0, series1, 0)).toEqual('6.22 meters');
+    expect(tooltipFunction(7.8, 0, series2, 0)).toEqual('7.8 meters');
   });
   it('displays unit labels when there are multiple unit types', function () {
-    const series3 = "weight";
-    axis.y2 = cg.formatYAxis("kilograms");
-    axes[series3] = "y2";
+    const series3 = 'weight';
+    axis.y2 = cg.formatYAxis('kilograms');
+    axes[series3] = 'y2';
     tooltipFunction = cg.makeTooltipDisplayNumbersWithUnits(axes, axis);
-    expect(tooltipFunction(9.73, 0, series1, 0)).toEqual("9.73 meters");
-    expect(tooltipFunction(-2.4, 0, series2, 0)).toEqual("-2.4 meters");
-    expect(tooltipFunction(100000, 0, series3, 0)).toEqual("100000 kilograms");
-  }); 
+    expect(tooltipFunction(9.73, 0, series1, 0)).toEqual('9.73 meters');
+    expect(tooltipFunction(-2.4, 0, series2, 0)).toEqual('-2.4 meters');
+    expect(tooltipFunction(100000, 0, series3, 0)).toEqual('100000 kilograms');
+  });
 });
 
 describe('timeseriesToAnnualCycleGraph', function () {
   const metadata = mockAPI.metadataToArray();
   it('rejects data sets with too many units', function () {
     let fakeData = JSON.parse(JSON.stringify(mockAPI.monthlyTasminTimeseries));
-    fakeData.units = "meters";
+    fakeData.units = 'meters';
     const func = function () {
-      cg.timeseriesToAnnualCycleGraph(metadata, fakeData, 
+      cg.timeseriesToAnnualCycleGraph(metadata, fakeData,
           mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyPrTimeseries);
-      };
-    expect(func).toThrow();  
+    };
+    expect(func).toThrow();
   });
   it('displays a single timeseries', function () {
     const c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries);
@@ -125,44 +125,36 @@ describe('timeseriesToAnnualCycleGraph', function () {
     expect(c.axis.y).toBeDefined();
     expect(c.axis.y2).toBeDefined();
   });
-  it('displays two variables with different units at once', function () {
-    const c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
-        mockAPI.monthlyPrTimeseries);
-    expect(validate.allDefinedObject(c)).toBe(true);
-    expect(validate.isRectangularArray(c.data.columns, 2, 13)).toBe(true);
-    expect(validate.allDefinedArray(c.data.columns)).toBe(true);
-    expect(c.axis.x).toBeDefined();
-    expect(c.axis.y).toBeDefined();
-    expect(c.axis.y2).toBeDefined();    
-  });
 });
 
 describe('getMonthlyData', function () {
-  it('rejects data with an unsupported time resolution', function (){
+  it('rejects data with an unsupported time resolution', function () {
     let seventeen = {};
-    for(let i = 0; i < 17; i++){
+    for (let i = 0; i < 17; i++) {
       seventeen[Date(i)] = i * 3;
     }
-    const tooMany = function() {cg.getMonthlyData(seventeen);};
+    const tooMany = function () {cg.getMonthlyData(seventeen);};
     expect(tooMany).toThrow();
   });
   it('rejects data with inconsistent time resolution', function () {
-    const inconsistent = function () {cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, "yearly");};
+    const inconsistent = function () {
+      cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, 'yearly');
+    };
     expect(inconsistent).toThrow();
   });
   it('processes a monthly timeseries', function () {
-    const processed = cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, "monthly");
+    const processed = cg.getMonthlyData(mockAPI.monthlyTasmaxTimeseries.data, 'monthly');
     expect(processed.length).toEqual(12);
     expect(processed[5]).toEqual(11.841563876512202);
-    expect(processed[11]).toEqual(-16.96361296358877);    
+    expect(processed[11]).toEqual(-16.96361296358877);
   });
   it('processes a seasonal timeseries', function () {
-    const processed = cg.getMonthlyData(mockAPI.seasonalTasmaxTimeseries.data, "seasonal");
+    const processed = cg.getMonthlyData(mockAPI.seasonalTasmaxTimeseries.data, 'seasonal');
     expect(processed.length).toEqual(12);
     expect(processed[0]).toEqual(processed[11]);
   });
-  it('processes an annual timeseries', function() {
-    const processed = cg.getMonthlyData(mockAPI.annualTasmaxTimeseries.data, "yearly");
+  it('processes an annual timeseries', function () {
+    const processed = cg.getMonthlyData(mockAPI.annualTasmaxTimeseries.data, 'yearly');
     expect(processed.length).toEqual(12);
     expect(processed[0]).toEqual(processed[7]);
     expect(processed[4]).toEqual(processed[11]);
@@ -172,38 +164,42 @@ describe('getMonthlyData', function () {
 describe('shortestUniqueTimeseriesNamingFunction', function () {
   const metadata = mockAPI.metadataToArray();
   it('rejects identical time series', function () {
-    const minimalMetadata = [{unique_id: "foo", md: "bar"}, {unique_id: "baz", md: "bar"}];
-    const minimalData = [{id: "foo"}, {id: "baz"}];
-    const func = function() {cg.shortestUniqueTimeseriesNamingFunction(minimalMetadata, minimalData);};
+    const minimalMetadata = [{ unique_id: 'foo', md: 'bar' }, { unique_id: 'baz', md: 'bar' }];
+    const minimalData = [{ id: 'foo' }, { id: 'baz' }];
+    const func = function () {
+      cg.shortestUniqueTimeseriesNamingFunction(minimalMetadata, minimalData);
+    };
     expect(func).toThrow();
   });
   it('uses a a default naming scheme for a single data series', function () {
-    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, [mockAPI.monthlyTasmaxTimeseries]);
-    expect(nameFunction(metadata[0])).toEqual("Monthly Mean");
+    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata,
+        [mockAPI.monthlyTasmaxTimeseries]);
+    expect(nameFunction(metadata[0])).toEqual('Monthly Mean');
   });
   it('names series by time resolution', function () {
-    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, 
-        [mockAPI.monthlyTasmaxTimeseries, mockAPI.seasonalTasmaxTimeseries, 
+    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata,
+        [mockAPI.monthlyTasmaxTimeseries, mockAPI.seasonalTasmaxTimeseries,
           mockAPI.annualTasmaxTimeseries]);
-    expect(nameFunction(metadata[0])).toEqual("Monthly Mean");
-    expect(nameFunction(metadata[1])).toEqual("Seasonal Mean");
-    expect(nameFunction(metadata[2])).toEqual("Yearly Mean");
+    expect(nameFunction(metadata[0])).toEqual('Monthly Mean');
+    expect(nameFunction(metadata[1])).toEqual('Seasonal Mean');
+    expect(nameFunction(metadata[2])).toEqual('Yearly Mean');
   });
   it('names series by variable', function () {
-    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata, 
+    const nameFunction = cg.shortestUniqueTimeseriesNamingFunction(metadata,
         [mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyTasminTimeseries]);
-    expect(nameFunction(metadata[0])).toEqual("Tasmax Mean");
-    expect(nameFunction(metadata[3])).toEqual("Tasmin Mean");
+    expect(nameFunction(metadata[0])).toEqual('Tasmax Mean');
+    expect(nameFunction(metadata[3])).toEqual('Tasmin Mean');
   });
 });
 
-describe('dataToLongTermAverageGraph', function() {
+describe('dataToLongTermAverageGraph', function () {
   it('rejects datasets with missing metadata', function () {
-    const func = function () {cg.dataToLongTermAverageGraph(
+    const func = function () {
+      cg.dataToLongTermAverageGraph(
         [mockAPI.tasmaxData, mockAPI.tasminData]);};
-    expect(func).toThrow();      
+    expect(func).toThrow();
   });
-  it('graphs a single data series', function() {
+  it('graphs a single data series', function () {
     const c = cg.dataToLongTermAverageGraph([mockAPI.tasmaxData]);
     expect(validate.allDefinedObject(c)).toBe(true);
     expect(c.data.columns.length).toEqual(2);
@@ -213,8 +209,8 @@ describe('dataToLongTermAverageGraph', function() {
     expect(c.axis.y2).not.toBeDefined();
   });
   it('graphs two data series', function () {
-    const tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
-    const tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
+    const tasmaxQuery = { variable_id: 'tasmax', model_id: 'bcc-csm1-1-m' };
+    const tasminQuery = { variable_id: 'tasmin', model_id: 'bcc-csm1-1-m' };
     const c = cg.dataToLongTermAverageGraph(
         [mockAPI.tasmaxData, mockAPI.tasminData],
         [tasmaxQuery, tasminQuery]);
@@ -226,9 +222,9 @@ describe('dataToLongTermAverageGraph', function() {
     expect(c.axis.y2).toBeDefined();
   });
   it('throw an error on more than two data series with different variables', function () {
-    const tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
-    const tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
-    const prQuery = {"variable_id": "pr", "model_id": "bcc-csm1-1-m"};
+    const tasmaxQuery = { variable_id: 'tasmax', model_id: 'bcc-csm1-1-m' };
+    const tasminQuery = { variable_id: 'tasmin', model_id: 'bcc-csm1-1-m' };
+    const prQuery = { variable_id: 'pr', model_id: 'bcc-csm1-1-m' };
     const func = function () {
       cg.dataToLongTermAverageGraph(
         [mockAPI.tasmaxData, mockAPI.tasminData, mockAPI.prData],
@@ -238,13 +234,13 @@ describe('dataToLongTermAverageGraph', function() {
   });
 });
 
-describe('getAllTimestamps', function() {
+describe('getAllTimestamps', function () {
   it('throws an error if there is no data', function () {
     const func = function () {cg.getAllTimestamps([]);};
     expect(func).toThrow();
   });
   it('throws an error if there are no available timestamps', function () {
-    const func = function () {cg.getAllTimestamps([{"r1p1i1": {"data": {}}}]);};
+    const func = function () {cg.getAllTimestamps([{ r1p1i1: { data: {} } }]);};
     expect(func).toThrow();
   });
   it('returns timestamps associated with a data API call', function () {
@@ -253,34 +249,37 @@ describe('getAllTimestamps', function() {
   });
   it('combines timestamps from multiple data API calls', function () {
     let fakeData = JSON.parse(JSON.stringify(mockAPI.tasminData));
-    fakeData["r1i1p1"].data = {"1990-04-01T00:00:00Z": 20, "1997-01-15T00:00:00Z": 0};
+    fakeData.r1i1p1.data = { '1990-04-01T00:00:00Z': 20, '1997-01-15T00:00:00Z': 0 };
     const stamps = cg.getAllTimestamps([mockAPI.tasmaxData, fakeData]);
     expect(stamps.length).toBe(7);
   });
   it('extracts timestamps from timeseries API calls', function () {
-    const stamps = cg.getAllTimestamps([mockAPI.monthlyTasmaxTimeseries, mockAPI.seasonalTasmaxTimeseries]);
+    const stamps = cg.getAllTimestamps([mockAPI.monthlyTasmaxTimeseries,
+      mockAPI.seasonalTasmaxTimeseries]);
     expect(stamps.length).toBe(16);
   });
 });
 
 describe('nameAPICallParametersFunction', function () {
   it('refuses identical data sets', function () {
-    const func = function () {cg.nameAPICallParametersFunction(
-        [{"variable": "foo"}, {"variable": "foo"}]);};
+    const func = function () {
+      cg.nameAPICallParametersFunction(
+        [{ variable: 'foo' }, { variable: 'foo' }]);};
     expect(func).toThrow();
   });
   it('refuses data sets calculated over different areas', function () {
-    const func = function () {cg.nameAPICallParametersFunction(
-        [{"area": "POLYGON+((-114,+-113,+-103,+-104+63,+-114+63))"},
-         {"area": "POLYGON+((-115,+-113,+-103,+-105+63,+-115+63))"}]);};
+    const func = function () {
+      cg.nameAPICallParametersFunction(
+        [{ area: 'POLYGON+((-114,+-113,+-103,+-104+63,+-114+63))' },
+         { area: 'POLYGON+((-115,+-113,+-103,+-105+63,+-115+63))' }]);};
     expect(func).toThrow();
   });
   it('assigns distinct names to data sets', function () {
-    const tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
-    const tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
+    const tasmaxQuery = { variable_id: 'tasmax', model_id: 'bcc-csm1-1-m' };
+    const tasminQuery = { variable_id: 'tasmin', model_id: 'bcc-csm1-1-m' };
     const nameFunction = cg.nameAPICallParametersFunction([tasmaxQuery, tasminQuery]);
-    expect(nameFunction("r1i1p1", tasmaxQuery)).toBe("tasmax r1i1p1");
-    expect(nameFunction("r1i1p1", tasminQuery)).toBe("tasmin r1i1p1");
+    expect(nameFunction('r1i1p1', tasmaxQuery)).toBe('tasmax r1i1p1');
+    expect(nameFunction('r1i1p1', tasminQuery)).toBe('tasmin r1i1p1');
   });
 });
 
@@ -288,11 +287,11 @@ describe('timeseriesToTimeSeriesGraph', function () {
   const metadata = mockAPI.metadataToArray();
   it('rejects data sets with too many units', function () {
     let fakeData = JSON.parse(JSON.stringify(mockAPI.monthlyTasminTimeseries));
-    fakeData.units = "meters";
+    fakeData.units = 'meters';
     const func = function () {
       cg.timeseriesToTimeseriesGraph(metadata, fakeData,
           mockAPI.monthlyTasmaxTimeseries, mockAPI.monthlyPrTimeseries);
-      };
+    };
     expect(func).toThrow();
   });
   it('displays a single timeseries', function () {
@@ -305,7 +304,7 @@ describe('timeseriesToTimeSeriesGraph', function () {
     expect(c.axis.y).toBeDefined();
     expect(c.axis.y2).not.toBeDefined();
   });
-  it('displays two timeseries with different units', function() {
+  it('displays two timeseries with different units', function () {
     const c = cg.timeseriesToTimeseriesGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyPrTimeseries);
     expect(validate.allDefinedObject(c)).toBe(true);

--- a/src/core/__tests__/chart-generator-tests.js
+++ b/src/core/__tests__/chart-generator-tests.js
@@ -123,7 +123,7 @@ describe('timeseriesToAnnualCycleGraph', function () {
     expect(validate.allDefinedArray(c.data.columns)).toBe(true);
     expect(c.axis.x).toBeDefined();
     expect(c.axis.y).toBeDefined();
-    expect(c.axis.y2).not.toBeDefined();
+    expect(c.axis.y2).toBeDefined();
   });
   it('displays two variables with different units at once', function () {
     const c = cg.timeseriesToAnnualCycleGraph(metadata, mockAPI.monthlyTasmaxTimeseries,
@@ -212,7 +212,7 @@ describe('dataToLongTermAverageGraph', function() {
     expect(c.axis.y).toBeDefined();
     expect(c.axis.y2).not.toBeDefined();
   });
-  it('graphs multiple data series', function () {
+  it('graphs two data series', function () {
     const tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
     const tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
     const c = cg.dataToLongTermAverageGraph(
@@ -223,22 +223,18 @@ describe('dataToLongTermAverageGraph', function() {
     expect(validate.allDefinedArray(c.data.columns)).toBe(true);
     expect(c.axis.x).toBeDefined();
     expect(c.axis.y).toBeDefined();
-    expect(c.axis.y2).not.toBeDefined();
+    expect(c.axis.y2).toBeDefined();
   });
-  it('graphs data series with distinct units', function () {
+  it('throw an error on more than two data series with different variables', function () {
     const tasmaxQuery = {"variable_id": "tasmax", "model_id": "bcc-csm1-1-m"};
     const tasminQuery = {"variable_id": "tasmin", "model_id": "bcc-csm1-1-m"};
     const prQuery = {"variable_id": "pr", "model_id": "bcc-csm1-1-m"};
-    const c = cg.dataToLongTermAverageGraph(
+    const func = function () {
+      cg.dataToLongTermAverageGraph(
         [mockAPI.tasmaxData, mockAPI.tasminData, mockAPI.prData],
         [tasmaxQuery, tasminQuery, prQuery]);
-    expect(validate.allDefinedObject(c)).toBe(true);
-    expect(validate.isRectangularArray(c.data.columns, 4, 7)).toBe(true);
-    expect(validate.allDefinedArray(c.data.columns)).toBe(true);
-    expect(c.axis.x).toBeDefined();
-    expect(c.axis.y).toBeDefined();
-    expect(c.axis.y2).toBeDefined();
-    expect(c.data.axes["tasmin r1i1p1"]).not.toBe(c.data.axes["pr r1i1p1"]);
+    };
+    expect(func).toThrow();
   });
 });
 

--- a/src/core/__tests__/chart-transformer-tests.js
+++ b/src/core/__tests__/chart-transformer-tests.js
@@ -44,8 +44,8 @@ describe('getAxisTextForVariable', function () {
     const c = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(), 
         mockAPI.monthlyTasmaxTimeseries,
         mockAPI.monthlyPrTimeseries);
-    expect(ct.getAxisTextForVariable(c, "tasmax")).toBe("degC");
-    expect(ct.getAxisTextForVariable(c, "pr")).toBe("kg m-2 d-1");
+    expect(ct.getAxisTextForVariable(c, "tasmax")).toBe("tasmax degC");
+    expect(ct.getAxisTextForVariable(c, "pr")).toBe("pr kg m-2 d-1");
   });
   it('throws an error on a single-variable graph', function () {
     const c2 = cg.timeseriesToAnnualCycleGraph(mockAPI.metadataToArray(),

--- a/src/core/__tests__/export-test.js
+++ b/src/core/__tests__/export-test.js
@@ -92,7 +92,7 @@ describe('generateDataCellsFromC3Graph', function () {
     expect(validate.isRectangularArray(cells, 2, 14)).toBe(true);
     expect(cells[1][0]).toBe("Monthly Mean");
     //spot check representative values
-    expect(cells[1][13]).toBe("degC");
+    expect(cells[1][13]).toBe("tasmax degC");
     expect(cells[1][1]).toBe('-20.60');
     expect(cells[1][12]).toBe('-16.96');
     //make sure nothing is undefined

--- a/src/core/chart-accessors.js
+++ b/src/core/chart-accessors.js
@@ -1,0 +1,51 @@
+/* **********************************************************************
+ * chart-accessors.js - functions that return information about a C3 chart
+ *   spec without modifying it. Used by chart-displaying components to 
+ *   make decisions about how to format and display charts, without needing
+ *   to understand or access the internals of charts.
+ *   
+ * Reference on the C3 chart format can be found at https://c3js.org
+ ***************************************************************************/
+import _ from 'underscore';
+
+export function hasTwoYAxes(graph) {
+  // returns true if this graph has a both a y and y2 axis defined
+  return !_.isUndefined(graph.axis.y2) && !_.isUndefined(graph.axis.y2);
+};
+
+export function checkYAxisValidity(graph, axis) {
+  // helper function that throws an error if the given y axis is
+  // not present in the graph spec.
+  if(_.isUndefined(graph.axis[axis])) {
+    throw new Error("Error: invalid axis " + axis);
+  }
+}
+
+export function yAxisUnits(graph, axis) {
+  // returns the units associated with a y-axis, which are set by 
+  // chart-generators.assignDataToYAxis(). If a chart was generated
+  // without using assignDataToYAxis(), or put through a graph transform
+  // that affects axis attributes to remove units, it returns undefined.
+  // Currently all CE graphs use assignDataToYAxis()
+  checkYAxisValidity(graph, axis);
+  return graph.axis[axis].units;
+};
+
+export function yAxisRange(graph, axis) {
+  // returns an object containing the maximum and minimum of all 
+  // data series associated with a particular y-axis, 
+  // like {max: 10, min: 0}
+  checkYAxisValidity(graph, axis);
+  let min = Infinity;
+  let max = -Infinity;
+  for(let i = 0; i < graph.data.columns.length; i++) {
+   if (axis === graph.data.axes[graph.data.columns[i][0]]) {
+     min = Math.min(min, _.min(graph.data.columns[i]));
+     max = Math.max(max, _.max(graph.data.columns[i]));
+   }
+  }
+  return {
+    min: min,
+    max: max,
+    };
+};

--- a/src/core/chart-accessors.js
+++ b/src/core/chart-accessors.js
@@ -4,19 +4,19 @@
  *   make decisions about how to format and display charts, without needing
  *   to understand or access the internals of charts.
  *
- * Reference on the C3 chart format can be found at https://c3js.org
+ * Reference on the C3 chart spec format can be found at https://c3js.org
  ***************************************************************************/
 import _ from 'underscore';
 
 export function hasTwoYAxes(graph) {
-  // returns true if this graph has a both a y and y2 axis defined
-  return !_.isUndefined(graph.axis.y2) && !_.isUndefined(graph.axis.y2);
+  // returns a truthy object if this graph has a both a y and y2 axis defined
+  return !!(graph.axis.y && graph.axis.y2);
 }
 
 export function checkYAxisValidity(graph, axis) {
-  // helper function that throws an error if the given y axis is
-  // not present in the graph spec.
-  if (_.isUndefined(graph.axis[axis])) {
+  // helper function that throws an error if the named (typically "y" or "y2")
+  // y axis is not present in the graph spec.
+  if (!graph.axis[axis]) {
     throw new Error('Error: invalid axis ' + axis);
   }
 }
@@ -33,19 +33,16 @@ export function yAxisUnits(graph, axis) {
 
 export function yAxisRange(graph, axis) {
   // returns an object containing the maximum and minimum of all
-  // data series associated with a particular y-axis,
-  // like {max: 10, min: 0}
+  // data series in this graph spec associated with a particular 
+  // y-axis. The axis argument is typically either "y" or "y2".
+  // Return value has the format {max: 10, min: 0}
   checkYAxisValidity(graph, axis);
-  let min = Infinity;
-  let max = -Infinity;
-  for (let i = 0; i < graph.data.columns.length; i++) {
-    if (axis === graph.data.axes[graph.data.columns[i][0]]) {
-      min = Math.min(min, _.min(graph.data.columns[i]));
-      max = Math.max(max, _.max(graph.data.columns[i]));
-    }
-  }
+  
+  //filter to just the data points associated with this y axis
+  const axisData = _.flatten(graph.data.columns.filter(ser => axis === graph.data.axes[ser[0]]));
+  
   return {
-    min: min,
-    max: max,
-  };
+    min: _.min(axisData),
+    max: _.max(axisData),
+  };  
 }

--- a/src/core/chart-accessors.js
+++ b/src/core/chart-accessors.js
@@ -1,9 +1,9 @@
 /* **********************************************************************
  * chart-accessors.js - functions that return information about a C3 chart
- *   spec without modifying it. Used by chart-displaying components to 
+ *   spec without modifying it. Used by chart-displaying components to
  *   make decisions about how to format and display charts, without needing
  *   to understand or access the internals of charts.
- *   
+ *
  * Reference on the C3 chart format can be found at https://c3js.org
  ***************************************************************************/
 import _ from 'underscore';
@@ -11,41 +11,41 @@ import _ from 'underscore';
 export function hasTwoYAxes(graph) {
   // returns true if this graph has a both a y and y2 axis defined
   return !_.isUndefined(graph.axis.y2) && !_.isUndefined(graph.axis.y2);
-};
+}
 
 export function checkYAxisValidity(graph, axis) {
   // helper function that throws an error if the given y axis is
   // not present in the graph spec.
-  if(_.isUndefined(graph.axis[axis])) {
-    throw new Error("Error: invalid axis " + axis);
+  if (_.isUndefined(graph.axis[axis])) {
+    throw new Error('Error: invalid axis ' + axis);
   }
 }
 
 export function yAxisUnits(graph, axis) {
-  // returns the units associated with a y-axis, which are set by 
+  // returns the units associated with a y-axis, which are set by
   // chart-generators.assignDataToYAxis(). If a chart was generated
   // without using assignDataToYAxis(), or put through a graph transform
   // that affects axis attributes to remove units, it returns undefined.
   // Currently all CE graphs use assignDataToYAxis()
   checkYAxisValidity(graph, axis);
   return graph.axis[axis].units;
-};
+}
 
 export function yAxisRange(graph, axis) {
-  // returns an object containing the maximum and minimum of all 
-  // data series associated with a particular y-axis, 
+  // returns an object containing the maximum and minimum of all
+  // data series associated with a particular y-axis,
   // like {max: 10, min: 0}
   checkYAxisValidity(graph, axis);
   let min = Infinity;
   let max = -Infinity;
-  for(let i = 0; i < graph.data.columns.length; i++) {
-   if (axis === graph.data.axes[graph.data.columns[i][0]]) {
-     min = Math.min(min, _.min(graph.data.columns[i]));
-     max = Math.max(max, _.max(graph.data.columns[i]));
-   }
+  for (let i = 0; i < graph.data.columns.length; i++) {
+    if (axis === graph.data.axes[graph.data.columns[i][0]]) {
+      min = Math.min(min, _.min(graph.data.columns[i]));
+      max = Math.max(max, _.max(graph.data.columns[i]));
+    }
   }
   return {
     min: min,
     max: max,
-    };
-};
+  };
+}

--- a/src/core/chart-formatters.js
+++ b/src/core/chart-formatters.js
@@ -289,6 +289,39 @@ function padYAxis (graph, axis = "y", direction = "top", padding = 1) {
 }
 
 /*
+ * Post-processing graph function that accepts a graph with two y axes and
+ * sets the axes to have the same range.
+ * 
+ * Most of the time, if two y-axes have the same range, a single shared y-axis
+ * should obviously be used instead. However, for graphs that are *normally*
+ * displayed with 2 y-axes, having two identical y-axes may be a better option
+ * than either: 1) having an axis that appears and disappears depending on
+ * the data range, or 2) having two misleadingly *almost* identical axes.
+ * 
+ * This graph transform function is for those limited circumstances.
+ */
+function matchYAxisRange(graph) {
+  const y = graph.axis.y;
+  const y2 = graph.axis.y2;
+  
+  if(!(y && y2)) {
+    throw new Error("Error: cannot match single axis range");
+  }
+
+  const ymin = y.min ? y.min : _.min(_.map(getDataSeriesByAxis(graph, "y"), series => _.min(series)));
+  const ymax = y.max ? y.max : _.max(_.map(getDataSeriesByAxis(graph, "y"), series => _.max(series)));
+  const y2min = y2.min ? y2.min : _.min(_.map(getDataSeriesByAxis(graph, "y2"), series => _.min(series)));
+  const y2max = y2.max ? y2.max : _.max(_.map(getDataSeriesByAxis(graph, "y2"), series => _.max(series)));
+
+  graph.axis.y.min = Math.min(ymin, y2min);
+  graph.axis.y2.min = Math.min(ymin, y2min);
+  graph.axis.y.max = Math.max(ymax, y2max);
+  graph.axis.y2.max = Math.max(ymax, y2max);
+  return graph;
+}
+
+
+/*
  * Post-processing graph function that alters the graph to only display
  * numerical values for axis ticks inside a certain range. This is 
  * intended to help make it clearer which data series are
@@ -329,7 +362,7 @@ function hideTicksByRange(graph, axis = "y", min, max) {
 
 module.exports = { assignColoursByGroup, fadeSeriesByRank,
     hideSeriesInLegend, sortSeriesByRank, hideSeriesInTooltip,
-    padYAxis, hideTicksByRange,
+    padYAxis, matchYAxisRange, hideTicksByRange,
     //helper functions exported only for testing:
     getDataSeriesByAxis
     };

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -216,7 +216,7 @@ function assignDataToYAxis(graph, seriesMetadata, groupByUnits = false) {
   }
 
   graph.axis = graph.axis ? graph.axis : {};
-  const yLabel = groupByUnits ? yUnits : `${yGroup} ${yUnits}`;
+  const yLabel = groupByUnits || _.isEmpty(yGroup) ? yUnits : `${yGroup} ${yUnits}`;
   graph.axis.y = formatYAxis(yLabel);
   graph.axis.y.units = yUnits;
   graph.axis.y.groupBy = {
@@ -595,7 +595,6 @@ function dataToLongTermAverageGraph(data, contexts = []) {
   c3Data.columns.push(['x'].concat(_.map(timestamps, extendedDateToBasicDate)));
   c3Data.x = 'x';
 
-
   // add each API call to the chart
   for (let i = 0; i < data.length; i++) {
     const context = contexts.length ? contexts[i] : {};
@@ -607,7 +606,7 @@ function dataToLongTermAverageGraph(data, contexts = []) {
       const seriesVariable = _.isEmpty(context) ? undefined : context.variable_id;
       seriesVariables[runName] = seriesVariable;
       seriesMetadata[runName] = {
-        variable: seriesVariable,
+        variable: seriesVariable || '', // single-run has no var metadata
         units: call[run].units,
       };
       const series = [runName];

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -152,6 +152,7 @@ function assignDataToYAxis(graph, seriesMetadata, groupByUnits = false) {
   let y2Units = '';
 
   // if a y axis already exists, add new data to it.
+  // TODO: this code is undertested, as at present we aren't using it
   if (nestedAttributeIsDefined(graph, 'axis', 'y')) {
     if (nestedAttributeIsDefined(graph, 'axis', 'y', 'groupBy')
         && nestedAttributeIsDefined(graph, 'axis', 'y', 'units')) {
@@ -165,6 +166,9 @@ function assignDataToYAxis(graph, seriesMetadata, groupByUnits = false) {
     }
   }
   // if a second y axis already exists, use it.
+  // TODO: This code is included for completeness, but not currently
+  // reachable - new data are never added to an existing graph -
+  // nor well tested.
   if (nestedAttributeIsDefined(graph, 'axis', 'y2')) {
     if (nestedAttributeIsDefined(graph, 'axis', 'y2', 'groupBy')
         && nestedAttributeIsDefined(graph, 'axis', 'y2', 'units')) {
@@ -227,8 +231,8 @@ function assignDataToYAxis(graph, seriesMetadata, groupByUnits = false) {
   if (y2Group) {
     const y2Label = groupByUnits ? y2Units : `${y2Group} ${y2Units}`;
     graph.axis.y2 = formatYAxis(y2Label);
-    graph.axis.y.units = y2Units;
-    graph.axis.y.groupBy = {
+    graph.axis.y2.units = y2Units;
+    graph.axis.y2.groupBy = {
       type: groupBy,
       value: y2Group,
     };

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -1,7 +1,7 @@
-/************************************************************************
+/* **********************************************************************
  * chart-generators.js - functions that generate a C3 chart specification
  * object from backend query results and metadata describing the query.
- * 
+ *
  * The three primary functions in this file are:
  * - timeseriesToAnnualCycleGraph, which accepts data from the "timeseries"
  *   API call and generates a structure annual cycle graph with months
@@ -9,11 +9,11 @@
  *
  * - timeseriesToTimeseriesGraph, which accepts data from the "timeseries"
  *   API call and generates an unstructured timeseries of arbitrary
- *   resolution using whatever dates are available.   
+ *   resolution using whatever dates are available.
  *
  * - dataToLongTermAverageGraph, which accepts data from the "data" API call
  *   and creates timeseries graphs of arbitrary resolution
- * 
+ *
  * This file also contains helper functions used by the primary functions
  * to generate pieces of the C3 graph-describing data structure, which is
  * specified here: http://c3js.org/reference.html.
@@ -21,38 +21,35 @@
  ***************************************************************************/
 
 import _ from 'underscore';
-import {PRECISION,
+import { PRECISION,
         extendedDateToBasicDate,
         capitalizeWords,
-        caseInsensitiveStringSearch,
-        nestedAttributeIsDefined,
-        getVariableOptions} from './util';
-import chroma from 'chroma-js';
+        getVariableOptions } from './util';
 
-/*****************************************************
+/* **************************************************
  * 0. Helper functions used by all graph generators *
- *****************************************************/
-
-//Generates a typical y-axis configuration, given the text of the label.
-function formatYAxis (label) {
-  return {
-    "label": {
-      "text": label,
-      "position": "outer-middle"
-    },
-    "tick": {
-      "format": fixedPrecision
-    },
-    "show": true
-  };
-};
+ ****************************************************/
 
 /*
  * Simple formatting function for numbers to be displayed on the graph.
  * Used as a default when a more specialized formatting function isn't
  * available; ignores all its inputs except the number to be formatted.
  */
-function fixedPrecision (n, ...rest) { return +n.toFixed(PRECISION);};
+function fixedPrecision(n) { return +n.toFixed(PRECISION);}
+
+// Generates a typical y-axis configuration, given the text of the label.
+function formatYAxis(label) {
+  return {
+    label: {
+      text: label,
+      position: 'outer-middle',
+    },
+    tick: {
+      format: fixedPrecision,
+    },
+    show: true,
+  };
+}
 
 /*
  * Accepts a object with seriesname:variable pairs.
@@ -61,55 +58,160 @@ function fixedPrecision (n, ...rest) { return +n.toFixed(PRECISION);};
  * file for the associated variable, or a default precision with
  * util.PRECISION for variables with no precision options in the file.
  */
-function makePrecisionBySeries (series) {
+function makePrecisionBySeries(series) {
   let dictionary = {};
-  for(let s in series) {
-    const fromConfig = getVariableOptions(series[s], "decimalPrecision");
+  for (let s in series) {
+    const fromConfig = getVariableOptions(series[s], 'decimalPrecision');
     dictionary[s] = _.isUndefined(fromConfig) ? PRECISION : fromConfig;
   }
 
-  return function(n, series) {return +n.toFixed(dictionary[series])};
-};
+  return function (n, name) {return +n.toFixed(dictionary[name]);};
+}
 
 /*
  * This function returns a number-formatting function for use by the C3
  * tooltip.
- * C3 passes the tooltip formatting function four pieces of information about the 
- * datum being examined: data value, ratio (pie charts only), series id, 
+ * C3 passes the tooltip formatting function four pieces of information about the
+ * datum being examined: data value, ratio (pie charts only), series id,
  * and point index within the series.
  *
  * This function extracts unit names for each data series from the axis
- * labels, then returns a function that uses the series id passed by 
+ * labels, then returns a function that uses the series id passed by
  * C3 to append a units string to each value.
  *
  * It optionally accepts a precisionFunction for more exact formatting of
  * numbers. precisionFunction will be passed the number to format and the
  * series id it belongs to.
  */
-function makeTooltipDisplayNumbersWithUnits (axes, axis, precisionFunction) {
+function makeTooltipDisplayNumbersWithUnits(axes, axis, precisionFunction) {
   let unitsDictionary = {};
-  if(_.isUndefined(precisionFunction)) { //use a default.
-    precisionFunction = fixedPrecision;
-  }
-  
-  //build a dictionary between timeseries names and units
-  for(let series in axes) {
+  const pf = _.isUndefined(precisionFunction) ? fixedPrecision : precisionFunction;
+
+  // build a dictionary between timeseries names and units
+  for (let series in axes) {
     unitsDictionary[series] = axis[axes[series]].label.text;
   }
 
-  return function(value, ratio, id, index) {
-    return `${precisionFunction(value, id)} ${unitsDictionary[id]}`;
+  return function (value, ratio, id) {
+    return `${pf(value, id)} ${unitsDictionary[id]}`;
   };
-};
+}
 
-/**************************************************************
+/* ************************************************************
  * 1. timeseriesToAnnualCycleGraph() and its helper functions *
  **************************************************************/
 
+/*
+ * Helper constant for timeseriesToAnnualCycleGraph: an X-axis configuration
+ * object representing a categorical axis labeled in months.
+ */
+const monthlyXAxis = {
+  type: 'category',
+  categories: ['January', 'February', 'March', 'April', 'May', 'June',
+          'July', 'August', 'September', 'October', 'November', 'December'],
+};
+
+/*
+ * Helper function for timeseriesToAnnualCycleGraph.
+ * Accepts a dataseries object with 1, 4, or 12 timestamp:value pairs
+ * and returns an array with twelve values in order by timestamp,
+ * repeating values as necessary to get a monthly-resolution sequence.
+ */
+function getMonthlyData(data, timescale = 'monthly') {
+  const expectedTimestamps = { monthly: 12, seasonal: 4, yearly: 1 };
+  let monthlyData = [];
+  const timestamps = Object.keys(data).sort();
+
+  if (timestamps.length === 17) {
+    throw new Error('Error: concatenated 17-point chronology.');
+  }
+
+  if (timestamps.length !== expectedTimestamps[timescale]) {
+    throw new Error('Error: inconsistent time resolution in data');
+  }
+
+  for (let i = 0; i < 12; i++) {
+    let mapped = Math.ceil((timestamps.length / 12.0) * (i + 1)) - 1;
+    monthlyData.push(data[timestamps[mapped]]);
+  }
+
+  // Seasonal timeseries need one month of winter removed from the beginning of the
+  // year and added at the end, since winter wraps around the calendar new year.
+  if (timescale === 'seasonal') {
+    monthlyData = monthlyData.slice(1, 12);
+    monthlyData.push(data[timestamps[0]]);
+  }
+
+  return monthlyData;
+}
+
+/*
+ * Helper function for timeseriesToAnnualCycleGraph. Given a set of timeserieses
+ * to be graphed and metadata about each timeseries, returns a function
+ * that generates the shortest name necessary to distinguish a particular
+ * timeseries from all others being shown on the same chart.
+ *
+ * For example, when graphing monthly, seasonal, and yearly means for
+ * otherwise identical data files, only "monthly", "seasonal," and "yearly"
+ * need to appear in the graph legend. But if graphing multiple variables,
+ * the graph legend will need to display variable names as well.
+ *
+ * Timeseries names include any descriptive  metadata that vary between
+ * timeseries and leave out any metadata that doesn't. They end with "mean".
+ */
+// TODO: special case climatological period to display as (XXXX-XXXX)
+// TODO: possibly cue descriptors to appear in a specific order?
+// "Tasmin Monthly Mean" sounds better than "Monthly Tasmin Mean".
+function shortestUniqueTimeseriesNamingFunction(metadata, data) {
+  if (metadata.length === 0) {
+    throw new Error('No data to show');
+  }
+
+  // only one timeseries being graphed, simple label.
+  if (data.length === 1) {
+    return function (m) { return capitalizeWords(`${m.timescale} mean`);};
+  }
+
+  let variation = [];
+  const exemplarMetadata = _.find(metadata, function (m) {return m.unique_id === data[0].id;});
+
+  for (let datum of data) {
+    const comparandMetadata = _.find(metadata, function (m) {return m.unique_id === datum.id;});
+
+    for (let att in comparandMetadata) {
+      if (exemplarMetadata[att] !== comparandMetadata[att] && variation.indexOf(att) === -1) {
+        variation.push(att);
+      }
+    }
+  }
+
+  // Remove unique_id from the list of possible variations. All
+  // datasets have unique unique_id's; it's not useful on a graph
+  variation.splice(variation.indexOf('unique_id'), 1);
+
+  // Remove variable_name if variable_id is present, since we don't need both
+  if (variation.indexOf('variable_name') !== -1 && variation.indexOf('variable_id' !== -1)) {
+    variation.splice(variation.indexOf('variable_name'), 1);
+  }
+
+  if (variation.length === 0) {
+    throw new Error('Error: cannot graph identical timeseries');
+  }
+
+  return function (m) {
+    let name = '';
+    for (let v of variation) {
+      name = name.concat(`${m[v]} `);
+    }
+    name = name.concat('mean');
+    return capitalizeWords(name);
+  };
+}
+
 /* timeseriesToAnnualCycleGraph()
- * This function takes one or more JSON objects from the 
+ * This function takes one or more JSON objects from the
  * "timeseries" API call with this format:
- * 
+ *
  * {
  * "id": "tasmax_mClim_BCCAQv2_bcc-csm1-1-m_historical-rcp45_r1i1p1_20700101-20991231_Canada",
  * "units": "degC",
@@ -120,224 +222,203 @@ function makeTooltipDisplayNumbersWithUnits (axes, axis, precisionFunction) {
  *                    ...
  *    }
  * }
- * 
+ *
  * along with an array of dataset metadata entries that includes each
- * dataset referenced by the "id" field in the API results and return 
+ * dataset referenced by the "id" field in the API results and return
  * a C3 graph object displaying all the timeseries.
- * 
+ *
  * It takes an arbitrary number of data objects, but no more than
- * two separate unit types. Allowable data resolutions are monthly(12), 
- * seasonal (4), or yearly (1); an error will be thrown 
+ * two separate unit types. Allowable data resolutions are monthly(12),
+ * seasonal (4), or yearly (1); an error will be thrown
  * if this function is called on data with another time resolution.
  */
-function timeseriesToAnnualCycleGraph (metadata, ...data) {
-
-  //blank graph data object to be populated - holds data values
-  //and individual-timeseries-level display options.
+function timeseriesToAnnualCycleGraph(metadata, ...data) {
+  // blank graph data object to be populated - holds data values
+  // and individual-timeseries-level display options.
   let c3Data = {
-      columns: [],
-      types: {},
-      labels: {},
-      axes: {}
+    columns: [],
+    types: {},
+    labels: {},
+    axes: {},
   };
 
-  let yUnits = "";
-  let y2Units = "";
-  let yVariable = "";
-  let y2Variable = "";
+  let yUnits = '';
+  let y2Units = '';
+  let yVariable = '';
+  let y2Variable = '';
   let seriesVariables = {};
-  
-  const getTimeseriesName = shortestUniqueTimeseriesNamingFunction(metadata, data);
-  
-  //Add each timeseries to the graph
-  for(let timeseries of data) {
 
-    //get metadata for this timeseries
-    const timeseriesMetadata = _.find(metadata, function(m) {return m.unique_id === timeseries.id;});  
+  const getTimeseriesName = shortestUniqueTimeseriesNamingFunction(metadata, data);
+
+  // Add each timeseries to the graph
+  for (let timeseries of data) {
+    // get metadata for this timeseries
+    const timeseriesMetadata = _.find(metadata, function (m) {
+      return m.unique_id === timeseries.id;
+    });
     const timeseriesName = getTimeseriesName(timeseriesMetadata);
     const seriesVariable = timeseriesMetadata.variable_id;
     seriesVariables[timeseriesName] = seriesVariable;
-       
-    //add the actual data to the graph
-    c3Data.columns.push([timeseriesName].concat(getMonthlyData(timeseries.data, timeseriesMetadata.timescale)));
-    
-    //monthly data is displayed as a line graph, but yearly and seasonal
-    //display as step graphs.
-    c3Data.types[timeseriesName] = timeseriesMetadata.timescale == "monthly" ? "line" : "step";
 
-    //Each timeseries needs to be associated with a y-axis.
-    //Each y-axis represents one variable.
-    //C3 can theoretically support indefinite numbers of y-axes,
-    //but that would be hard for a user to make sense of, 
-    //so it's capped at two here.
-    if(!yVariable) {
-      //create new primary axis
+    // add the actual data to the graph
+    c3Data.columns.push([timeseriesName].concat(
+        getMonthlyData(timeseries.data, timeseriesMetadata.timescale)));
+
+    // monthly data is displayed as a line graph, but yearly and seasonal
+    // display as step graphs.
+    c3Data.types[timeseriesName] = timeseriesMetadata.timescale === 'monthly' ? 'line' : 'step';
+
+    // Each timeseries needs to be associated with a y-axis.
+    // Each y-axis represents one variable.
+    // C3 can theoretically support indefinite numbers of y-axes,
+    // but that would be hard for a user to make sense of,
+    // so it's capped at two here.
+    if (!yVariable) {
+      // create new primary axis
       yVariable = seriesVariable;
       yUnits = timeseries.units;
-      c3Data.axes[timeseriesName] = "y";
-    }
-    else if (yVariable === seriesVariable) {
-      //add series to existing primary axis
-      if(timeseries.units != yUnits) {
-        throw new Error("Error: mismatched units for " + yVariable);
+      c3Data.axes[timeseriesName] = 'y';
+    } else if (yVariable === seriesVariable) {
+      // add series to existing primary axis
+      if (timeseries.units !== yUnits) {
+        throw new Error('Error: mismatched units for ' + yVariable);
       }
-      c3Data.axes[timeseriesName] = "y";
-    }
-    else if (!y2Variable) {
-      //create new secondary axis
+      c3Data.axes[timeseriesName] = 'y';
+    } else if (!y2Variable) {
+      // create new secondary axis
       y2Variable = seriesVariable;
       y2Units = timeseries.units;
-      c3Data.axes[timeseriesName] = "y2";
-    }
-    else if (y2Variable == seriesVariable) {
-      //add series to existing secondary axis
-      if(timeseries.units != y2Units) {
-        throw new Error("Error: mismatched units for " + y2Variable);
+      c3Data.axes[timeseriesName] = 'y2';
+    } else if (y2Variable === seriesVariable) {
+      // add series to existing secondary axis
+      if (timeseries.units !== y2Units) {
+        throw new Error('Error: mismatched units for ' + y2Variable);
       }
-      c3Data.axes[timeseriesName] = "y2";
-    }
-    else {
-      //a problem: we already have two variables axes; third disallowed
-      throw new Error("Error: too many data axes required for graph");
+      c3Data.axes[timeseriesName] = 'y2';
+    } else {
+      // a problem: we already have two variables axes; third disallowed
+      throw new Error('Error: too many data axes required for graph');
     }
   }
-  
-  //whole-graph display options: axis formatting and tooltip behaviour
+
+  // whole-graph display options: axis formatting and tooltip behaviour
   let c3Axis = {};
   c3Axis.x = monthlyXAxis;
   c3Axis.y = formatYAxis(`${yVariable} ${yUnits}`);
-  if(y2Units) { 
+  if (y2Units) {
     c3Axis.y2 = formatYAxis(`${y2Variable} ${y2Units}`);
-    }
+  }
 
   const precision = makePrecisionBySeries(seriesVariables);
-  let c3Tooltip = {format: {}};
-  c3Tooltip.grouped = "true";
+  let c3Tooltip = { format: {} };
+  c3Tooltip.grouped = 'true';
   c3Tooltip.format.value = makeTooltipDisplayNumbersWithUnits(c3Data.axes, c3Axis, precision);
-  
+
   return {
     data: c3Data,
     tooltip: c3Tooltip,
     axis: c3Axis,
-  }; 
+  };
+}
+
+/* **********************************************************
+ * 2. dataToLongTermAverageGraph() and its helper functions *
+ ************************************************************/
+
+/*
+ * Helper constant for dataToLongTermAverageGraph: Format object
+ * for a timeseries X axis.
+ */
+const timeseriesXAxis = {
+  type: 'timeseries',
+  tick: {
+    format: '%Y-%m-%d',
+  },
 };
 
 /*
- * Helper function for timeseriesToAnnualCycleGraph.
- * Accepts a dataseries object with 1, 4, or 12 timestamp:value pairs
- * and returns an array with twelve values in order by timestamp,
- * repeating values as necessary to get a monthly-resolution sequence.
+ * Helper function for dataToLongTermAverageGraph. Extracts the
+ * list of all unique timestamps found in the data.
  */
-function getMonthlyData (data, timescale = "monthly") {
+function getAllTimestamps(data) {
+  let allTimes = [];
 
-  const expectedTimestamps = {"monthly": 12, "seasonal": 4, "yearly": 1};
-  let monthlyData = [];
-  const timestamps = Object.keys(data).sort();
-  
-  if(timestamps.length == 17) {
-    throw new Error("Error: concatenated 17-point chronology.");
+  const addSeries = function (seriesData) {
+    for (let timestamp in seriesData) {
+      if (!_.find(allTimes, function (t) {return t === timestamp;})) {
+        allTimes.push(timestamp);
+      }
+    }
+  };
+
+  for (let i in _.keys(data)) {
+    if (!_.isUndefined(data[i].data)) { // data is from "timeseries" API
+      addSeries(data[i].data);
+    } else { // data is from "data" API
+      for (let run in data[i]) {
+        addSeries(data[i][run].data);
+      }
+    }
   }
-  
-  if(timestamps.length != expectedTimestamps[timescale]) {
-    throw new Error("Error: inconsistent time resolution in data");
+  if (allTimes.length === 0) {
+    throw new Error('Error: no time stamps in data');
   }
-  
-  for(let i = 0; i < 12; i++) {
-    let mapped = Math.ceil((timestamps.length / 12.0) * (i + 1)) - 1;
-    monthlyData.push(data[timestamps[mapped]]);
-  }
-  
-  //Seasonal timeseries need one month of winter removed from the beginning of the
-  //year and added at the end, since winter wraps around the calendar new year.
-  if(timescale == "seasonal") {
-    monthlyData = monthlyData.slice(1, 12);
-    monthlyData.push(data[timestamps[0]]);
-  }
-  
-  return monthlyData;
-};
+  return allTimes;
+}
 
 /*
- * Helper function for timeseriesToAnnualCycleGraph. Given a set of timeserieses 
- * to be graphed and metadata about each timeseries, returns a function 
- * that generates the shortest name necessary to distinguish a particular
- * timeseries from all others being shown on the same chart.
- * 
- * For example, when graphing monthly, seasonal, and yearly means for 
- * otherwise identical data files, only "monthly", "seasonal," and "yearly"
- * need to appear in the graph legend. But if graphing multiple variables,
- * the graph legend will need to display variable names as well.
- * 
- * Timeseries names include any descriptive  metadata that vary between 
- * timeseries and leave out any metadata that doesn't. They end with "mean".
+ * Helper function for dataToLongTermAverageGraph. Examines
+ * the query context for multiple API calls to the "data"
+ * API and determines which possible query parameters
+ * (model, variable, emission, or timescale) vary by query.
+ *
+ * Returns a function that prefixes the "run" parameter
+ * from each API call with the parameters that vary between that
+ * specific run's call and other calls being graphed at the same time.
+ * Example: "tasmax r1i1p1" vs "pr r1i1p1"
  */
-//TODO: special case climatological period to display as (XXXX-XXXX)
-//TODO: possibly cue descriptors to appear in a specific order?
-// "Tasmin Monthly Mean" sounds better than "Monthly Tasmin Mean".
-function shortestUniqueTimeseriesNamingFunction (metadata, data) {
-  if (metadata.length === 0) {
-    throw new Error('No data to show');
-  }
-  
-  //only one timeseries being graphed, simple label.
-  if(data.length == 1) {
-    return function(m) { return capitalizeWords(`${m.timescale} mean`);};
-  }
-  
+function nameAPICallParametersFunction(contexts) {
   let variation = [];
-  const exemplarMetadata = _.find(metadata, function(m) {return m.unique_id === data[0].id;});
-  
-  for(let datum of data) {
-    const comparandMetadata = _.find(metadata, function(m) {return m.unique_id == datum.id;});
+  const exemplarContext = contexts[0];
 
-    for(let att in comparandMetadata) {
-      if(exemplarMetadata[att] !== comparandMetadata[att] && variation.indexOf(att) == -1) {
+  for (let context of contexts) {
+    for (let att in context) {
+      if (exemplarContext[att] !== context[att] && variation.indexOf(att) === -1) {
         variation.push(att);
       }
     }
   }
-  
-  //Remove unique_id from the list of possible variations. All
-  //datasets have unique unique_id's; it's not useful on a graph
-  variation.splice(variation.indexOf("unique_id"), 1);
-  
-  //Remove variable_name if variable_id is present, since we don't need both
-  if(variation.indexOf("variable_name") != -1 && variation.indexOf("variable_id" != -1)) {
-    variation.splice(variation.indexOf("variable_name"), 1);
+
+  // "data" API was called more than once with the same arguments -
+  // probably a mistake.
+  if (variation.length === 0) {
+    throw new Error('Error: cannot graph two identical queries');
   }
-  
-  if(variation.length === 0) {
-    throw new Error("Error: cannot graph identical timeseries");
+
+  // an "area" is just a list of points. The naive algorithm used to generate
+  // data series names here would just display the entire list next to each
+  // data series in the graph legend, which would be unhelpful, and an invalid
+  // series name as far as C3 is concerned. At present, throw an error
+  // if attempting to graph data series associated with different areas. If
+  // this functionality is needed in the future, it can be implemented here.
+  if (variation.indexOf('area') !== -1) {
+    throw new Error('Error: cannot display two datasets associated with different areas.');
   }
-  
-  return function (m) {
-    let name = "";
-    for(let v of variation) {
-      name = name.concat(`${m[v]} `);
+
+  return function (run, context) {
+    let name = '';
+    for (let v of variation) {
+      name = name.concat(`${context[v]} `);
     }
-    name = name.concat("mean");
-    return capitalizeWords(name);
+    name = name.concat(run);
+    return name;
   };
-};
-
-/* 
- * Helper constant for timeseriesToAnnualCycleGraph: an X-axis configuration 
- * object representing a categorical axis labeled in months.
- */
-const monthlyXAxis = {
-    type: 'category',
-    categories: ['January', 'February', 'March', 'April', 'May', 'June',
-          'July', 'August', 'September', 'October', 'November', 'December']
-};
-
-/************************************************************
- * 2. dataToLongTermAverageGraph() and its helper functions *
- ************************************************************/
+}
 
 /* dataToLongTermAverageGraph()
- * This function takes an array containins one or more JSON objects 
+ * This function takes an array containins one or more JSON objects
  * from the "data" API call with this format:
- * 
+ *
  * {
  *   "r1i1p1": {
  *     "data": {
@@ -352,20 +433,20 @@ const monthlyXAxis = {
  *           .........
  *  },
  *}
- * 
+ *
  * and returns a C3 graph object displaying them.
- * 
- * It takes an array containing an arbitrary number of data objects, each 
- * containing an arbitrary number of runs, but no more than two separate 
- * unit types. 
- * 
- * If there is more than one data object, an array of context objects is 
- * needed as well, because the data API call returns no metadata beyond run 
+ *
+ * It takes an array containing an arbitrary number of data objects, each
+ * containing an arbitrary number of runs, but no more than two separate
+ * unit types.
+ *
+ * If there is more than one data object, an array of context objects is
+ * needed as well, because the data API call returns no metadata beyond run
  * names. It's possible that two different datasets would share a run
- * name, and would appear identically on the graph, so additional context 
+ * name, and would appear identically on the graph, so additional context
  * is needed to to differentiate.
- * Each context object provides the attributes that were passed to the 
- * API to generate the data object at the same array position. 
+ * Each context object provides the attributes that were passed to the
+ * API to generate the data object at the same array position.
  * For example:
  * {
  *   model_id: bcc-csm1-1-m
@@ -373,233 +454,134 @@ const monthlyXAxis = {
  *   experiment: historical,+rcp45
  *   area: undefined
  * }
- * 
+ *
  * The context objects are used in the graph legend, to distinguish runs
  * with the same name ("r1i1p1") from different datasets.
  */
-function dataToLongTermAverageGraph (data, contexts = []){
-
-  //blank graph data object to be populated - holds data values
-  //and individual-timeseries-level display options.
+function dataToLongTermAverageGraph(data, contexts = []) {
+  // blank graph data object to be populated - holds data values
+  // and individual-timeseries-level display options.
   let c3Data = {
-      columns: [],
-      types: {},
-      labels: {},
-      axes: {}
+    columns: [],
+    types: {},
+    labels: {},
+    axes: {},
   };
-  
-  let yUnits = "";
-  let y2Units = "";
-  let yVariable = "";
-  let y2Variable = "";
-  
+
+  let yUnits = '';
+  let y2Units = '';
+  let yVariable = '';
+  let y2Variable = '';
+
   let seriesVariables = {};
   let nameSeries;
-  
-  if(data.length == 1) {
-    nameSeries = function(run, context) {return run;};
-  }
-  else if(data.length == contexts.length) {
+
+  if (data.length === 1) {
+    nameSeries = function (run) {return run;};
+  } else if (data.length === contexts.length) {
     nameSeries = nameAPICallParametersFunction(contexts);
-  }
-  else {
-    throw new Error("Error: no context provided for timeseries data");
+  } else {
+    throw new Error('Error: no context provided for timeseries data');
   }
 
-  //get the list of all timestamps and add them to the chart
-  //(C3 requires x-axis timestamps be added as a data column)
+  // get the list of all timestamps and add them to the chart
+  // (C3 requires x-axis timestamps be added as a data column)
   const timestamps = getAllTimestamps(data);
   c3Data.columns.push(['x'].concat(_.map(timestamps, extendedDateToBasicDate)));
-  c3Data.x = "x";
-  
+  c3Data.x = 'x';
 
-  //add each API call to the chart
-  for(let i = 0; i < data.length; i++) {
+
+  // add each API call to the chart
+  for (let i = 0; i < data.length; i++) {
     const context = contexts.length ? contexts[i] : {};
     const call = data[i];
-    
-    //add each individual dataset from the API to the chart
-    for(let run in call) {
+
+    // add each individual dataset from the API to the chart
+    for (let run in call) {
       const runName = nameSeries(run, context);
       const seriesVariable = _.isEmpty(context) ? undefined : context.variable_id;
       seriesVariables[runName] = seriesVariable;
       const series = [runName];
-      
-      //if a given timestamp is present in some, but not all
-      //datasets, set the timestamp's value to "null"
-      //in the C3 data object. This will cause C3 to render the
-      //line with a break where the missing timestamp is.
-      for(let t of timestamps ) {
+
+      // if a given timestamp is present in some, but not all
+      // datasets, set the timestamp's value to "null"
+      // in the C3 data object. This will cause C3 to render the
+      // line with a break where the missing timestamp is.
+      for (let t of timestamps) {
         series.push(_.isUndefined(call[run].data[t]) ? null : call[run].data[t]);
       }
       c3Data.columns.push(series);
-      c3Data.types[runName] = "line";
-      
-      //Each line on the graph needs to be associated with a y-axis
-      //and a y-scale. Each variable gets its own y-axis, up to the
-      //limit of two variables. (c3 supports more axis, but it looks
-      //terrible.)
-      if(!yVariable) {
-        //create new primary axis
+      c3Data.types[runName] = 'line';
+
+      // Each line on the graph needs to be associated with a y-axis
+      // and a y-scale. Each variable gets its own y-axis, up to the
+      // limit of two variables. (c3 supports more axis, but it looks
+      // terrible.)
+      if (!yVariable) {
+        // create new primary axis
         yVariable = seriesVariable;
         yUnits = call[run].units;
-        c3Data.axes[runName] = "y";
-      }
-      else if (yVariable === seriesVariable) {
-        //add series to existing primary axis
-        if(run.units != yUnits) {
-          throw new Error("Error: mismatched units for " + yVariable);
+        c3Data.axes[runName] = 'y';
+      } else if (yVariable === seriesVariable) {
+        // add series to existing primary axis
+        if (run.units !== yUnits) {
+          throw new Error('Error: mismatched units for ' + yVariable);
         }
-        c3Data.axes[runName] = "y";
-      }
-      else if (!y2Variable) {
-        //create new secondary axis
+        c3Data.axes[runName] = 'y';
+      } else if (!y2Variable) {
+        // create new secondary axis
         y2Variable = seriesVariable;
         y2Units = call[run].units;
-        c3Data.axes[runName] = "y2";
-      }
-      else if (y2Variable == seriesVariable) {
-        //add series to existing secondary axis
-        if(run.units != y2Units) {
-          throw new Error("Error: mismatched units for " + y2Variable);
+        c3Data.axes[runName] = 'y2';
+      } else if (y2Variable === seriesVariable) {
+        // add series to existing secondary axis
+        if (run.units !== y2Units) {
+          throw new Error('Error: mismatched units for ' + y2Variable);
         }
-        c3Data.axes[runName] = "y2";
-      }
-      else {
-        //a problem: we already have two variables axes; third disallowed
-        throw new Error("Error: too many data axes required for graph");
+        c3Data.axes[runName] = 'y2';
+      } else {
+        // a problem: we already have two variables axes; third disallowed
+        throw new Error('Error: too many data axes required for graph');
       }
     }
   }
-  
-  //whole-graph display options: axis formatting and tooltip behaviour
+
+  // whole-graph display options: axis formatting and tooltip behaviour
   let c3Axis = {};
   c3Axis.x = timeseriesXAxis;
-  c3Axis.y = formatYAxis(`${yVariable || ""} ${yUnits || ""}`);
-  if(y2Units) { 
+  c3Axis.y = formatYAxis(`${yVariable || ''} ${yUnits || ''}`);
+  if (y2Units) {
     c3Axis.y2 = formatYAxis(`${y2Variable} ${y2Units}`);
-    }
+  }
 
-  //The long term average graph doesn't require every series to have the exact
-  //same timestamps, since it's comparing long term trends anyway. Allow C3
-  //to smoothly connect series even if they're "missing" timestamps.
+  // The long term average graph doesn't require every series to have the exact
+  // same timestamps, since it's comparing long term trends anyway. Allow C3
+  // to smoothly connect series even if they're "missing" timestamps.
   const c3Line = {
-      connectNull: true
+    connectNull: true,
   };
 
-  //Note: if context is empty (dataToLongTermAverageGraph was called with only
-  //one time series), variable-determined precision will not be available and
-  //numbers will be formatted with default precision.
+  // Note: if context is empty (dataToLongTermAverageGraph was called with only
+  // one time series), variable-determined precision will not be available and
+  // numbers will be formatted with default precision.
   const precision = makePrecisionBySeries(seriesVariables);
-  let c3Tooltip = {format: {}};
-  c3Tooltip.grouped = "true";
+  let c3Tooltip = { format: {} };
+  c3Tooltip.grouped = 'true';
   c3Tooltip.format.value = makeTooltipDisplayNumbersWithUnits(c3Data.axes, c3Axis, precision);
-  
+
   return {
     data: c3Data,
     tooltip: c3Tooltip,
     axis: c3Axis,
-    line: c3Line
-  }; 
-};
-
-/*
- * Helper function for dataToLongTermAverageGraph. Extracts the
- * list of all unique timestamps found in the data.
- */
-function getAllTimestamps (data) {
-  let allTimes = [];
-
-  const addSeries = function(seriesData) {
-    for(let timestamp in seriesData) {
-      if(!_.find(allTimes, function(t){return t== timestamp;})) {
-        allTimes.push(timestamp);
-      }
-    }
+    line: c3Line,
   };
+}
 
-  for(let i in _.keys(data)) {
-    if(!_.isUndefined(data[i].data)) { //data is from "timeseries" API
-      addSeries(data[i].data);
-    }
-    else { //data is from "data" API
-      for(let run in data[i]) {
-        addSeries(data[i][run].data);
-      }
-    }
-  }
-  if (allTimes.length === 0) {
-    throw new Error("Error: no time stamps in data");
-  }
-  return allTimes;
-};
-
-/* 
- * Helper function for dataToLongTermAverageGraph. Examines
- * the query context for multiple API calls to the "data" 
- * API and determines which possible query parameters 
- * (model, variable, emission, or timescale) vary by query.
- * 
- * Returns a function that prefixes the "run" parameter
- * from each API call with the parameters that vary between that 
- * specific run's call and other calls being graphed at the same time. 
- * Example: "tasmax r1i1p1" vs "pr r1i1p1"
- */
-function nameAPICallParametersFunction (contexts) {
-  
-  let variation = [];
-  const exemplarContext = contexts[0];
-  
-  for (let context of contexts) {
-    for(let att in context) {
-      if(exemplarContext[att] != context[att] && variation.indexOf(att) == -1) {
-        variation.push(att);
-      }
-    }
-  }
-  
-  //"data" API was called more than once with the same arguments -
-  // probably a mistake.
-  if(variation.length === 0) {
-    throw new Error("Error: cannot graph two identical queries");
-  }
-  
-  //an "area" is just a list of points. The naive algorithm used to generate
-  //data series names here would just display the entire list next to each 
-  //data series in the graph legend, which would be unhelpful, and an invalid 
-  //series name as far as C3 is concerned. At present, throw an error 
-  //if attempting to graph data series associated with different areas. If 
-  //this functionality is needed in the future, it can be implemented here.
-  if(variation.indexOf("area") != -1) {
-    throw new Error("Error: cannot display two datasets associated with different areas.");
-  }
-  
-  return function (run, context) {
-    let name = "";
-    for(let v of variation) {
-      name = name.concat(`${context[v]} `);
-    }
-    name = name.concat(run);
-    return name;
-  };  
-};
-
-/*
- * Helper constant for dataToLongTermAverageGraph: Format object 
- * for a timeseries X axis.
- */
-const timeseriesXAxis = {
-    type: 'timeseries',
-    tick: {
-      format: '%Y-%m-%d'
-    }
-};
-
-/**************************************************************
+/* ************************************************************
  * 3. timeseriesToTimeseriesGraph
  **************************************************************/
 
-/* 
+/*
  * timeseriesToTimeseriesGraph()
  * This function takes one or more JSON objects from the
  * "timeseries" API call with this format:
@@ -633,107 +615,104 @@ const timeseriesXAxis = {
  * Accepts an arbitrary number of data objects, but no more than
  * two separate unit types.
  */
-function timeseriesToTimeseriesGraph (metadata, ...data) {
-  //blank graph data object to be populated - holds data values
-  //and individual-timeseries-level display options.
+function timeseriesToTimeseriesGraph(metadata, ...data) {
+  // blank graph data object to be populated - holds data values
+  // and individual-timeseries-level display options.
   let c3Data = {
-      columns: [],
-      types: {},
-      labels: {},
-      axes: {}
+    columns: [],
+    types: {},
+    labels: {},
+    axes: {},
   };
 
-  let yUnits = "";
-  let y2Units = "";
-  let yVariable = "";
-  let y2Variable = "";
+  let yUnits = '';
+  let y2Units = '';
+  let yVariable = '';
+  let y2Variable = '';
   let seriesVariables = {};
 
   const getTimeseriesName = shortestUniqueTimeseriesNamingFunction(metadata, data);
 
-  //get list of all timestamps
+  // get list of all timestamps
   const timestamps = getAllTimestamps(data);
   c3Data.columns.push(['x'].concat(_.map(timestamps, extendedDateToBasicDate)));
-  c3Data.x = "x";
+  c3Data.x = 'x';
 
-  //Add each timeseries to the graph
-  for(let timeseries of data) {
-    //get metadata for this timeseries
-    const timeseriesMetadata = _.find(metadata, function(m) {return m.unique_id === timeseries.id;});
+  // Add each timeseries to the graph
+  for (let timeseries of data) {
+    // get metadata for this timeseries
+    const timeseriesMetadata = _.find(metadata,
+        function (m) {return m.unique_id === timeseries.id;});
     const timeseriesName = getTimeseriesName(timeseriesMetadata);
     const seriesVariable = timeseriesMetadata.variable_id;
     seriesVariables[timeseriesName] = seriesVariable;
 
-    //add the actual data to the graph
+    // add the actual data to the graph
     let column = [timeseriesName];
 
-    for(let t of timestamps) {
-      //assigns "null" for any timestamps missing from this series.
-      //C3's behaviour toward null values is set by the line.connectNull attribute
+    for (let t of timestamps) {
+      // assigns "null" for any timestamps missing from this series.
+      // C3's behaviour toward null values is set by the line.connectNull attribute
       column.push(_.isUndefined(timeseries.data[t]) ? null : timeseries.data[t]);
     }
 
     c3Data.columns.push(column);
-    c3Data.types[timeseriesName] = "line";
+    c3Data.types[timeseriesName] = 'line';
 
-    //Each timeseries needs to be associated with a y-axis
-    //by variable. Only two variables are allowed at present -
+    // Each timeseries needs to be associated with a y-axis
+    // by variable. Only two variables are allowed at present -
     // more than two y-axes is too hard to read.
-    if(!yVariable) {
-      //create new primary axis
+    if (!yVariable) {
+      // create new primary axis
       yVariable = seriesVariable;
       yUnits = timeseries.units;
-      c3Data.axes[timeseriesName] = "y";
-    }
-    else if (yVariable === seriesVariable) {
-      //add series to existing primary axis
-      if(timeseries.units != yUnits) {
-        throw new Error("Error: mismatched units for " + yVariable);
+      c3Data.axes[timeseriesName] = 'y';
+    } else if (yVariable === seriesVariable) {
+      // add series to existing primary axis
+      if (timeseries.units !== yUnits) {
+        throw new Error('Error: mismatched units for ' + yVariable);
       }
-      c3Data.axes[timeseriesName] = "y";
-    }
-    else if (!y2Variable) {
-      //create new secondary axis
+      c3Data.axes[timeseriesName] = 'y';
+    } else if (!y2Variable) {
+      // create new secondary axis
       y2Variable = seriesVariable;
       y2Units = timeseries.units;
-      c3Data.axes[timeseriesName] = "y2";
-    }
-    else if (y2Variable === seriesVariable) {
-      //add series to existing secondary axis
-      if(timeseries.units != y2Units) {
-        throw new Error("Error: mismatched units for " + y2Variable);
+      c3Data.axes[timeseriesName] = 'y2';
+    } else if (y2Variable === seriesVariable) {
+      // add series to existing secondary axis
+      if (timeseries.units !== y2Units) {
+        throw new Error('Error: mismatched units for ' + y2Variable);
       }
-      c3Data.axes[timeseriesName] = "y2";
-    }
-    else {
-      //a problem: we already have two variables axes; third disallowed
-      throw new Error("Error: too many data axes required for graph");
+      c3Data.axes[timeseriesName] = 'y2';
+    } else {
+      // already have two axes, throw an error.
+      throw new Error('Error: too many data axes required for graph');
     }
   }
- 
-  //whole-graph display options: axis formatting and tooltip behaviour
+
+  // whole-graph display options: axis formatting and tooltip behaviour
   let c3Axis = {};
   c3Axis.x = timeseriesXAxis;
   c3Axis.y = formatYAxis(`${yVariable} ${yUnits}`);
-  if(y2Units) {
+  if (y2Units) {
     c3Axis.y2 = formatYAxis(`${y2Variable} ${y2Units}`);
-    }
+  }
 
-  const c3Subchart = {show: true,
-      size: {height: 20} };
+  const c3Subchart = { show: true,
+      size: { height: 20 } };
 
-  //instructs c3 to connect series across gaps where a timeseries is missing
-  //a timestamp. While this could be confusing in cases where a datapoint
-  //is actually missing from a series, it's helpful in cases where
-  //series are at different time resolutions (monthly/yearly), so it's
-  //included by default.
+  // instructs c3 to connect series across gaps where a timeseries is missing
+  // a timestamp. While this could be confusing in cases where a datapoint
+  // is actually missing from a series, it's helpful in cases where
+  // series are at different time resolutions (monthly/yearly), so it's
+  // included by default.
   const c3Line = {
-      connectNull: true
+    connectNull: true,
   };
 
   const precision = makePrecisionBySeries(seriesVariables);
-  let c3Tooltip = {format: {}};
-  c3Tooltip.grouped = "true";
+  let c3Tooltip = { format: {} };
+  c3Tooltip.grouped = 'true';
   c3Tooltip.format.value = makeTooltipDisplayNumbersWithUnits(c3Data.axes, c3Axis, precision);
 
   return {
@@ -741,13 +720,13 @@ function timeseriesToTimeseriesGraph (metadata, ...data) {
     subchart: c3Subchart,
     tooltip: c3Tooltip,
     axis: c3Axis,
-    line: c3Line
-  }; 
-};
+    line: c3Line,
+  };
+}
 
 module.exports = { timeseriesToAnnualCycleGraph, dataToLongTermAverageGraph,
     timeseriesToTimeseriesGraph,
-    //exported only for testing purposes:
+    // exported only for testing purposes:
     formatYAxis, fixedPrecision, makePrecisionBySeries, makeTooltipDisplayNumbersWithUnits,
     getMonthlyData, shortestUniqueTimeseriesNamingFunction,
-    getAllTimestamps, nameAPICallParametersFunction};
+    getAllTimestamps, nameAPICallParametersFunction };

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -245,9 +245,12 @@ function makeAnomalyGraph (base, variable_id, graph) {
   }
   graph.axis.y2.label = {};
   graph.axis.y2.label.position = 'outer-middle';
+  
+  let oldAxisText = getAxisTextForVariable(graph, baseSeriesName);
+  oldAxisText = oldAxisText.replace(variable_id, ""); // avoid repetition with base series name 
   graph.axis.y2.label.text = displayPercent ?
       `% change from ${baseSeriesName}` :
-      `change in ${getAxisTextForVariable(graph, baseSeriesName)} from ${baseSeriesName}`;
+      `change in ${oldAxisText} from ${baseSeriesName}`;
   graph.axis.y2.tick = {};
   graph.axis.y2.tick.format = graph.axis.y.tick.format;
   

--- a/variable-options.yaml
+++ b/variable-options.yaml
@@ -26,14 +26,26 @@
 #        be expressed as percentages, not nominal values, in
 #        graphs and tables that display anomalies
 #        (default: false)
+#   - shiftAnnualCycle
+#        LIST OF VARIABLE NAMES
+#        if this variable is displayed for comparison with one
+#        of the variables in the list in an Annual Cycle Graph,
+#        their lines will be shifted apart vertically. This helps
+#        clarify variables whose values move in parallel over the
+#        course of a year, such as tasmax and tasmin.
+#        (default: none)
 ################################################################
 
 #GCM output variables
 tasmin:
   decimalPrecision: 1
+  shiftAnnualCycle:
+    - tasmax
   
 tasmax:
   decimalPrecision: 1
+  shiftAnnualCycle:
+    - tasmin
 
 pr:
   overrideLogarithmicScale: true


### PR DESCRIPTION
This PR fixes #107 .

Previously, when generating graphs of variables, any two variables that had the same units would be shown with the same scale. This led to graphs like this, where the number of icing days and the number of tropical days - both measured with the unit "days" - have different magnitudes:

![days](https://user-images.githubusercontent.com/4512605/49041631-90a77d80-f17a-11e8-9477-4807d9ef9c48.png)

Now, by default, different variables are automatiucally scaled to take up the entire vertical range of the graph and shown with different y-axes even if they have the same units. Here's the same data, with the new layout:

![trvsid2](https://user-images.githubusercontent.com/4512605/49041729-df551780-f17a-11e8-9c7a-f921a116903c.png)

Axis labels now explicitly include the variable if each axis represents a separate variable

Minor associated changes:
* As Y-axis formatting got more complicated, moved it into a helper function that each graph generator calls
* Linted chart-generators.js
* Updated tests and chart transformation functions that work with axis formatting