### PR TITLE
Display specific month or season in graph popup

### DIFF
--- a/src/core/__tests__/chart-generator-tests.js
+++ b/src/core/__tests__/chart-generator-tests.js
@@ -16,6 +16,7 @@ jest.dontMock('underscore');
 import {formatYAxis,
         fixedPrecision,
         makePrecisionBySeries,
+        tooltipAddTimeOfYear,
         makeTooltipDisplayNumbersWithUnits,
         timeseriesToAnnualCycleGraph,
         getMonthlyData,
@@ -72,6 +73,19 @@ describe('makePrecisionBySeries', function () {
   it('uses a default precision for unspecified variables', function () {
     const precision = makePrecisionBySeries({ testseries: 'tasmin' });
     expect(precision(4.777, 'testseries')).toEqual(4.78);
+  });
+});
+
+describe('tooltipAddTimeOfYear', function() {
+  it('substitutes in the name of a month', function () {
+    expect(tooltipAddTimeOfYear("Monthly Bills", undefined, 100, 6)).toBe("July Bills");
+    expect(tooltipAddTimeOfYear("Income Monthly", undefined, 600, 3)).toBe("Income April");
+  });
+  it('substitutes in the name of a season', function () {
+    expect(tooltipAddTimeOfYear("Seasonal Harvest", undefined, 600, 1)).toBe("Winter-DJF Harvest");
+  });
+  it('does nothing when not needed', function () {
+    expect(tooltipAddTimeOfYear("Eggs per Chicken", undefined, 10, 10)).toBe("Eggs per Chicken");
   });
 });
 


### PR DESCRIPTION
This addresses #221 

Adds a series name formatting function, `chart-generators.tooltipAddTimeOfYear()`, to tooltips on Annual Cycle Graphs. The formatting function substitutes a specific season for occurances of the word "Seasonal" or a specific month for the word "Monthly" in the names of data series.

The legend at the bottom of the graph will still say "Monthly Mean", "Seasonal Mean," and "Yearly Mean" but now the popups will say **"June Mean**", **"Summer-JJA Mean**" and "**Yearly Mean**" if you hover your mouse in the June section of the graph.

![tooltip](https://user-images.githubusercontent.com/4512605/50794409-e42fdf80-127f-11e9-8c2b-4e0ac25141d9.png)
