### PR TITLE
Save zipped shapefiles to root folder in zipfile

### DIFF
--- a/src/core/geo.js
+++ b/src/core/geo.js
@@ -118,7 +118,6 @@ var g = {
   },
 
   save: function (format) {
-    console.log(`geo.save('${format}'):`, this.feature)
     switch (format) {
       case 'wkt':
         saveAs(


### PR DESCRIPTION
Resolves #239 

Creates an alternate version of the `download` function of the `shp-write` package. Pretty simple code.