### PR TITLE
Visually disambiguate annual-only MYM datasets on Annual Cycle Graph

### DIFF
--- a/variable-options.yaml
+++ b/variable-options.yaml
@@ -156,45 +156,222 @@ wsdiETCCDI:
   decimalPrecision: 0
 
 #degree-day variables
+# these are annual-only multi year mean datasets, so they have a
+# graphable annual cycle, but it's a flat line.
+# apply shiftAnnualCycle to the other annual-only flat graph MYM
+# datasets.
 cdd:
   decimalPrecision: 0
+  shiftAnnualCycle:
+    - fdd
+    - gdd
+    - hdd
+    - rp5pr
+    - rp20pr
+    - rp50pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp20tasmin
+    - rp50tasmin
 
 fdd:
   decimalPrecision: 0
+  shiftAnnualCycle:
+    - cdd
+    - gdd
+    - hdd
+    - rp5pr
+    - rp20pr
+    - rp50pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp20tasmin
+    - rp50tasmin
 
 gdd:
   decimalPrecision: 0
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - hdd
+    - rp5pr
+    - rp20pr
+    - rp50pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp20tasmin
+    - rp50tasmin
 
 hdd:
   decimalPrecision: 0
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - gdd
+    - rp5pr
+    - rp20pr
+    - rp50pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp20tasmin
+    - rp50tasmin
 
 #return period variables
+# these are annual-only multi year mean datasets, so they have a
+# graphable annual cycle, but it's a flat line.
+# apply shiftAnnualCycle to the other annual-only flat graph MYM
+# datasets.
 rp20pr:
   decimalPrecision: 0
   percentageAnomalies: true
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - gdd
+    - hdd
+    - rp5pr
+    - rp50pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp20tasmin
+    - rp50tasmin
 
 rp20tasmax:
   decimalPrecision: 1
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - gdd
+    - hdd
+    - rp5pr
+    - rp20pr
+    - rp50pr
+    - rp5tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp20tasmin
+    - rp50tasmin
 
 rp20tasmin:
   decimalPrecision: 1
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - gdd
+    - hdd
+    - rp5pr
+    - rp20pr
+    - rp50pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp50tasmin
 
 rp50pr:
   decimalPrecision: 0
   percentageAnomalies: true
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - gdd
+    - hdd
+    - rp5pr
+    - rp20pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp20tasmin
+    - rp50tasmin
 
 rp50tasmax:
   decimalPrecision: 1
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - gdd
+    - hdd
+    - rp5pr
+    - rp20pr
+    - rp50pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp5tasmin
+    - rp20tasmin
+    - rp50tasmin
 
 rp50tasmin:
   decimalPrecision: 1
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - gdd
+    - hdd
+    - rp5pr
+    - rp20pr
+    - rp50pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp20tasmin
 
 rp5pr:
   decimalPrecision: 0
   percentageAnomalies: true
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - gdd
+    - hdd
+    - rp20pr
+    - rp50pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp20tasmin
+    - rp50tasmin
 
 rp5tasmax:
   decimalPrecision: 1
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - gdd
+    - hdd
+    - rp5pr
+    - rp20pr
+    - rp50pr
+    - rp20tasmax
+    - rp50tasmax
+    - rp5tasmin
+    - rp20tasmin
+    - rp50tasmin
 
 rp5tasmin:
   decimalPrecision: 1
+  shiftAnnualCycle:
+    - cdd
+    - fdd
+    - gdd
+    - hdd
+    - rp5pr
+    - rp20pr
+    - rp50pr
+    - rp5tasmax
+    - rp20tasmax
+    - rp50tasmax
+    - rp20tasmin
+    - rp50tasmin


### PR DESCRIPTION
Addresses #267 
Annual-only multi-year means appear as horizontal lines on Annual Cycle Graphs - they have only a single value throughout the year. When graphing two such datasets at once, the lines are hard to see because C3 automatically scales each y-axis to frame data in the graph and draws the two horizontal lines on top of eachother, like this:
![before-shift](https://user-images.githubusercontent.com/4512605/50849433-e18ac400-132b-11e9-92eb-70abe20e43a0.png)

This PR adds the `shiftAnnualCycle` attribute to all variables that are annual-only multi-year-mean datasets in the variable configuration file, signalling `DualAnnualCycleGraph` to pad the y axes of the graph to vertically translate the graph lines apart from eachother.

Variables changed: all the Degree Day and Return Period variables.

- cdd
- fdd
- gdd
- hdd
- rp5pr
- rp20pr
- rp50pr
- rp5tasmax
- rp20tasmax
- rp50tasmax
- rp5tasmin
- rp20tasmin
- rp50tasmin

With shifted annual cycles, the graph above looks like this:
![after-shift](https://user-images.githubusercontent.com/4512605/50849518-2151ab80-132c-11e9-94d2-388d65f45af7.png)
