### PR TITLE
Update LTAG and SST lifecycle to match AnnualCycleGraph

### DIFF
--- a/src/components/StatisticalSummaryTable/StatisticalSummaryTable.js
+++ b/src/components/StatisticalSummaryTable/StatisticalSummaryTable.js
@@ -45,8 +45,8 @@ export default class StatisticalSummaryTable extends React.Component {
   constructor(props) {
     super(props);
 
-    // See ../README for an explanation of the content and usage
-    // of state values. This is important for understanding how this
+    // See src/components/graphs/README for an explanation of the content and
+    // usage of state values. This is important for understanding how this
     // component works.
 
     this.state = {

--- a/src/components/StatisticalSummaryTable/StatisticalSummaryTable.js
+++ b/src/components/StatisticalSummaryTable/StatisticalSummaryTable.js
@@ -45,25 +45,43 @@ export default class StatisticalSummaryTable extends React.Component {
   constructor(props) {
     super(props);
 
+    // See ../README for an explanation of the content and usage
+    // of state values. This is important for understanding how this
+    // component works.
+
     this.state = {
       prevMeta: null,
       prevArea: null,
-      timeOfYear: defaultTimeOfYear(timeResolutions(this.props.meta)),
+      prevTimeOfYear: null,
+      timeOfYear: null,
+      fetchingData: false,
       data: null,
       dataError: null,
     };
   }
 
   static getDerivedStateFromProps(props, state) {
-    if (
-      props.meta !== state.prevMeta ||
-      props.area !== state.prevArea
-    ) {
+    if (props.meta !== state.prevMeta || props.area !== state.prevArea) {
+      const timeOfYear = defaultTimeOfYear(timeResolutions(props.meta))
       return {
         prevMeta: props.meta,
         prevArea: props.area,
-        timeOfYear: defaultTimeOfYear(timeResolutions(props.meta)),
+        // Avoid triggering an unnecessary second second data fetch due to
+        // change in timeOfYear.
+        prevTimeOfYear: timeOfYear,
+        timeOfYear,
+        fetchingData: false,  // not quite yet
         data: null,  // Signal that data fetch is required
+        dataError: null,
+      };
+    }
+
+    // State change (timeOfYear). Signal need for data fetch.
+    if (state.prevTimeOfYear !== state.timeOfYear) {
+      return {
+        prevTimeOfYear: state.timeOfYear,
+        fetchingData: false,  // not quite yet
+        data: null,  // Signal that data fetch is required due to state change
         dataError: null,
       };
     }
@@ -77,12 +95,7 @@ export default class StatisticalSummaryTable extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (
-      // props changed => data invalid
-      this.state.data === null ||
-      // user selected new time of year
-      this.state.timeOfYear !== prevState.timeOfYear
-    ) {
+    if (!this.state.fetchingData && this.state.data === null) {
       this.fetchData();
     }
   }
@@ -108,6 +121,7 @@ export default class StatisticalSummaryTable extends React.Component {
   }
 
   fetchData() {
+    this.setState({ fetchingData: true });
     const metadata = {
       ..._.pick(this.props,
         'ensemble_name', 'model_id', 'variable_id', 'experiment', 'area'),
@@ -116,6 +130,7 @@ export default class StatisticalSummaryTable extends React.Component {
     this.getAndValidateData(metadata)
     .then(data => {
       this.setState({
+        fetchingData: false,
         data: parseBootstrapTableData(
           this.injectRunIntoStats(data), this.props.meta),
         dataError: null,
@@ -123,6 +138,7 @@ export default class StatisticalSummaryTable extends React.Component {
     }).catch(dataError => {
       this.setState({
         // Do we have to set data non-null here to prevent infinite update loop?
+        fetchingData: false,
         dataError,
       });
     });
@@ -134,6 +150,7 @@ export default class StatisticalSummaryTable extends React.Component {
     this.setState({ timeOfYear });
   };
 
+  // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/261
   exportDataTable(format) {
     exportDataToWorksheet(
       'stats', this.props, this.state.data, format,
@@ -153,7 +170,7 @@ export default class StatisticalSummaryTable extends React.Component {
     }
 
     // Waiting for data
-    if (this.state.data === null) {
+    if (this.state.fetchingData || this.state.data === null) {
       return { noDataText: 'Loading data...' };
     }
 

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -77,6 +77,7 @@ export default class LongTermAveragesGraph extends React.Component {
       props.meta !== state.prevMeta ||
       props.area !== state.prevArea
     ) {
+      const timeOfYear = defaultTimeOfYear(timeResolutions(props.meta))
       return {
         prevMeta: props.meta,
         prevArea: props.area,

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -62,6 +62,10 @@ export default class LongTermAveragesGraph extends React.Component {
   constructor(props) {
     super(props);
 
+    // See ../README for an explanation of the content and usage
+    // of state values. This is important for understanding how this
+    // component works.
+
     this.state = {
       prevMeta: null,
       prevArea: null,
@@ -73,10 +77,7 @@ export default class LongTermAveragesGraph extends React.Component {
   }
 
   static getDerivedStateFromProps(props, state) {
-    if (
-      props.meta !== state.prevMeta ||
-      props.area !== state.prevArea
-    ) {
+    if (props.meta !== state.prevMeta || props.area !== state.prevArea) {
       const timeOfYear = defaultTimeOfYear(timeResolutions(props.meta))
       return {
         prevMeta: props.meta,

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -65,7 +65,8 @@ export default class LongTermAveragesGraph extends React.Component {
     this.state = {
       prevMeta: null,
       prevArea: null,
-      timeOfYear: defaultTimeOfYear(timeResolutions(this.props.meta)),
+      prevTimeOfYear: null,
+      timeOfYear: null,
       data: null,
       dataError: null,
     };
@@ -73,15 +74,28 @@ export default class LongTermAveragesGraph extends React.Component {
 
   static getDerivedStateFromProps(props, state) {
     if (
-      // Assumes that metadata changes when model, variable, or experiment does.
       props.meta !== state.prevMeta ||
       props.area !== state.prevArea
     ) {
       return {
-        timeOfYear: defaultTimeOfYear(timeResolutions(props.meta)),
         prevMeta: props.meta,
         prevArea: props.area,
+        // Avoid triggering an unnecessary second second data fetch due to
+        // change in timeOfYear.
+        prevTimeOfYear: timeOfYear,
+        timeOfYear,
+        fetchingData: false,  // not quite yet
         data: null,  // Signal that data fetch is required
+        dataError: null,
+      };
+    }
+
+    // State change (timeOfYear). Signal need for data fetch.
+    if (state.prevTimeOfYear !== state.timeOfYear) {
+      return {
+        prevTimeOfYear: state.timeOfYear,
+        fetchingData: false,  // not quite yet
+        data: null,  // Signal that data fetch is required due to state change
         dataError: null,
       };
     }
@@ -95,12 +109,7 @@ export default class LongTermAveragesGraph extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (
-      // props changed => data invalid
-      this.state.data === null ||
-      // user selected new time of year
-      this.state.timeOfYear !== prevState.timeOfYear
-    ) {
+    if (!this.state.fetchingData && this.state.data === null) {
       this.fetchData();
     }
   }
@@ -121,18 +130,21 @@ export default class LongTermAveragesGraph extends React.Component {
     .filter(metadata => !!metadata)
 
   fetchData() {
+    this.setState({ fetchingData: true });
     Promise.all(
       this.getMetadatas()
       .map(metadata => this.getAndValidateData(metadata))
     )
     .then(data => {
       this.setState({
+        fetchingData: false,
         data,
         dataError: null,
       });
     }).catch(dataError => {
       this.setState({
         // Do we have to set data non-null here to prevent infinite update loop?
+        fetchingData: false,
         dataError,
       });
     });
@@ -170,13 +182,19 @@ export default class LongTermAveragesGraph extends React.Component {
     }
 
     // Waiting for data
-    if (this.state.data === null) {
+    if (this.state.fetchingData || this.state.data === null) {
       return loadingDataGraphSpec;
     }
 
     // We can haz data
-    return this.props.dataToGraphSpec(
-      this.state.data, this.getMetadatas());
+    try {
+      return this.props.dataToGraphSpec(this.state.data, this.getMetadatas());
+    } catch (error) {
+      // dataToGraphSpec may blow a raspberry if the data it is passed is
+      // invalid. This won't happen due to mismatched timeOfYear and data,
+      // because we don't allow that mismatch to occur.
+      return noDataMessageGraphSpec(errorMessage(error));
+    }
   }
 
   render() {


### PR DESCRIPTION
Resolves https://github.com/pacificclimate/climate-explorer-frontend/issues/259

This PR eliminates the case where `state.timeOfYear` and `state.data` are transiently inconsistent. The equivalent situation produced a visible bug in ACG, but not here (by chance). This PR ports the learning from ACG to LTAG and SST.

In passing a [bug](https://github.com/pacificclimate/climate-explorer-frontend/issues/261) was noted in the SST export code.

Note to reviewers: This should be an easy one. It is just the same thing as a previous PR, repeated twice.