### PR TITLE
Support substituting user-friendly units, resolve #169

### DIFF
--- a/src/components/graphs/SingleLongTermAveragesGraph.js
+++ b/src/components/graphs/SingleLongTermAveragesGraph.js
@@ -18,10 +18,10 @@ export default function SingleLongTermAveragesGraph(props) {
     ];
   }
 
-  function dataToGraphSpec(data) {
+  function dataToGraphSpec(data, meta) {
     // Convert `data` (described by `meta`) to a graph specification compatible
     // with `DataGraph`.
-    return dataToLongTermAverageGraph(data);
+    return dataToLongTermAverageGraph(data, meta);
   }
 
   const graphProps = _.pick(props,

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -28,7 +28,8 @@ import { PRECISION,
         nestedAttributeIsDefined,
         caseInsensitiveStringSearch,
         timeResolutionIndexToTimeOfYear,
-        timestampToTimeOfYear} from './util';
+        timestampToTimeOfYear,
+        getDataUnits} from './util';
 
 /* **************************************************
  * 0. Helper functions used by all graph generators *
@@ -491,7 +492,7 @@ function timeseriesToAnnualCycleGraph(metadata, ...data) {
     c3Data.types[timeseriesName] = timeseriesMetadata.timescale === 'monthly' ? 'line' : 'step';
 
     seriesMetadata[timeseriesName] = {
-      units: timeseries.units,
+      units: getDataUnits(timeseries, timeseriesMetadata.variable_id),
       variable: timeseriesMetadata.variable_id,
     };
     seriesVariables[timeseriesName] = timeseriesMetadata.variable_id;
@@ -706,7 +707,7 @@ function dataToLongTermAverageGraph(data, contexts = []) {
       seriesVariables[runName] = seriesVariable;
       seriesMetadata[runName] = {
         variable: seriesVariable || '', // single-run has no var metadata
-        units: call[run].units,
+        units: getDataUnits(call[run], seriesVariable),
       };
       const series = [runName];
 
@@ -819,7 +820,7 @@ function timeseriesToTimeseriesGraph(metadata, ...data) {
     const seriesVariable = timeseriesMetadata.variable_id;
     seriesVariables[timeseriesName] = seriesVariable;
     seriesMetadata[timeseriesName] = {
-      units: timeseries.units,
+      units: getDataUnits(timeseries, seriesVariable),
       variable: seriesVariable,
     };
 

--- a/variable-options.yaml
+++ b/variable-options.yaml
@@ -34,6 +34,12 @@
 #        clarify variables whose values move in parallel over the
 #        course of a year, such as tasmax and tasmin.
 #        (default: none)
+#   - userFriendlyUnits
+#        LIST OF UNIT1: UNIT2 PAIRS
+#        UNIT2, an equivalent but more user-friendly version of
+#        UNIT1, will be substituted for UNIT1 in user-visible
+#        displays like graphs and tables.
+#        (default: no substitutions)
 ################################################################
 
 #GCM output variables
@@ -52,8 +58,9 @@ pr:
   defaultRasterPalette: seq-Greens
   percentageAnomalies: true
   #decimalPrecision: 0
-  #Note: in an ideal universe, pr would be measured in millimeters with 0
-  #decimal places, but our pr data is in kg m-2 d-1 instead.
+  userFriendlyUnits:
+    - kg m-2 d-1: mm/day
+    - kg d-1 m-2: mm/day
 
 #CLIMDEX variables
 altcddETCCDI:


### PR DESCRIPTION
Addresses #169 

Adds a `userFriendlyUnits` attribute to the variable configuration file to be configured individually for each variable. This attribute's value is a list of pairs of unit strings (UNITSTRING1: UNITSTRING2) where UNITSTRING2 is an equivalent but more user-friendly version of UNITSTRING1. When displaying information from the backend API to the user, if the units attribute of the API results is UNITSTRING1, UNITSTRING2 will be substituted in graph labels, tables, and file exports instead.

For example:
```yaml
pr:
  userFriendlyUnits:
    - kg m-2 d-1: mm/day
    - kg d-1 m-2: mm/day
```

Would cause precipitation data received from the backend with units of kg m-2 d-1 to be labeled with units of mm/day. If some other variable was given in kg m-2 d-1, it would be unaffected by this attribute on pr. If precipitation was given in inches/day, it would also be unaffected.

This functionality affects only the units string. It does no numerical conversion and could not be used to convert `inches/day` to `mm/day` or similar.