### PR TITLE
Flexible determination of "matching" climatologies (start and end dates)

### DIFF
--- a/src/components/graphs/DualAnnualCycleGraph.js
+++ b/src/components/graphs/DualAnnualCycleGraph.js
@@ -124,13 +124,13 @@ export default function DualAnnualCycleGraph(
     // shift their respective graph lines apart vertically.
     if (hasTwoYAxes(graph) && comparand_id !== variable_id) {
       // see if either variable is listed as conflicting with the other
-      const variableOverlaps = getVariableOptions(variable_id, "shiftAnnualCycle");
-      const comparandOverlaps = getVariableOptions(comparand_id, "shiftAnnualCycle");
+      const variableOverlaps = getVariableOptions(variable_id, 'shiftAnnualCycle');
+      const comparandOverlaps = getVariableOptions(comparand_id, 'shiftAnnualCycle');
       
       const overlap = (comparandOverlaps && comparandOverlaps.includes(variable_id))
         || (variableOverlaps && variableOverlaps.includes(comparand_id));
       
-      if(overlap) {
+      if (overlap) {
         // if the two data series have overlapping ranges and the same units,
         // set their y axes to the same range to avoid 
         // the misleading visuals of *slightly* different y axes.
@@ -141,17 +141,17 @@ export default function DualAnnualCycleGraph(
         // determine whether the data ranges overlap:
         const yRange = yAxisRange(graph, 'y');
         const y2Range = yAxisRange(graph, 'y2');
-        if(yAxisUnits(graph, 'y') === yAxisUnits(graph, 'y2') &&
+        if (yAxisUnits(graph, 'y') === yAxisUnits(graph, 'y2') &&
            !(yRange.max < y2Range.min || y2Range.max < yRange.min)) {
           // y axes will have the same range
           graph = matchYAxisRange(graph);
         }
         else {
           // y axes padded by 20%
-          const shiftUpAxis = yRange.max > y2Range.max ? "y" : "y2";
-          const shiftDownAxis = yRange.max < y2Range.max ? "y" : "y2";
-          graph = padYAxis(graph, shiftUpAxis, "bottom", .2);
-          graph = padYAxis(graph, shiftDownAxis, "top", .2);
+          const shiftUpAxis = yRange.max > y2Range.max ? 'y' : 'y2';
+          const shiftDownAxis = yRange.max < y2Range.max ? 'y' : 'y2';
+          graph = padYAxis(graph, shiftUpAxis, 'bottom', 0.2);
+          graph = padYAxis(graph, shiftDownAxis, 'top', 0.2);
         }
       }
     }
@@ -160,11 +160,12 @@ export default function DualAnnualCycleGraph(
 
   return (
     <AnnualCycleGraph
-      {...{ model_id, experiment, variable_id, meta,
-        comparand_id, comparandMeta, area }
-      }
-      getMetadata={getMetadata}
-      dataToGraphSpec={dataToGraphSpec}
+      {...{
+        model_id, experiment, variable_id, meta,
+        comparand_id, comparandMeta, area,
+        getMetadata,
+        dataToGraphSpec,
+      }}
     />
   );
 }

--- a/src/components/graphs/DualAnnualCycleGraph.js
+++ b/src/components/graphs/DualAnnualCycleGraph.js
@@ -2,33 +2,23 @@ import React from 'react';
 
 import _ from 'underscore';
 
-import {timeseriesToAnnualCycleGraph} from '../../core/chart-generators';
-import {assignColoursByGroup,
-        fadeSeriesByRank,
-        padYAxis,
-        matchYAxisRange} from '../../core/chart-formatters';
-import {hasTwoYAxes,
-        yAxisUnits,
-        yAxisRange, } from '../../core/chart-accessors';
+import { timeseriesToAnnualCycleGraph } from '../../core/chart-generators';
+import {
+  assignColoursByGroup,
+  fadeSeriesByRank,
+  padYAxis,
+  matchYAxisRange,
+} from '../../core/chart-formatters';
+import {
+  hasTwoYAxes,
+  yAxisUnits,
+  yAxisRange,
+} from '../../core/chart-accessors';
 import AnnualCycleGraph from './AnnualCycleGraph';
-import { getVariableOptions } from '../../core/util';
-
-const valuesWithin = (tolerance, a, b) => Math.abs(+a - +b) <= tolerance;
-
-const findMatchingMetadata = (
-  metadata, tolerance,
-  { model_id, experiment, variable_id, timescale,
-    start_date, end_date, ensemble_member },
-) =>
-  _.find(metadata, metadatum =>
-    // Match exactly on these parameters
-    _.matcher(
-      { model_id, experiment, variable_id, timescale, ensemble_member }
-    )(metadatum) &&
-    // Match within `tolerance` on start and end date
-    valuesWithin(tolerance, start_date, metadatum.start_date) &&
-    valuesWithin(tolerance, end_date, metadatum.end_date)
-  );
+import {
+  getVariableOptions,
+  findMatchingMetadata,
+} from '../../core/util';
 
 export default function DualAnnualCycleGraph(
   { model_id, experiment, variable_id, meta, comparand_id, comparandMeta, area }

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -151,7 +151,7 @@ export function getVariableOptions(variable, option) {
 
 /************************************************************
  * Data spec helper functions
- */
+ ************************************************************/
 
 /*
  * Determine a valid default data spec given a set of metadata
@@ -169,6 +169,28 @@ export function defaultDataSpec({ meta, model_id, variable_id, experiment }) {
     }
   }
 }
+
+/************************************************************
+ * Metadata helper functions
+************************************************************/
+
+export const valuesWithin = (tolerance, a, b) => Math.abs(+a - +b) <= tolerance;
+
+export const findMatchingMetadata = (
+  metadata, tolerance,
+  { model_id, experiment, variable_id, timescale,
+    start_date, end_date, ensemble_member },
+) =>
+  _.find(metadata, metadatum =>
+    // Match exactly on these parameters
+    _.matcher(
+      { model_id, experiment, variable_id, timescale, ensemble_member }
+    )(metadatum) &&
+    // Match within `tolerance` on start and end date
+    valuesWithin(tolerance, start_date, metadatum.start_date) &&
+    valuesWithin(tolerance, end_date, metadatum.end_date)
+  );
+
 
 /************************************************************
  * Date and calendar helper functions


### PR DESCRIPTION
Resolves https://github.com/pacificclimate/climate-explorer-frontend/issues/225

This PR modifies the matching function used to select comparand climatologies matched to the primary climatology. It allows for start and end dates with slightly differing values, in this case by 1 year.