### PR TITLE
Fix invalid default climatology (Dataset) selection

### DIFF
--- a/src/components/data-controllers/GraphTabs/GraphTabs.js
+++ b/src/components/data-controllers/GraphTabs/GraphTabs.js
@@ -49,7 +49,7 @@ export default class GraphTabs extends React.Component {
       );
 
     return (
-      <Tabs id='Graphs'>
+      <Tabs id='Graphs' mountOnEnter>
         {graphTabs}
       </Tabs>
     );

--- a/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
+++ b/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
@@ -54,22 +54,18 @@ export default class AnnualCycleGraph extends React.Component {
     // this general component to particular cases (single vs. dual controller).
   };
 
-  ///////////////////////////////////////////////////////////////////////////
-  // NEW
-
   // Lifecycle hooks
   // Follows React 16+ lifecycle API and recommendations.
   // See https://reactjs.org/blog/2018/03/29/react-v-16-3.html
   // See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html
   // See https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html
 
-  // Multiple of this component are created by SingleDataController.
-  // The instance and state variables `instance` are used to identify the
-  // instance in debug logging, etc. I'm keeping this because there is still
-  // some sleuthing to do that can use it. (https://github.com/pacificclimate/climate-explorer-frontend/issues/258)
   static instance = 0;  // for debugging
   constructor(props) {
-    console.log('ACG.constructor')
+    // Multiple instances of this component are created by SingleDataController.
+    // The instance and state variables `instance` are used to identify the
+    // instance in debug logging, etc. I'm keeping this because there is still
+    // some sleuthing to do that can use it. (https://github.com/pacificclimate/climate-explorer-frontend/issues/258)
     super(props);
     this.instance = AnnualCycleGraph.instance++;  // for debugging
 

--- a/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
+++ b/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
@@ -12,11 +12,9 @@ import { getTimeseries } from '../../../data-services/ce-backend';
 import {
   defaultDataSpec,
   validateAnnualCycleData,
-  validateUnstructuredTimeseriesData,
 } from '../../../core/util';
 import {
   noDataMessageGraphSpec,
-  multiYearMeanSelected,
   errorMessage,
   loadingDataGraphSpec,
 } from '../graph-helpers';
@@ -157,16 +155,11 @@ export default class AnnualCycleGraph extends React.Component {
 
   // Data fetching
 
-  getAndValidateData(metadata) {
-    const validateData = multiYearMeanSelected(this.props) ?
-      validateAnnualCycleData :
-      validateUnstructuredTimeseriesData;
-    return (
-      getTimeseries(metadata, this.props.area)
-      .then(validateData)
-      .then(response => response.data)
-    );
-  }
+  getAndValidateData = (metadata) => (
+    getTimeseries(metadata, this.props.area)
+    .then(validateAnnualCycleData)
+    .then(response => response.data)
+  );
 
   getMetadatas = () =>
     // This fn is called multiple times, so memoize it if inefficient

--- a/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
+++ b/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
@@ -67,27 +67,9 @@ export default class AnnualCycleGraph extends React.Component {
     super(props);
     this.instance = AnnualCycleGraph.instance++;  // for debugging
 
-    // The content of `state.data` is determined by two qualitatively
-    // different kinds of values:
-    //
-    //    props (specifically, `meta` and `area`)
-    //    state (specifically, `dataSpec`)
-    //
-    // A change to any of these values triggers a data fetch.
-    // The need for a data fetch is signalled by setting `data = null`.
-    // The fact of a fetch in progress is signalled by `fetchingData`.
-    // Signal, fetch initiation, and fetch completion occur separately.
-    //
-    // Between the time `dataSpec` changes and the time that the
-    // data fetch completes, `dataSpec` and `data` are inconsistent, and any
-    // computation based on them will be invalid (e.g., `this.graphSpec()`).
-    // We must therefore treat dataSpec (and its changes) like props.
-    // This requires putting the previous value of dataSpec on state as well,
-    // so that it can, like props, be compared in `getDerivedStateFromProps`.
-    // (Note: `getDerivedStateFromProps` does only has access to the current
-    // state and props ... hence the need for prev values stored on state.
-    // This comes directly from the design of and recommended practice
-    // in React.)
+    // See ../README for an explanation of the content and usage
+    // of state values. This is important for understanding how this
+    // component works.
 
     this.state = {
       instance: this.instance,  // for debugging

--- a/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
+++ b/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
@@ -119,7 +119,6 @@ export default class AnnualCycleGraph extends React.Component {
       props.meta !== state.prevMeta ||
       props.area !== state.prevArea
     ) {
-      console.log('ACG.getDerivedStateFromProps: props change')
       const dataSpec = defaultDataSpec(props);
       return {
         prevMeta: props.meta,
@@ -138,7 +137,6 @@ export default class AnnualCycleGraph extends React.Component {
     if (
       state.prevDataSpec !== state.dataSpec
     ) {
-      console.log('ACG.getDerivedStateFromProps: state change')
       return {
         prevDataSpec: state.dataSpec,
         fetchingData: false,  // not quite yet
@@ -180,28 +178,22 @@ export default class AnnualCycleGraph extends React.Component {
     .filter(metadata => !!metadata);
 
   fetchData() {
-    console.log('ACG.fetchData')
     this.setState({ fetchingData: true });
     Promise.all(
       this.getMetadatas()
       .map(metadata => this.getAndValidateData(metadata))
     )
     .then(data => {
-      console.log('ACG.fetchData: data received')
       this.setState({
         fetchingData: false,
         data,
         dataError: null,
       });
     }).catch(dataError => {
-      console.log('ACG.fetchData: error', dataError)
       this.setState({
         // Do we have to set data non-null here to prevent infinite update loop?
         fetchingData: false,
         dataError,
-      }).finally(() => {
-        console.log('ACG.fetchData: finally')
-        this.setState({ fetchingData: false });
       });
     });
   }

--- a/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
+++ b/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
@@ -65,7 +65,6 @@ export default class AnnualCycleGraph extends React.Component {
 
   static instance = 0;
   constructor(props) {
-    console.log(`ACG.constructor (${AnnualCycleGraph.instance}) `)
     super(props);
     this.instance = AnnualCycleGraph.instance++;
 
@@ -81,13 +80,11 @@ export default class AnnualCycleGraph extends React.Component {
   }
 
   static getDerivedStateFromProps(props, state) {
-    console.log(`ACG.getDerivedStateFromProps (${state.instance}) , props =`, props, 'state =', state)
     if (
       // Assumes that metadata changes when model, variable, or experiment does.
       props.meta !== state.prevMeta ||
       props.area !== state.prevArea
     ) {
-      console.log(`ACG.getDerivedStateFromProps (${state.instance}) : meta or area changed`)
       return {
         prevMeta: props.meta,
         prevArea: props.area,
@@ -98,12 +95,10 @@ export default class AnnualCycleGraph extends React.Component {
     }
 
     // No state update necessary.
-    console.log(`ACG.getDerivedStateFromProps (${state.instance}) : no change`)
     return null;
   }
 
   componentDidMount() {
-    console.log(`ACG.componentDidMount (${this.instance}) : fetch`)
     this.fetchData();
   }
 
@@ -115,23 +110,14 @@ export default class AnnualCycleGraph extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    console.log(`ACG.componentDidUpdate (${this.instance}) , prevProps =`, prevProps, 'prevState =', prevState)
-    console.log(`ACG.componentDidUpdate (${this.instance}) , props =`, this.props, 'state =', this.state)
     if (
       // props changed => data invalid
       this.state.data === null ||
       // user selected new dataset
       !_.isEqual(this.state.dataSpec, prevState.dataSpec)
     ) {
-      console.log(`ACG.componentDidUpdate (${this.instance}) : change/fetch`)
       this.fetchData();
-    } else {
-      console.log(`ACG.componentDidUpdate (${this.instance}) : no change/fetch`)
     }
-  }
-
-  componentWillUnmount() {
-    console.log(`ACG.componentWillUnmount (${this.instance}) `)
   }
 
   // Data fetching
@@ -153,27 +139,23 @@ export default class AnnualCycleGraph extends React.Component {
     .filter(metadata => !!metadata);
 
   fetchData() {
-    console.log(`ACG.fetchData (${this.instance}) : start data fetches`)
     this.setState({ fetchingData: true });
     Promise.all(
       this.getMetadatas()
       .map(metadata => this.getAndValidateData(metadata))
     )
     .then(data => {
-      console.log(`ACG.fetchData (${this.instance}) : data received`)
       this.setState({
         fetchingData: false,
         data,
         dataError: null,
       });
     }).catch(dataError => {
-      console.log(`ACG.fetchData (${this.instance}) : error`, dataError)
       this.setState({
         // Do we have to set data non-null here to prevent infinite update loop?
         fetchingData: false,
         dataError,
       }).finally(() => {
-        console.log(`ACG.fetchData (${this.instance}) : finally`)
         this.setState({ fetchingData: false });
       });
     });
@@ -203,40 +185,31 @@ export default class AnnualCycleGraph extends React.Component {
 
   graphSpec() {
     // Return a graphSpec appropriate to the given state
-    console.log(`ACG.graphSpec (${this.instance}) `)
 
     // An error occurred
     if (this.state.dataError) {
-      console.log(`ACG.graphSpec (${this.instance}) : data error`)
       return noDataMessageGraphSpec(errorMessage(this.state.dataError));
     }
 
     // Waiting for data
     if (this.state.fetchingData) {
-      console.log(`ACG.graphSpec (${this.instance}) : no data (fetchingData)`)
       return loadingDataGraphSpec;
     }
 
     // Waiting for data
     if (this.state.data === null) {
-      console.log(`ACG.graphSpec (${this.instance}) : no data (data === null)`)
       return loadingDataGraphSpec;
     }
 
     // We can haz data
-    console.log(`ACG.graphSpec (${this.instance}) : data`, this.state.data)
-    // console.log(`ACG.graphSpec (${this.instance}) , metadatas =`, this.getMetadatas())
-    // console.log(`ACG.graphSpec (${this.instance}) , data =`, this.state.data)
     try {
       return this.props.dataToGraphSpec(this.getMetadatas(), this.state.data);
     } catch (error) {
-      console.log(`ACG.graphSpec (${this.instance}) : error thrown in dataToGraphSpec`)
       return noDataMessageGraphSpec(errorMessage(error));
     }
   }
 
   render() {
-    console.log(`ACG.render (${this.instance}) , data =`, this.state.data)
     return (
       <React.Fragment>
         <Row>

--- a/src/components/graphs/README.md
+++ b/src/components/graphs/README.md
@@ -45,7 +45,155 @@ in the data controllers via `DataControllerMixin`.
 
 ## Graph component pattern
 
-Currently, all graph components follow a common pattern, as follows:
+Currently, all graph components follow one of two common patterns, 
+the old and the new. 
+
+Old and new patterns are very similar, and differ mainly on the
+usage of lifecycle hooks and in particular how they are used to choreograph
+data fetching.
+
+### New graph component pattern
+
+This pattern follows the lifecycle API and recommended usage introduced in
+React 16.3. Not all graph components have been brought up to this pattern yet.
+It will eventually be necessary to do so because some lifecycle hooks have been
+deprecated and will eventually be removed (in React 17).
+
+All new graph components should follow this pattern.
+
+This pattern is based on the recommended pattern for asynchronous data fetching
+described in
+
+- https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html
+
+See also
+
+- https://reactjs.org/blog/2018/03/29/react-v-16-3.html
+- https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html
+
+The recommended pattern has been extended to handle data fetching based also 
+on changes to a state value (`<selection>`). Here's a summary:
+
+The content of `state.data` is determined by two qualitatively
+different kinds of values:
+
+- props (specifically, `meta` and `area`)
+- state (specifically, `<selection>`)
+
+A change to any of these values triggers a data fetch.
+
+The need for a data fetch is signalled by setting `state.data = null`.
+
+The fact of a fetch in progress is signalled by `state.fetchingData` 
+(a Boolean).
+
+Signal, fetch initiation, and fetch completion occur separately.
+
+Between the time `state.<selection>` changes and the time that the
+data fetch completes, `state.<selection>` and `state.data` are 
+inconsistent, and any computation based on them will be invalid 
+(e.g., `this.graphSpec()`).
+
+We must therefore treat `state.<selection>` (and its changes) like props.
+This requires putting the previous value of `state.<selection>` 
+on state as well (as `state.prev<selection>`),
+so that it can, like props, be compared in `getDerivedStateFromProps`.
+(Note: `getDerivedStateFromProps` does only has access to the current
+state and props, hence the need for prev values stored on state.
+This comes directly from the design of and recommended practice
+for lifecycle management in React 16.3+.)
+
+Specifics:
+
+- props:
+    - `model_id`, `variable_id`, `experiment`: Characterize the context;
+    specifically, characterize what `meta` contains.
+    - `meta`: Array of metadata, collectively describing all available datasets 
+    matching the specified context of model, variable, experiment.
+    - `getMetadata` Function returning an array of metadata 
+    (not necessarily the same kind as elements of `meta`) describing the 
+    specific datasets to display in this graph. This function may take an 
+    argument that controls what metadata is returned. 
+    This function is a 
+    prop so that different functions can be used to specialize the graph
+    component to different uses, typically to single or dual graphs.
+    - `dataToGraphSpec`: Function mapping arrays of metadata and of data
+    (corresponding element by element) to a graph specification consumable
+    by `DataGraph`.
+    This function is a 
+    prop so that different functions can be used to specialize the graph
+    component to different uses, typically to single or dual graphs.
+    
+- state:
+    - `prevMeta`: Previous (to current update) value of `props.meta`. 
+    Used to coordinate data fetches.
+    - `prevArea`: Previous (to current update) value of `props.area`. 
+    Used to coordinate data fetches.
+    - `prev<selection>`: (optional, name varies) 
+    Present if the graph includes a data sub-selector component to control 
+    what values are displayed on graph. Previous (to current update) value 
+    of `state.<selection>`. Used to coordinate data fetches.
+    - `<selection>`: (optional, name varies) Present if the graph includes a 
+    data sub-selector component to control what values are displayed on graph.
+    Value passed to `getMetadata`.
+    - `data`: Data fetched according to metadata, area, and selector.
+    Null value signals need for new data (data fetch).
+    - `fetchingData`: True when data fetch is in progress. False otherwise.
+    - `dataError`: Non-null when a data fetching resulted in an error.
+    
+- render:
+    - (optional) A data sub-selector component to control what values are 
+    displayed on the graph. This should be a 
+    [controlled component](https://reactjs.org/docs/forms.html#controlled-components) 
+    whose `onChange` callback updates `state.selection`. 
+    - (optional) Data export buttons whose `onClick` callbacks cause the data 
+    in the graph to be exported in XLSX or CSV format.
+    - `<DataGraph {...this.state.graphSpec}/>`: The graph.
+    
+- lifecycle:
+    - Use of lifecycle hooks should follow standard recommendations, 
+    specifically for when to launch asynchronous data fetches, as follows:
+    - `componentDidMount`: `fetchData()`
+    - `componentDidUpdate`: if new data required, `fetchData()`
+    
+- data loading (`fetchData()`):
+    - Get metadata for data to display: `metadatas = getMetadata(state.<selection>)`
+    - Map `metadatas` to array of promises `dataPromises` for data fetches
+    - When all data promises resolve, `Promise.all(dataPromises)`,
+    update `state.data`, `state.fetchingData`, `state.dataError` as appropriate.
+    
+For examples, see the components `AnnualCycleGraph`, `LongTermAveragesGraph`
+
+One additional note regarding the derivation of the graph spec from data and
+metadata: A function, `this.graphSpec()` returns a graph spec reflecting the 
+current state (and props). `graphSpec` in turn calls some suggestively 
+(and overloaded )named functions such as `getMetadata`, which might lead one
+to suspect it is hitting the backend whenever it is called. This is not the
+case:
+
+`graphSpec` (when it has data) calls 
+
+- `this.getMetadatas`, which in turn calls `props.getMetadata`, 
+which is a function that returns a filtered subset of the already-fetched 
+metadata. 
+  - The components which specialize ACG (by passing in `props.getMetadata`) 
+  do not (or at least should not) hit the backend to obtain this metadata; 
+  they already have it (passed in as a prop). 
+  - Metdata is only obtained from the backend when the model, emissions, 
+  or variable selection changes. This is the responsibility of the app 
+  controllers, way up the component tree. Metadata passes as props from 
+  there down the tree. 
+- `props.dataToGraphSpec`, which mixes up a batch of special objects to 
+please C3. This is based on 
+  - results of `this.getMetadatas` above
+  - `state.data` (which is gotten from the backend when and only when the 
+  metadata, area, or current dataSpec changes). 
+  No (extra) backend calls here either.
+
+### Old graph component pattern
+
+This pattern follows the lifecycle API and recommended usage introduced in
+React 15. See remarks above about deprecation.
 
 - props:
     - `model_id`, `variable_id`, `experiment`: Characterize the context;
@@ -95,13 +243,14 @@ Currently, all graph components follow a common pattern, as follows:
     convert metadata and data fetched to graph spec: 
     `dataToGraphSpec(metadatas, data)` and update `state.graphSpec`.
     
-For examples, see the components `AnnualCycleGraph`, `ContextGraph`, 
-`LongTermAveragesGraph`, `TimeSeriesGraph`.
+For examples, see the components `ContextGraph`, `TimeSeriesGraph`.
 
 ## Important notes
 
-1. Component state should be limited to graph specification and (optionally)
-data (sub-)selection.
+1. Component state should be limited to data 
+(in old pattern, graph specification, which is derived from data) 
+and (optionally) data (sub-)selection.
+
 1. Data (sub-)selector should be a     
 [controlled component](https://reactjs.org/docs/forms.html#controlled-components) , 
 meaning that:
@@ -109,6 +258,7 @@ meaning that:
     - it is controlled by a `value` prop
     - it communicates changes via an `onChange` callback
     - the selection state is stored in the parent graph component
+
 1. Asynch data fetching should be done only in lifecycle hooks 
 `componentDidMount` and `componentDidUpdate`, as recommeded by 
 React documentation.

--- a/src/components/graphs/SingleAnnualCycleGraph.js
+++ b/src/components/graphs/SingleAnnualCycleGraph.js
@@ -44,8 +44,6 @@ export default function SingleAnnualCycleGraph(props) {
   function dataToGraphSpec(meta, data) {
     // Convert `data` (described by `meta`) to a graph specification compatible
     // with `DataGraph`.
-    console.log('SingleACG.dataToGraphSpec, meta =', meta)
-    console.log('SingleACG.dataToGraphSpec, data =', data)
     let graph = timeseriesToAnnualCycleGraph(meta, ...data);
 
     // arrange the graph so that the highest-resolution data is most visible.

--- a/src/components/graphs/SingleAnnualCycleGraph.js
+++ b/src/components/graphs/SingleAnnualCycleGraph.js
@@ -44,7 +44,8 @@ export default function SingleAnnualCycleGraph(props) {
   function dataToGraphSpec(meta, data) {
     // Convert `data` (described by `meta`) to a graph specification compatible
     // with `DataGraph`.
-
+    console.log('SingleACG.dataToGraphSpec, meta =', meta)
+    console.log('SingleACG.dataToGraphSpec, data =', data)
     let graph = timeseriesToAnnualCycleGraph(meta, ...data);
 
     // arrange the graph so that the highest-resolution data is most visible.

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -150,6 +150,27 @@ export function getVariableOptions(variable, option) {
 }
 
 /************************************************************
+ * Data spec helper functions
+ */
+
+/*
+ * Determine a valid default data spec given a set of metadata
+ * and model, variable, and experiment values.
+ *
+ * Prefers the highest-resolution data available
+ */
+export function defaultDataSpec({ meta, model_id, variable_id, experiment }) {
+  for (const timescale of ['monthly', 'seasonal', 'yearly']) {
+    const matchingMetadata =
+      _.findWhere(meta, { model_id, variable_id, experiment, timescale });
+    if (matchingMetadata) {
+      return _.pick(matchingMetadata,
+        'start_date', 'end_date', 'ensemble_member');
+    }
+  }
+}
+
+/************************************************************
  * Date and calendar helper functions
  *
  * Several different representations of time are needed to


### PR DESCRIPTION
Resolves https://github.com/pacificclimate/climate-explorer-frontend/issues/219

This PR follows follows the recommended lifecycle hook usage for asynchronous data fetching, and adapts it to the case where data fetches are triggered by state change as well as by props change. This proved somewhat tricky, but it's logical once understood.

Note to reviewer: Reorganization of component AnnualCycleGraph has made the diff a bear. Given that it really is a reimplementation, possibly just review the new code without the diff.