### PR TITLE
Allow users to change opacity on climate layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-bootstrap": "^0.32.0",
     "react-bootstrap-table": "^4.3.1",
     "react-dom": "^16.6.3",
+    "react-input-range": "^1.3.0",
     "react-leaflet": "^2.0.0",
     "react-leaflet-draw": "^0.19.0",
     "react-router-bootstrap": "^0.24.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
       "CE_ENSEMBLE_NAME": "ce",
       "CE_CURRENT_VERSION": "Climate Explorer test version"
     },
+    "moduleNameMapper": {
+      "\\.(png|jpg|gif|ttf|eot|svg)$": "<rootDir>/test_support/jest/__mocks__/fileMock.js"
+    },
     "unmockedModulePathPatterns": [
       "fbjs",
       "react",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "PCIC Climate Explorer front end application",
   "main": "index.js",
   "scripts": {
+    "reinstall": "rm -rf ./node_modules && npm install",
     "prestart": "if [ ! -f ./variable-options.yaml ]; then touch ./variable-options.yaml; fi",
     "start": "CE_BACKEND_URL=https://services.pacificclimate.org/marmot/api NCWMS_URL=https://services.pacificclimate.org/marmot/ncwms TILECACHE_URL=https://tiles.pacificclimate.org/tilecache/tilecache.py CE_ENSEMBLE_NAME=all_downscale_files CE_CURRENT_VERSION=$(./generate-commitish.sh) webpack-dev-server --host 0.0.0.0 --history-api-fallback",
     "build": "webpack --progress --colors",

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -21,6 +21,7 @@ import About from '../guidance-content/about/About';
 import logo from '../../assets/logo.png';
 import marmot from '../../assets/marmot.png';
 import styles from './App.css';
+import '!style!css!react-input-range/lib/css/index.css';
 
 
 export default class App extends React.Component {

--- a/src/components/DataMap/DataLayer.js
+++ b/src/components/DataMap/DataLayer.js
@@ -2,9 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { WMSTileLayer } from 'react-leaflet';
-import { getIsolineWMSParams, getRasterWMSParams, getAnnotatedWMSParams } from '../../data-services/ncwms';
-import _ from "underscore";
-import {layerParamsPropTypes} from '../../types/types.js';
+import {
+  getIsolineWMSParams, getRasterWMSParams, getAnnotatedWMSParams,
+} from '../../data-services/ncwms';
+import _ from 'underscore';
+import { layerParamsPropTypes } from '../../types/types.js';
 
 export default class DataLayer extends React.Component {
   static propTypes = {
@@ -30,7 +32,7 @@ export default class DataLayer extends React.Component {
     const wmsParams = {
       raster: getRasterWMSParams,
       isoline: getIsolineWMSParams,
-      annotated: getAnnotatedWMSParams
+      annotated: getAnnotatedWMSParams,
     }[layerType](layerParams);
 
     if (layerParams && layerParams.dataset) {

--- a/src/components/DataMap/DataMap.css
+++ b/src/components/DataMap/DataMap.css
@@ -1,0 +1,3 @@
+:global(.leaflet-top.leaflet-right) {
+    margin-right: 70px;
+}

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -104,7 +104,6 @@ class DataMap extends React.Component {
     onSetArea: PropTypes.func.isRequired,
     activeGeometryStyle: PropTypes.string.isRequired,
     inactiveGeometryStyle: PropTypes.string.isRequired,
-    defaultLayerOpacity: PropTypes.object.isRequired,
     children: PropTypes.node,
   };
 

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -74,12 +74,14 @@ import _ from 'underscore';
 
 import 'proj4';
 import 'proj4leaflet';
+import { LayersControl } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
 
 import GeoLoader from '../GeoLoader';
 import GeoExporter from '../GeoExporter';
 
 import './DataMap.css';
+
 import { getLayerMinMax } from '../../data-services/ncwms';
 import { makeHandleLeafletRef } from '../../core/react-leaflet-utils';
 import CanadaBaseMap from '../CanadaBaseMap';
@@ -271,11 +273,16 @@ class DataMap extends React.Component {
 
     const dataLayers = ['raster', 'isoline', 'annotated'].map(layerType => (
       this.props[layerType] && (
-        <DataLayer
-          layerType={layerType}
-          layerParams={this.props[layerType]}
-          onLayerRef={this.handleLayerRef.bind(this, layerType)}
-        />
+        <LayersControl.Overlay
+          name={`Climate ${layerType}`}
+          checked={true}
+        >
+          <DataLayer
+            layerType={layerType}
+            layerParams={this.props[layerType]}
+            onLayerRef={this.handleLayerRef.bind(this, layerType)}
+          />
+        </LayersControl.Overlay>
       )
     ));
 
@@ -285,7 +292,9 @@ class DataMap extends React.Component {
       <CanadaBaseMap
         mapRef={this.handleMapRef}
       >
-        {dataLayers}
+        <LayersControl>
+          {dataLayers}
+        </LayersControl>
 
         <NcWMSColorbarControl
           layer={this.state.rasterLayer}

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -74,14 +74,12 @@ import _ from 'underscore';
 
 import 'proj4';
 import 'proj4leaflet';
-import { LayersControl } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
 
 import GeoLoader from '../GeoLoader';
 import GeoExporter from '../GeoExporter';
 
 import './DataMap.css';
-
 import { getLayerMinMax } from '../../data-services/ncwms';
 import { makeHandleLeafletRef } from '../../core/react-leaflet-utils';
 import CanadaBaseMap from '../CanadaBaseMap';
@@ -293,19 +291,14 @@ class DataMap extends React.Component {
 
     const dataLayers = DataMap.layerTypes.map(layerType => (
       this.props[layerType] && (
-        <LayersControl.Overlay
-          name={`Climate ${layerType} layer`}
-          checked={true}
-        >
-          <DataLayer
-            layerType={layerType}
-            layerParams={{
-              ...this.props[layerType],
-              opacity: this.state.layerOpacity[layerType],
-            }}
-            onLayerRef={this.handleLayerRef.bind(this, layerType)}
-          />
-        </LayersControl.Overlay>
+        <DataLayer
+          layerType={layerType}
+          layerParams={{
+            ...this.props[layerType],
+            opacity: this.state.layerOpacity[layerType],
+          }}
+          onLayerRef={this.handleLayerRef.bind(this, layerType)}
+        />
       )
     ));
 
@@ -315,9 +308,7 @@ class DataMap extends React.Component {
       <CanadaBaseMap
         mapRef={this.handleMapRef}
       >
-        <LayersControl>
-          {dataLayers}
-        </LayersControl>
+        {dataLayers}
 
         <LayerOpacityControl
           layerOpacity={this.state.layerOpacity}

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -100,8 +100,8 @@ class DataMap extends React.Component {
     annotated: layerParamsPropTypes,
     area: PropTypes.object,
     onSetArea: PropTypes.func.isRequired,
-    activeGeometryStyle: PropTypes.string.isRequired,
-    inactiveGeometryStyle: PropTypes.string.isRequired,
+    activeGeometryStyle: PropTypes.object.isRequired,
+    inactiveGeometryStyle: PropTypes.object.isRequired,
     children: PropTypes.node,
   };
 

--- a/src/components/LayerOpacityControl/LayerOpacityControl.css
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.css
@@ -3,7 +3,8 @@
 /*}*/
 
 :global(.LayerOpacityControl .row) {
-    padding: 0.5em 0
+    line-height: 1.0em;
+    padding: 0.8em 0
 }
 
 :global(.LayerOpacityControl .input-range) {

--- a/src/components/LayerOpacityControl/LayerOpacityControl.css
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.css
@@ -4,7 +4,7 @@
 
 :global(.LayerOpacityControl .row) {
     line-height: 1.0em;
-    padding: 0.8em 0
+    padding: 0.8em 0em;
 }
 
 :global(.LayerOpacityControl .input-range) {

--- a/src/components/LayerOpacityControl/LayerOpacityControl.css
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.css
@@ -1,0 +1,30 @@
+/*:global(.LayerOpacityControl) {*/
+    /*width: 200px;*/
+/*}*/
+
+:global(.LayerOpacityControl .row) {
+    padding: 0.5em 0
+}
+
+:global(.LayerOpacityControl .input-range) {
+    height: 1.8em;
+    margin: 0em 0em 0.5em 0.5em;
+    width: 10em;
+}
+
+:global(.LayerOpacityControl .input-range__label) {
+    color: inherit;
+    font-family: inherit;
+    font-size: 90%;
+}
+
+
+:global(.LayerOpacityControl .input-range__label--min),
+:global(.LayerOpacityControl .input-range__label--max)
+{
+    bottom: -0.9em;
+}
+
+:global(.LayerOpacityControl .input-range__label--value) {
+    top: -2em;
+}

--- a/src/components/LayerOpacityControl/LayerOpacityControl.css
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.css
@@ -1,10 +1,23 @@
-/*:global(.LayerOpacityControl) {*/
-    /*width: 200px;*/
-/*}*/
+:global(.LayerOpacityControl .layer-controls-container) {
+    margin: 0 1em;
+}
 
-:global(.LayerOpacityControl .row) {
-    line-height: 1.0em;
-    padding: 0.8em 0em;
+:global(.LayerOpacityControl .layer-controls) {
+    padding-top: 0.8em;
+    padding-bottom: 0.8em;
+}
+
+:global(.LayerOpacityControl .layer-identifier) {
+    font-weight: bold;
+    text-align: center;
+}
+
+:global(.LayerOpacityControl .opacity) {
+    margin-top: 0.6em;
+}
+
+:global(.LayerOpacityControl .opacity-icon) {
+    top: 0.2em;
 }
 
 :global(.LayerOpacityControl .input-range) {

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Row, Col } from 'react-bootstrap';
+import { Grid, Row, Col, Button, Glyphicon } from 'react-bootstrap';
 
 import InputRange from 'react-input-range';
 
@@ -25,8 +25,6 @@ export default class LayerOpacityControl extends PureComponent {
     handleMouseLeave = () => this.setState({ showControls: false });
 
     render() {
-      const show = this.state.showControls;
-      const titleSep = show ? ' ' : <br/>;
       return (
         <StaticControl position={'topright'}>
           <div
@@ -34,31 +32,39 @@ export default class LayerOpacityControl extends PureComponent {
             onMouseEnter={this.handleMouseEnter}
             onMouseLeave={this.handleMouseLeave}
           >
-            <Grid fluid>
-              <Row>
-                <Col lg={12} className='text-center'>
-                  Climate{titleSep}layer{titleSep}opacity
-                </Col>
-              </Row>
-              {
-                show &&
-                Object.entries(this.props.layerOpacity).map(
-                  ([layerType, opacity]) => (
-                    <Row key={layerType}>
-                      <Col lg={3}>{layerType}</Col>
-                      <Col lg={8}>
-                        <InputRange
-                          minValue={0} maxValue={1} step={0.05}
-                          formatLabel={value => `${(value*100).toFixed(0)}%`}
-                          value={opacity}
-                          onChange={this.props.onChange.bind(this, layerType)}
-                        />
-                      </Col>
-                    </Row>
-                  )
-                )
-              }
-            </Grid>
+            {
+              this.state.showControls ?
+              (
+                <Grid fluid>
+                  <Row>
+                    <Col lg={12} className='text-center'>
+                      Climate layer opacity
+                    </Col>
+                  </Row>
+                  {
+                    Object.entries(this.props.layerOpacity).map(
+                      ([layerType, opacity]) => (
+                        <Row key={layerType}>
+                          <Col lg={3}>{layerType}</Col>
+                          <Col lg={8}>
+                            <InputRange
+                              minValue={0} maxValue={1} step={0.05}
+                              formatLabel={value => `${(value*100).toFixed(0)}%`}
+                              value={opacity}
+                              onChange={this.props.onChange.bind(this, layerType)}
+                            />
+                          </Col>
+                        </Row>
+                      )
+                    )
+                  }
+                </Grid>
+              ) : (
+                <Button bsSize='small'>
+                  <Glyphicon glyph='adjust' />
+                </Button>
+              )
+            }
           </div>
         </StaticControl>
       );

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -143,17 +143,20 @@ export default class LayerOpacityControl extends PureComponent {
             true || this.state.showControls ?
             (
               <Grid fluid className='layer-controls-container'>
-                <Row className='layer-controls'>
-                  <Col lg={1} className='visibility-toggle'>
-                    <LayerVisibilityButton
-                      layerVisibility={!this.state.allLayersVisible}
-                      onClick={this.toggleAllLayersVisiblility}
-                    />
-                  </Col>
-                  <Col lg={10} className='layer-identifier'>
-                    All climate layers
-                  </Col>
-                </Row>
+                {
+                  _.keys(this.props.layerOpacity).length > 1 &&
+                  <Row className='layer-controls'>
+                    <Col lg={1} className='visibility-toggle'>
+                      <LayerVisibilityButton
+                        layerVisibility={!this.state.allLayersVisible}
+                        onClick={this.toggleAllLayersVisiblility}
+                      />
+                    </Col>
+                    <Col lg={10} className='layer-identifier'>
+                      All climate layers
+                    </Col>
+                  </Row>
+                }
                 {layerVisibilityControls}
               </Grid>
             ) : (

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -40,6 +40,9 @@ export default class LayerOpacityControl extends PureComponent {
     // If no visibility change, do nothing.
     // If hiding layer, save its current opacity, then set its opacity to 0.
     // If showing layer, restore its saved opacity.
+    //
+    // Update the all-layers toggling state if we go to all hidden
+    // or all visible.
 
     const nextVisible = _.isBoolean(visible) ?
       visible : !this.state.layerState[layerType].visible;
@@ -58,16 +61,30 @@ export default class LayerOpacityControl extends PureComponent {
     );
 
     // Update layer's visibility state: Set visibility flag to next visibility,
-    // store current opacity.
-    this.setState(prevState => ({
-      layerState: {
+    // store current opacity for restoration later.
+
+    this.setState(prevState => {
+      const layerState = {
         ...prevState.layerState,
         [layerType]: {
           visible: nextVisible,
           prevOpacity: currentOpacity,
         },
-      },
-    }));
+      };
+
+      // If we're now showing all layers, change all-layers toggling accordingly
+      if (_.every(layerState, 'visible')) {
+        return { layerState, allLayersVisible: true };
+      }
+
+      // If we're now hiding all layers, change all-layers toggling accordingly
+      if (!_.some(layerState, 'visible')) {
+        return { layerState, allLayersVisible: false };
+      }
+
+      // Otherwise don't mess with the all-layers toggling state
+      return { layerState };
+    });
   };
 
   toggleAllLayersVisiblility = () => {

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -157,7 +157,7 @@ export default class LayerOpacityControl extends PureComponent {
           onMouseLeave={this.handleMouseLeave}
         >
           {
-            true || this.state.showControls ?
+            this.state.showControls ?
             (
               <Grid fluid className='layer-controls-container'>
                 {

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -1,0 +1,70 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Grid, Row, Col } from 'react-bootstrap';
+
+import InputRange from 'react-input-range';
+
+import StaticControl from '../StaticControl';
+
+import './LayerOpacityControl.css';
+
+export default class LayerOpacityControl extends PureComponent {
+    static propTypes = {
+      layerOpacity: PropTypes.object.isRequired,
+      onChange: PropTypes.func.isRequired,
+    };
+
+    constructor(props) {
+      super(props);
+      this.state = {
+        showControls: false,
+      };
+    }
+
+    handleMouseEnter = () => this.setState({ showControls: true });
+    handleMouseLeave = () => this.setState({ showControls: false });
+
+    render() {
+      return (
+        <StaticControl position={'topright'}>
+          <div
+            className={'LayerOpacityControl'}
+            onMouseEnter={this.handleMouseEnter}
+            onMouseLeave={this.handleMouseLeave}
+          >
+            <Grid fluid>
+              <Row>
+                <Col lg={12}>Layer opacity</Col>
+              </Row>
+              {
+                this.state.showControls &&
+                Object.entries(this.props.layerOpacity).map(
+                  ([layerType, opacity]) => (
+                    <Row key={layerType}>
+                      <Col lg={3}>{layerType}</Col>
+                      <Col lg={8}>
+                        <InputRange
+                          minValue={0} maxValue={1} step={0.05}
+                          formatLabel={value => `${(value*100).toFixed(0)}%`}
+                          value={opacity}
+                          onChange={this.props.onChange.bind(this, layerType)}
+                        />
+                      </Col>
+                    </Row>
+                  )
+                )
+              }
+            </Grid>
+          </div>
+        </StaticControl>
+      );
+    }
+}
+
+LayerOpacityControl.propTypes = {
+  faderOpacity: PropTypes.number,
+  faderColor: PropTypes.string,
+  onChangeFaderOpacity: PropTypes.func.isRequired,
+  onChangeFaderColor: PropTypes.func.isRequired,
+};
+

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Grid, Row, Col, Button, Glyphicon } from 'react-bootstrap';
 
+import layersIcon from 'leaflet/dist/images/layers.png';
+
 import _ from 'underscore';
 
 import InputRange from 'react-input-range';
@@ -177,8 +179,8 @@ export default class LayerOpacityControl extends PureComponent {
                 {layerVisibilityControls}
               </Grid>
             ) : (
-              <Button bsSize='small'>
-                <Glyphicon glyph='adjust' />
+              <Button>
+                <img src={layersIcon}/>
               </Button>
             )
           }

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -9,64 +9,70 @@ import StaticControl from '../StaticControl';
 import './LayerOpacityControl.css';
 
 export default class LayerOpacityControl extends PureComponent {
-    static propTypes = {
-      layerOpacity: PropTypes.object.isRequired,
-      onChange: PropTypes.func.isRequired,
+  static propTypes = {
+    layerOpacity: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      showControls: false,
     };
+  }
 
-    constructor(props) {
-      super(props);
-      this.state = {
-        showControls: false,
-      };
-    }
+  handleMouseEnter = () => this.setState({ showControls: true });
+  handleMouseLeave = () => this.setState({ showControls: false });
 
-    handleMouseEnter = () => this.setState({ showControls: true });
-    handleMouseLeave = () => this.setState({ showControls: false });
-
-    render() {
-      return (
-        <StaticControl position={'topright'}>
-          <div
-            className={'LayerOpacityControl'}
-            onMouseEnter={this.handleMouseEnter}
-            onMouseLeave={this.handleMouseLeave}
-          >
-            {
-              this.state.showControls ?
-              (
-                <Grid fluid>
-                  <Row>
-                    <Col lg={12} className='text-center'>
-                      Climate layer opacity
-                    </Col>
-                  </Row>
-                  {
-                    Object.entries(this.props.layerOpacity).map(
-                      ([layerType, opacity]) => (
-                        <Row key={layerType}>
-                          <Col lg={3}>{layerType}</Col>
-                          <Col lg={8}>
-                            <InputRange
-                              minValue={0} maxValue={1} step={0.05}
-                              formatLabel={value => `${(value*100).toFixed(0)}%`}
-                              value={opacity}
-                              onChange={this.props.onChange.bind(this, layerType)}
-                            />
-                          </Col>
-                        </Row>
-                      )
+  render() {
+    return (
+      <StaticControl position={'topright'}>
+        <div
+          className={'LayerOpacityControl'}
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
+        >
+          {
+            this.state.showControls ?
+            (
+              <Grid fluid>
+                <Row>
+                  <Col lg={12} className='text-center'>
+                    Climate layer opacity
+                  </Col>
+                </Row>
+                {
+                  Object.entries(this.props.layerOpacity).map(
+                    ([layerType, opacity]) => (
+                      <Row key={layerType}>
+                        <Col lg={3}>{layerType}</Col>
+                        <Col lg={8}>
+                          <InputRange
+                            // step=0.0499 ensures can go up to 100%
+                            // presumed rounding error means 0.05 won't work
+                            minValue={0} maxValue={1} step={0.0499}
+                            formatLabel={
+                              value => `${(value*100).toFixed(0)}%`
+                            }
+                            value={opacity}
+                            onChange={
+                              this.props.onChange.bind(this, layerType)
+                            }
+                          />
+                        </Col>
+                      </Row>
                     )
-                  }
-                </Grid>
-              ) : (
-                <Button bsSize='small'>
-                  <Glyphicon glyph='adjust' />
-                </Button>
-              )
-            }
-          </div>
-        </StaticControl>
-      );
-    }
+                  )
+                }
+              </Grid>
+            ) : (
+              <Button bsSize='small'>
+                <Glyphicon glyph='adjust' />
+              </Button>
+            )
+          }
+        </div>
+      </StaticControl>
+    );
+  }
 }

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -25,6 +25,8 @@ export default class LayerOpacityControl extends PureComponent {
     handleMouseLeave = () => this.setState({ showControls: false });
 
     render() {
+      const show = this.state.showControls;
+      const titleSep = show ? ' ' : <br/>;
       return (
         <StaticControl position={'topright'}>
           <div
@@ -34,10 +36,12 @@ export default class LayerOpacityControl extends PureComponent {
           >
             <Grid fluid>
               <Row>
-                <Col lg={12}>Layer opacity</Col>
+                <Col lg={12} className='text-center'>
+                  Climate{titleSep}layer{titleSep}opacity
+                </Col>
               </Row>
               {
-                this.state.showControls &&
+                show &&
                 Object.entries(this.props.layerOpacity).map(
                   ([layerType, opacity]) => (
                     <Row key={layerType}>
@@ -60,11 +64,3 @@ export default class LayerOpacityControl extends PureComponent {
       );
     }
 }
-
-LayerOpacityControl.propTypes = {
-  faderOpacity: PropTypes.number,
-  faderColor: PropTypes.string,
-  onChangeFaderOpacity: PropTypes.func.isRequired,
-  onChangeFaderColor: PropTypes.func.isRequired,
-};
-

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Grid, Row, Col, Button, Glyphicon } from 'react-bootstrap';
 
+import _ from 'underscore';
+
 import InputRange from 'react-input-range';
 
 import StaticControl from '../StaticControl';
@@ -18,11 +20,40 @@ export default class LayerOpacityControl extends PureComponent {
     super(props);
     this.state = {
       showControls: false,
+      layerState: _.mapObject(props.layerOpacity, () => ({
+        visible: true,
+      })),
     };
   }
 
   handleMouseEnter = () => this.setState({ showControls: true });
   handleMouseLeave = () => this.setState({ showControls: false });
+  
+  toggleLayerVisibility = layerType => {
+    // If current layer is visible, save its current opacity, then hide it by
+    // setting its opacity to 0.
+    // If current layer is invisible, restore its saved opacity.
+
+    const currLayerVisible = this.state.layerState[layerType].visible;
+
+    // Update layer opacity according to visibility.
+    this.props.onChange(
+      layerType,
+      currLayerVisible ? 0 : this.state.layerState[layerType].prevOpacity
+    );
+
+    // Update layer's visibility state: Toggle visibility flag,
+    // store current opacity.
+    this.setState(prevState => ({
+      layerState: {
+        ...prevState.layerState,
+        [layerType]: {
+          visible: !currLayerVisible,
+          prevOpacity: this.props.layerOpacity[layerType],
+        },
+      },
+    }));
+  }
 
   formatLabel = value => `${(value*100).toFixed(0)}%`;
 
@@ -37,31 +68,53 @@ export default class LayerOpacityControl extends PureComponent {
           {
             this.state.showControls ?
             (
-              <Grid fluid>
-                <Row>
-                  <Col lg={12} className='text-center'>
-                    Climate layer opacity
-                  </Col>
-                </Row>
+              <Grid fluid className='layer-controls-container'>
                 {
                   Object.entries(this.props.layerOpacity).map(
-                    ([layerType, opacity]) => (
-                      <Row key={layerType}>
-                        <Col lg={3}>{layerType}</Col>
-                        <Col lg={8}>
-                          <InputRange
-                            // step=0.0499 ensures can go up to 100%
-                            // presumed rounding error means 0.05 won't work
-                            minValue={0} maxValue={1} step={0.0499}
-                            formatLabel={this.formatLabel}
-                            value={opacity}
-                            onChange={
-                              this.props.onChange.bind(this, layerType)
-                            }
-                          />
-                        </Col>
-                      </Row>
-                    )
+                    ([layerType, opacity]) => {
+                      const showLayer = this.state.layerState[layerType].visible;
+                      return (
+                        <Row key={layerType} className='layer-controls'>
+                          <Row>
+                            <Col lg={1} className='visibility-toggle'>
+                              <Button
+                                bsSize={'xsmall'}
+                                onClick={
+                                  this.toggleLayerVisibility.bind(this, layerType)
+                                }
+                              >
+                                <Glyphicon
+                                  glyph={showLayer ? 'eye-open' : 'eye-close'}
+                                />
+                              </Button>
+                            </Col>
+                            <Col lg={10} className='layer-identifier'>
+                              {`Climate ${layerType} layer`}
+                            </Col>
+                          </Row>
+                          {
+                            showLayer &&
+                            <Row className='opacity'>
+                              <Col lg={1} className='opacity-icon'>
+                                <Glyphicon glyph={'adjust'}/>
+                              </Col>
+                              <Col lg={10} className='opacity-control'>
+                                <InputRange
+                                  // step=0.0499 ensures can go up to 100%
+                                  // presumed rounding error means 0.05 won't work
+                                  minValue={0} maxValue={1} step={0.0499}
+                                  formatLabel={this.formatLabel}
+                                  value={opacity}
+                                  onChange={
+                                    this.props.onChange.bind(this, layerType)
+                                  }
+                                />
+                              </Col>
+                            </Row>
+                          }
+                        </Row>
+                      );
+                    }
                   )
                 }
               </Grid>

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -24,6 +24,8 @@ export default class LayerOpacityControl extends PureComponent {
   handleMouseEnter = () => this.setState({ showControls: true });
   handleMouseLeave = () => this.setState({ showControls: false });
 
+  formatLabel = value => `${(value*100).toFixed(0)}%`;
+
   render() {
     return (
       <StaticControl position={'topright'}>
@@ -51,9 +53,7 @@ export default class LayerOpacityControl extends PureComponent {
                             // step=0.0499 ensures can go up to 100%
                             // presumed rounding error means 0.05 won't work
                             minValue={0} maxValue={1} step={0.0499}
-                            formatLabel={
-                              value => `${(value*100).toFixed(0)}%`
-                            }
+                            formatLabel={this.formatLabel}
                             value={opacity}
                             onChange={
                               this.props.onChange.bind(this, layerType)

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -28,7 +28,7 @@ export default class LayerOpacityControl extends PureComponent {
 
   handleMouseEnter = () => this.setState({ showControls: true });
   handleMouseLeave = () => this.setState({ showControls: false });
-  
+
   toggleLayerVisibility = layerType => {
     // If current layer is visible, save its current opacity, then hide it by
     // setting its opacity to 0.
@@ -53,11 +53,59 @@ export default class LayerOpacityControl extends PureComponent {
         },
       },
     }));
-  }
+  };
 
   formatLabel = value => `${(value*100).toFixed(0)}%`;
 
   render() {
+    // One Row per layer containing controls for managing that layer's vis.
+    const layerVisibilityControls = Object.entries(this.props.layerOpacity).map(
+      ([layerType, opacity]) => {
+        const showLayer = this.state.layerState[layerType].visible;
+        return (
+          <Row key={layerType} className='layer-controls'>
+            <Row>
+              <Col lg={1} className='visibility-toggle'>
+                <Button
+                  bsSize={'xsmall'}
+                  onClick={
+                    this.toggleLayerVisibility.bind(this, layerType)
+                  }
+                >
+                  <Glyphicon
+                    glyph={showLayer ? 'eye-open' : 'eye-close'}
+                  />
+                </Button>
+              </Col>
+              <Col lg={10} className='layer-identifier'>
+                {`Climate ${layerType} layer`}
+              </Col>
+            </Row>
+            {
+              showLayer &&
+              <Row className='opacity'>
+                <Col lg={1} className='opacity-icon'>
+                  <Glyphicon glyph={'adjust'}/>
+                </Col>
+                <Col lg={10} className='opacity-control'>
+                  <InputRange
+                    // step=0.0499 ensures can go up to 100%
+                    // presumed rounding error means 0.05 won't work
+                    minValue={0} maxValue={1} step={0.0499}
+                    formatLabel={this.formatLabel}
+                    value={opacity}
+                    onChange={
+                      this.props.onChange.bind(this, layerType)
+                    }
+                  />
+                </Col>
+              </Row>
+            }
+          </Row>
+        );
+      }
+    );
+
     return (
       <StaticControl position={'topright'}>
         <div
@@ -69,54 +117,7 @@ export default class LayerOpacityControl extends PureComponent {
             this.state.showControls ?
             (
               <Grid fluid className='layer-controls-container'>
-                {
-                  Object.entries(this.props.layerOpacity).map(
-                    ([layerType, opacity]) => {
-                      const showLayer = this.state.layerState[layerType].visible;
-                      return (
-                        <Row key={layerType} className='layer-controls'>
-                          <Row>
-                            <Col lg={1} className='visibility-toggle'>
-                              <Button
-                                bsSize={'xsmall'}
-                                onClick={
-                                  this.toggleLayerVisibility.bind(this, layerType)
-                                }
-                              >
-                                <Glyphicon
-                                  glyph={showLayer ? 'eye-open' : 'eye-close'}
-                                />
-                              </Button>
-                            </Col>
-                            <Col lg={10} className='layer-identifier'>
-                              {`Climate ${layerType} layer`}
-                            </Col>
-                          </Row>
-                          {
-                            showLayer &&
-                            <Row className='opacity'>
-                              <Col lg={1} className='opacity-icon'>
-                                <Glyphicon glyph={'adjust'}/>
-                              </Col>
-                              <Col lg={10} className='opacity-control'>
-                                <InputRange
-                                  // step=0.0499 ensures can go up to 100%
-                                  // presumed rounding error means 0.05 won't work
-                                  minValue={0} maxValue={1} step={0.0499}
-                                  formatLabel={this.formatLabel}
-                                  value={opacity}
-                                  onChange={
-                                    this.props.onChange.bind(this, layerType)
-                                  }
-                                />
-                              </Col>
-                            </Row>
-                          }
-                        </Row>
-                      );
-                    }
-                  )
-                }
+                {layerVisibilityControls}
               </Grid>
             ) : (
               <Button bsSize='small'>

--- a/src/components/LayerOpacityControl/__tests__/smoke.js
+++ b/src/components/LayerOpacityControl/__tests__/smoke.js
@@ -1,14 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Map } from 'react-leaflet';
-import MapFaderControl from '../';
+import LayerOpacityControl from '../';
+import { noop } from 'underscore';
 
 it('renders without crashing', () => {
     const div = document.createElement('div');
     div.style.height = 100;
     ReactDOM.render(
         <Map>
-            <MapFaderControl/>
+            <LayerOpacityControl
+              opacity={{
+                foo: 0.5,
+              }}
+              onChange={noop}
+            />
         </Map>,
         div);
 });

--- a/src/components/LayerOpacityControl/__tests__/smoke.js
+++ b/src/components/LayerOpacityControl/__tests__/smoke.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Map } from 'react-leaflet';
+import MapFaderControl from '../';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    div.style.height = 100;
+    ReactDOM.render(
+        <Map>
+            <MapFaderControl/>
+        </Map>,
+        div);
+});

--- a/src/components/LayerOpacityControl/__tests__/smoke.js
+++ b/src/components/LayerOpacityControl/__tests__/smoke.js
@@ -5,16 +5,16 @@ import LayerOpacityControl from '../';
 import { noop } from 'underscore';
 
 it('renders without crashing', () => {
-    const div = document.createElement('div');
-    div.style.height = 100;
-    ReactDOM.render(
-        <Map>
-            <LayerOpacityControl
-              opacity={{
-                foo: 0.5,
-              }}
-              onChange={noop}
-            />
-        </Map>,
-        div);
+  const div = document.createElement('div');
+  div.style.height = 100;
+  ReactDOM.render(
+      <Map>
+          <LayerOpacityControl
+            layerOpacity={{
+              foo: 0.5,
+            }}
+            onChange={noop}
+          />
+      </Map>,
+      div);
 });

--- a/src/components/LayerOpacityControl/package.json
+++ b/src/components/LayerOpacityControl/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "LayerOpacityControl",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./LayerOpacityControl.js"
+}

--- a/src/components/MapSettings/MapSettingsButton.js
+++ b/src/components/MapSettings/MapSettingsButton.js
@@ -5,7 +5,7 @@ import { Button, Glyphicon } from 'react-bootstrap';
 // TODO: Make into a PureComponent
 export default function (props) {
   return (
-    <Button onClick={props.open} title={props.title}>
+    <Button onClick={props.open} title={props.title} bsSize='small'>
       <Glyphicon glyph='menu-hamburger'/>
     </Button>
   );

--- a/src/components/NcWMSAutosetColorscaleControl/LeafletNcWMSAutosetColorscaleControl.js
+++ b/src/components/NcWMSAutosetColorscaleControl/LeafletNcWMSAutosetColorscaleControl.js
@@ -60,8 +60,13 @@ const LeafletNcWMSAutosetColorscaleControl = L.Control.extend({
           },
         }).then(response => {
           this.layers.forEach(layer => {
-            if(layer && layer.wmsParams.layers === response.config.params.layers) {
-              layer.setParams({ colorscalerange: response.data.min + ',' + response.data.max });
+            if (
+              layer &&
+              layer.wmsParams.layers === response.config.params.layers
+            ) {
+              layer.setParams({
+                colorscalerange: `${response.data.min},${response.data.max}`,
+              });
             }
           });
         });

--- a/src/components/NcWMSAutosetColorscaleControl/LeafletNcWMSAutosetColorscaleControl.js
+++ b/src/components/NcWMSAutosetColorscaleControl/LeafletNcWMSAutosetColorscaleControl.js
@@ -60,7 +60,7 @@ const LeafletNcWMSAutosetColorscaleControl = L.Control.extend({
           },
         }).then(response => {
           this.layers.forEach(layer => {
-            if(layer.wmsParams.layers == response.config.params.layers) {
+            if(layer && layer.wmsParams.layers === response.config.params.layers) {
               layer.setParams({ colorscalerange: response.data.min + ',' + response.data.max });
             }
           });

--- a/src/components/StaticControl/StaticControl.css
+++ b/src/components/StaticControl/StaticControl.css
@@ -1,6 +1,5 @@
-.StaticControl {
+:global(.StaticControl) {
     border: 2px solid rgba(0,0,0,0.2);
     border-radius: 5px;
-    padding: 0.5em;
     background: white;
 }

--- a/src/components/map-controllers/DualMapController/DualMapController.js
+++ b/src/components/map-controllers/DualMapController/DualMapController.js
@@ -282,6 +282,7 @@ export default class DualMapController extends React.Component {
                     this.props.meta, this.state.raster.timeIdx
                   )(),
                   ...this.state.raster,
+                  defaultOpacity: 0.7,
                   onChangeRange: this.handleChangeRasterRange,
                 }}
 
@@ -291,6 +292,7 @@ export default class DualMapController extends React.Component {
                     this.props.comparandMeta, this.state.isoline.timeIdx
                   )(),
                   ...this.state.isoline,
+                  defaultOpacity: 1.0,
                   onChangeRange: this.handleChangeIsolineRange,
                 }}
 

--- a/src/components/map-controllers/DualMapController/DualMapController.js
+++ b/src/components/map-controllers/DualMapController/DualMapController.js
@@ -298,10 +298,7 @@ export default class DualMapController extends React.Component {
                 area={this.props.area}
               >
 
-                <StaticControl
-                  position='topright'
-                  style={{ marginRight: '70px' }}
-                >
+                <StaticControl position='topright'>
                   <MapSettings
                     title='Map Settings'
                     meta={this.props.meta}

--- a/src/components/map-controllers/PrecipMapController/PrecipMapController.js
+++ b/src/components/map-controllers/PrecipMapController/PrecipMapController.js
@@ -263,7 +263,7 @@ export default class PrecipMapController extends React.Component {
                   dataset: getDatasetId.bind(
                     this, 'comparand', this.props.comparandMeta, this.state.annotated.timeIdx)(),
                   ...this.state.annotated,
-                  defaultOpacity: 0.1,
+                  defaultOpacity: 1.0,
                   onChangeRange: this.handleChangeAnnotatedRange,
                 }}
 

--- a/src/components/map-controllers/PrecipMapController/PrecipMapController.js
+++ b/src/components/map-controllers/PrecipMapController/PrecipMapController.js
@@ -35,8 +35,6 @@ import DataMap from '../../DataMap';
 import MapLegend from '../../MapLegend';
 import MapSettings from '../../MapSettings';
 import StaticControl from '../../StaticControl';
-import GeoLoader from '../../GeoLoader';
-import GeoExporter from '../../GeoExporter';
 
 import { hasValidData, currentDataSpec,
          updateLayerSimpleState, updateLayerTime,
@@ -271,7 +269,7 @@ export default class PrecipMapController extends React.Component {
                 area={this.props.area}
               >
 
-                <StaticControl position='topright' style={{ marginRight: '70px' }}>
+                <StaticControl position='topright'>
                   <MapSettings
                     title='Map Settings'
                     meta={this.props.meta}

--- a/src/components/map-controllers/PrecipMapController/PrecipMapController.js
+++ b/src/components/map-controllers/PrecipMapController/PrecipMapController.js
@@ -255,6 +255,7 @@ export default class PrecipMapController extends React.Component {
                   dataset: getDatasetId.bind(
                     this, 'variable', this.props.meta, this.state.raster.timeIdx)(),
                   ...this.state.raster,
+                  defaultOpacity: 0.7,
                   onChangeRange: this.handleChangeRasterRange,
                 }}
 
@@ -262,6 +263,7 @@ export default class PrecipMapController extends React.Component {
                   dataset: getDatasetId.bind(
                     this, 'comparand', this.props.comparandMeta, this.state.annotated.timeIdx)(),
                   ...this.state.annotated,
+                  defaultOpacity: 0.1,
                   onChangeRange: this.handleChangeAnnotatedRange,
                 }}
 

--- a/src/components/map-controllers/SingleMapController/SingleMapController.js
+++ b/src/components/map-controllers/SingleMapController/SingleMapController.js
@@ -238,6 +238,7 @@ export default class SingleMapController extends React.Component {
                   dataset: this.getDatasetId(
                     'variable', this.props.meta, this.state.raster.timeIdx),
                   ...this.state.raster,
+                  defaultOpacity: 0.7,
                   onChangeRange: this.handleChangeRasterRange,
                 }}
 

--- a/src/components/map-controllers/SingleMapController/SingleMapController.js
+++ b/src/components/map-controllers/SingleMapController/SingleMapController.js
@@ -30,8 +30,6 @@ import DataMap from '../../DataMap';
 import MapLegend from '../../MapLegend';
 import MapSettings from '../../MapSettings';
 import StaticControl from '../../StaticControl';
-import GeoLoader from '../../GeoLoader';
-import GeoExporter from '../../GeoExporter';
 
 import {
   hasValidData, selectRasterPalette,
@@ -247,10 +245,7 @@ export default class SingleMapController extends React.Component {
                 area={this.props.area}
               >
 
-                <StaticControl
-                  position='topright'
-                  style={{ marginRight: '70px' }}
-                >
+                <StaticControl position='topright'>
                   <MapSettings
                     title='Map Settings'
                     meta={this.props.meta}

--- a/src/data-services/ncwms.js
+++ b/src/data-services/ncwms.js
@@ -5,7 +5,9 @@ import axios from 'axios/index';
 import _ from 'underscore';
 
 
-function getBaseWMSParams({ dataset, variableId, wmsTime, logscale, range }) {
+export function getBaseWMSParams(
+  { dataset, variableId, wmsTime, opacity, logscale, range }
+) {
   const fixedParams = {
     layers: `${dataset}/${variableId}`,
     time: wmsTime,
@@ -16,6 +18,7 @@ function getBaseWMSParams({ dataset, variableId, wmsTime, logscale, range }) {
     version: '1.1.1',
     srs: 'EPSG:4326',
     logscale,
+    opacity,
   };
 
   if (logscale !== 'true' || _.isUndefined(range)) {
@@ -35,38 +38,35 @@ function getBaseWMSParams({ dataset, variableId, wmsTime, logscale, range }) {
 }
 
 
-function getRasterWMSParams({ dataset, variableId, wmsTime, palette, logscale, range }) {
+export function getRasterWMSParams({ palette, ...rest }) {
   return Object.assign(
-    getBaseWMSParams({ dataset, variableId, wmsTime, logscale, range }),
+    getBaseWMSParams(rest),
     {
       styles: `default-scalar/${palette}`,
-      opacity: 0.7,
     }
   );
 }
 
 
-function getIsolineWMSParams({ dataset, variableId, wmsTime, palette, logscale, range }) {
+export function getIsolineWMSParams({ palette, ...rest }) {
   return Object.assign(
-    getBaseWMSParams({ dataset, variableId, wmsTime, logscale, range }),
+    getBaseWMSParams(rest),
     {
       styles: `colored_contours/${palette}`,
-      opacity: 1.0,
     }
   );
 }
 
-function getAnnotatedWMSParams({ dataset, variableId, wmsTime, palette, logscale, range }) {
+function getAnnotatedWMSParams(props) {
   return Object.assign(
-    getBaseWMSParams({ dataset, variableId, wmsTime, logscale, range }),
+    getBaseWMSParams(props),
     {
       styles: `contours`,
-      opacity: 1.0,
     }
   );
 }
 
-function getWMSParams(layerType, props) {
+export function getWMSParams(layerType, props) {
   // Return parameters required for a call to the ncWMS tile layer API.
   // TODO: simplify
   if (layerType === 'raster') {
@@ -79,7 +79,7 @@ function getWMSParams(layerType, props) {
 }
 
 
-function getLayerMinMax(layer, props, bounds) {
+export function getLayerMinMax(layer, props, bounds) {
   // Request min and max values from ncWMS layer.
   // Returns a promise for the request response.
 
@@ -105,9 +105,3 @@ function getLayerMinMax(layer, props, bounds) {
     }
   );
 }
-
-
-export {
-  getRasterWMSParams, getIsolineWMSParams, getAnnotatedWMSParams, getWMSParams,
-  getLayerMinMax
-};

--- a/src/data-services/ncwms.js
+++ b/src/data-services/ncwms.js
@@ -57,7 +57,7 @@ export function getIsolineWMSParams({ palette, ...rest }) {
   );
 }
 
-function getAnnotatedWMSParams(props) {
+export function getAnnotatedWMSParams(props) {
   return Object.assign(
     getBaseWMSParams(props),
     {

--- a/src/test_support/jest/__mocks__/fileMock.js
+++ b/src/test_support/jest/__mocks__/fileMock.js
@@ -1,0 +1,6 @@
+// Jest mock for file imports.
+// See https://jestjs.io/docs/en/webpack#handling-static-assets
+// Reference: package.json, jest.moduleNameMapper
+
+const stub = 'test-file-stub';
+export default stub;

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -10,6 +10,7 @@ const layerParamsPropTypes = PropTypes.shape({
   dataset: PropTypes.string,
   variableId: PropTypes.string,
   time: PropTypes.string,
+  defaultOpacity: PropTypes.number,
   palette: PropTypes.string,
   logscale: PropTypes.string,
   range: PropTypes.object,


### PR DESCRIPTION
Resolve #106 

To address the fundamental complaint, which is that it's hard to see through the climate layers to the basemap, this PR adds two controls:

- Layer on/off switching (out of the box with React Leaflet)
- Layer opacity (custom control)

Probably these two controls should be merged into one, but that will take more effort. I think we should try these out on MoTI users and get feedback first (though I would be reluctant to remove the opacity control, which I personally like having).

Reviewers: Please feel free to comment on the UI. Some of the feedback may be stored for future reference (after feedback from MoTI), some may be implemented now.