### PR TITLE
Limit geometry to one active polygon

### DIFF
--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -301,22 +301,15 @@ class DataMap extends React.Component {
           {...this.props.isoline}  // update when any isoline prop changes
         />
 
-        <StaticControl position='topleft'>
-          {
-            allowGeometryDraw &&
-            <GeoLoader
-              onLoadArea={this.handleUploadArea}
-              title='Import polygon'
-            />
-          }
-          { // See comments at module head regarding current GeoExporter
-            // arrangement.
-          }
-          <GeoExporter
-            area={this.layersToArea(this.state.geometryLayers)}
-            title='Export polygon'
-          />
-        </StaticControl>
+        {
+          allowGeometryDraw &&
+          <StaticControl position='topleft'>
+              <GeoLoader
+                onLoadArea={this.handleUploadArea}
+                title='Import polygon'
+              />
+          </StaticControl>
+        }
 
         <LayerControlledFeatureGroup
           layers={this.state.geometryLayers}
@@ -342,6 +335,18 @@ class DataMap extends React.Component {
             onDeleted={this.handleAreaDeleted}
           />
         </LayerControlledFeatureGroup>
+
+        {
+          // See comments at module head regarding current GeoExporter
+          // arrangement.
+          !allowGeometryDraw &&
+          <StaticControl position='topleft'>
+              <GeoExporter
+                area={this.layersToArea(this.state.geometryLayers)}
+                title='Export polygon'
+              />
+          </StaticControl>
+        }
 
         { this.props.children }
 

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -265,6 +265,8 @@ class DataMap extends React.Component {
       )
     ));
 
+    const allowGeometryDraw = this.state.geometryLayers.length === 0;
+
     return (
       <CanadaBaseMap
         mapRef={this.handleMapRef}
@@ -285,6 +287,20 @@ class DataMap extends React.Component {
           {...this.props.isoline}  // update when any isoline prop changes
         />
 
+        <StaticControl position='topleft'>
+          <GeoLoader
+            onLoadArea={this.handleUploadArea}
+            title='Import polygon'
+          />
+          { // See comments at module head regarding current GeoExporter
+            // arrangement.
+          }
+          <GeoExporter
+            area={this.layersToArea(this.state.geometryLayers)}
+            title='Export polygon'
+          />
+        </StaticControl>
+
         <LayerControlledFeatureGroup
           layers={this.state.geometryLayers}
         >
@@ -295,11 +311,11 @@ class DataMap extends React.Component {
               circlemarker: false,
               circle: false,
               polyline: false,
-              polygon: {
+              polygon: allowGeometryDraw && {
                 showArea: false,
                 showLength: false,
               },
-              rectangle: {
+              rectangle: allowGeometryDraw && {
                 showArea: false,
                 showLength: false,
               },
@@ -309,23 +325,6 @@ class DataMap extends React.Component {
             onDeleted={this.handleAreaDeleted}
           />
         </LayerControlledFeatureGroup>
-
-        <StaticControl position='topleft'>
-          <GeoLoader
-            onLoadArea={this.handleUploadArea}
-            title='Import polygon'
-          />
-        </StaticControl>
-
-        <StaticControl position='topleft'>
-          { // See comments at module head regarding current GeoExporter
-            // arrangement.
-          }
-          <GeoExporter
-            area={this.layersToArea(this.state.geometryLayers)}
-            title='Export polygon'
-          />
-        </StaticControl>
 
         { this.props.children }
 

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -99,14 +99,14 @@ class DataMap extends React.Component {
     annotated: layerParamsPropTypes,
     area: PropTypes.object,
     onSetArea: PropTypes.func.isRequired,
-    activeGeometryColor: PropTypes.string.isRequired,
-    inactiveGeometryColor: PropTypes.string.isRequired,
+    activeGeometryStyle: PropTypes.string.isRequired,
+    inactiveGeometryStyle: PropTypes.string.isRequired,
     children: PropTypes.node,
   };
 
   static defaultProps = {
-    activeGeometryColor: '#3388ff',
-    inactiveGeometryColor: '#777777',
+    activeGeometryStyle: { color: '#3388ff' },
+    inactiveGeometryStyle: { color: '#777777' },
   };
 
   constructor(props) {
@@ -203,8 +203,8 @@ class DataMap extends React.Component {
   };
 
   layerStyle = (index) => index > 0 ?
-    { color: this.props.inactiveGeometryColor } :
-    { color: this.props.activeGeometryColor };
+    this.props.inactiveGeometryStyle :
+    this.props.activeGeometryStyle;
 
   addGeometryLayer = layer => {
     this.setState(prevState => {

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -99,7 +99,14 @@ class DataMap extends React.Component {
     annotated: layerParamsPropTypes,
     area: PropTypes.object,
     onSetArea: PropTypes.func.isRequired,
+    activeGeometryColor: PropTypes.string.isRequired,
+    inactiveGeometryColor: PropTypes.string.isRequired,
     children: PropTypes.node,
+  };
+
+  static defaultProps = {
+    activeGeometryColor: '#3388ff',
+    inactiveGeometryColor: '#777777',
   };
 
   constructor(props) {
@@ -195,10 +202,15 @@ class DataMap extends React.Component {
     this.props.onSetArea(this.layersToArea(this.state.geometryLayers));
   };
 
+  layerStyle = (index) => index > 0 ?
+    { color: this.props.inactiveGeometryColor } :
+    { color: this.props.activeGeometryColor };
+
   addGeometryLayer = layer => {
-    this.setState(prevState => ({
-      geometryLayers: prevState.geometryLayers.concat([layer]),
-    }), this.onSetArea);
+    this.setState(prevState => {
+      layer.setStyle(this.layerStyle(prevState.geometryLayers.length));
+      return { geometryLayers: prevState.geometryLayers.concat([layer]) };
+    }, this.onSetArea);
   };
 
   addGeometryLayers = layers => {
@@ -218,9 +230,11 @@ class DataMap extends React.Component {
   };
 
   deleteGeometryLayers = layers => {
-    this.setState(prevState => ({
-      geometryLayers: _.without(prevState.geometryLayers, ...layers),
-    }), this.onSetArea);
+    this.setState(prevState => {
+      const geometryLayers = _.without(prevState.geometryLayers, ...layers);
+      geometryLayers.forEach((layer, i) => layer.setStyle(this.layerStyle(i)));
+      return { geometryLayers };
+    }, this.onSetArea);
   };
 
   eventLayers = e => {

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -302,10 +302,13 @@ class DataMap extends React.Component {
         />
 
         <StaticControl position='topleft'>
-          <GeoLoader
-            onLoadArea={this.handleUploadArea}
-            title='Import polygon'
-          />
+          {
+            allowGeometryDraw &&
+            <GeoLoader
+              onLoadArea={this.handleUploadArea}
+              title='Import polygon'
+            />
+          }
           { // See comments at module head regarding current GeoExporter
             // arrangement.
           }

--- a/src/components/GeoExporter/GeoExporterButton.js
+++ b/src/components/GeoExporter/GeoExporterButton.js
@@ -4,7 +4,7 @@ import { Button, Glyphicon } from 'react-bootstrap';
 
 export default function (props) {
   return (
-    <Button onClick={props.open} title={props.title}>
+    <Button bsSize='small' onClick={props.open} title={props.title}>
       <Glyphicon glyph='save-file'/>
     </Button>
   );

--- a/src/components/GeoLoader/GeoLoaderButton.js
+++ b/src/components/GeoLoader/GeoLoaderButton.js
@@ -4,7 +4,7 @@ import { Button, Glyphicon } from 'react-bootstrap';
 
 export default function GeoloaderButton(props) {
   return (
-    <Button onClick={props.open} title={props.title}>
+    <Button bsSize='small' onClick={props.open} title={props.title}>
       <Glyphicon glyph='open-file'/>
     </Button>
   );

--- a/src/components/GeoLoader/GeoLoaderMainDialog.js
+++ b/src/components/GeoLoader/GeoLoaderMainDialog.js
@@ -36,14 +36,23 @@ export default class GeoloaderMainDialog extends React.Component {
         </Modal.Header>
   
         <Modal.Body>
-          <FormControl
-            type='file'
-            label='Select file'
-            onChange={(e) => this.importPolygon(e.currentTarget.files[0])}
-          />
           <p>
-            Accepts a zipped Shapefile or a GeoJSON file containing a
+            <FormControl
+              type='file'
+              label='Select file'
+              onChange={(e) => this.importPolygon(e.currentTarget.files[0])}
+            />
+          </p>
+          <p>
+            We recommend importing only a file containing a
             single Feature (not a FeatureCollection).
+          </p>
+          <p>
+            If you import a file containing multiple features,
+            only the first feature (in the internal order within the file)
+            will become active and be used to form spatial averages.
+            The active feature is coloured blue.
+            Inactive features are coloured grey.
           </p>
         </Modal.Body>
   


### PR DESCRIPTION
Resolves #184 

This PR implements the following behaviours:

- Allow only one geometry (polygon) to be drawn. 
- Disable drawing controls and import control when one or more geometries are present.
- If more than one geometry  is imported (e.g., from a file containing a GeoJSON FeatureCollection), then only the first (in order of importation) will be "active", meaning that only the first geometry will be used to form spatial data averages. 
- Color inactive geometries grey (as opposed to default blue for active geometry). This is simple to implement and avoids confusing users with the effect of importing only part of a file.
- Polygon export tool exports only the active geometry.
- Disable polygon export tool when no geometries are present.