### PR TITLE
Generate time-of-year object for data export

### DIFF
--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -67,7 +67,7 @@ var ModalMixin = {
 
   exportDataTable: function (format) {
     exportDataToWorksheet("stats", this.props, this.state.statsData, format, 
-        {timeidx: this.state.dataTableTimeOfYear, timeres:this.state.dataTableTimeScale});
+        {timeidx: this.state.dataTableTimeOfYear, timescale:this.state.dataTableTimeScale});
   },
 
   injectRunIntoStats: function (data) {

--- a/src/components/StatisticalSummaryTable/StatisticalSummaryTable.js
+++ b/src/components/StatisticalSummaryTable/StatisticalSummaryTable.js
@@ -154,8 +154,7 @@ export default class StatisticalSummaryTable extends React.Component {
   exportDataTable(format) {
     exportDataToWorksheet(
       'stats', this.props, this.state.data, format,
-      { timeidx: this.state.timeOfYear,
-        timeres: this.state.dataTableTimeScale }
+      timeKeyToResolutionIndex(this.state.timeOfYear)
     );
   }
 

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -159,14 +159,12 @@ export default class LongTermAveragesGraph extends React.Component {
   };
 
   exportData(format) {
-    const { timescale: timeres, timeidx } =
-      timeKeyToResolutionIndex(this.state.timeOfYear);
     exportDataToWorksheet(
       'climoseries',
       _.pick(this.props, 'model_id', 'variable_id', 'experiment', 'meta'),
       this.graphSpec(),
       format,
-      { timeres, timeidx }
+      timeKeyToResolutionIndex(this.state.timeOfYear)
     );
   }
 

--- a/src/core/export.js
+++ b/src/core/export.js
@@ -59,13 +59,13 @@ var exportDataToWorksheet = function(datatype, metadata, data, format, selection
       outputFilename = `${filenamePrefix}Timeseries${filenameInfix}${filenameSuffix}`;
       break;
     case "stats":
-      timeOfYear = timeResolutionIndexToTimeOfYear(selection.timeres, selection.timeidx);
+      timeOfYear = timeResolutionIndexToTimeOfYear(selection.timescale, selection.timeidx);
       summaryCells = createWorksheetSummaryCells(metadata, timeOfYear);
       dataCells = generateDataCellsFromDataTable(data, "Time Series", variable);
       outputFilename = `${filenamePrefix}StatsTable${filenameInfix}_${timeOfYear}${filenameSuffix}`;
       break;
     case "climoseries":
-      timeOfYear = timeResolutionIndexToTimeOfYear(selection.timeres, selection.timeidx);
+      timeOfYear = timeResolutionIndexToTimeOfYear(selection.timescale, selection.timeidx);
       summaryCells = createWorksheetSummaryCells(metadata, timeOfYear);
       dataCells = generateDataCellsFromC3Graph(data, "Run", variable);
       outputFilename = `${filenamePrefix}LongTermAverage${filenameInfix}_${timeOfYear}${filenameSuffix}`;


### PR DESCRIPTION
The file export function, `export.exportDataToWorksheet()`, requires a `selection` argument indicating what subset of data the user has selected for viewing. This corresponds to whatever the user has picked in the dropdown menu on the graph or table: a time-of-year `{time scale, time index}` object for the Statistical Summary Table and Long Term Average Graph, and an instance `{climatology period, run}` object for the Annual Cycle Graph. The information in the selection object is added to the filename and the explanatory metadata listed in the first part of the file, to indicate what's in the file.

At some point, refactoring broke the generation of the time-of-year selection object for the Statistical Summary Table. This PR fixes that.

The process of generating time-of-year selection objects was unnecessarily complicated by the fact that `exportDataToWorksheet` expected a time-of-year object with the attributes "timeres" and "timeidx" when the rest of CE constructs and uses time-of-year objects with the attributes "timescale" and "timeidx". So this PR also standardizes the timeres/timescale attribute name of `exportDataToWorksheet`'s time-of-year object for readibility and simplicity.

--------------------------------------------------------------------

It would be nice to figure out a way to write tests for `exportDataToWorksheet`. All its helper functions are well-tested, but I wasn't able to figure out how to catch and test the generated file. So bugs like this slip through our test suite. Maybe it would be a good idea to try and move even more of exportDataToWorksheet into testable helper functions.