### PR TITLE
Visually disambiguate annual-only MYM datasets on Annual Cycle Graph

### DIFF
--- a/src/components/graphs/DualAnnualCycleGraph.js
+++ b/src/components/graphs/DualAnnualCycleGraph.js
@@ -127,10 +127,16 @@ export default function DualAnnualCycleGraph(
       const variableOverlaps = getVariableOptions(variable_id, 'shiftAnnualCycle');
       const comparandOverlaps = getVariableOptions(comparand_id, 'shiftAnnualCycle');
       
+      // see if both variables are annual-only, in which case they visually
+      // overlap as well, because both will be graphed as horizontal lines.
+      //const annualOnly = !_.contains(_.pluck(meta, "timescale"), "seasonal")
+      //&& !_.contains(_.pluck(meta, "timescale"), "monthly");
+      const annualOnly = (_.reject(meta, m => {return m.timescale === 'yearly';})).length === 0;
+      
       const overlap = (comparandOverlaps && comparandOverlaps.includes(variable_id))
         || (variableOverlaps && variableOverlaps.includes(comparand_id));
       
-      if (overlap) {
+      if (overlap || annualOnly) {
         // if the two data series have overlapping ranges and the same units,
         // set their y axes to the same range to avoid 
         // the misleading visuals of *slightly* different y axes.

--- a/src/components/graphs/DualAnnualCycleGraph.js
+++ b/src/components/graphs/DualAnnualCycleGraph.js
@@ -129,9 +129,7 @@ export default function DualAnnualCycleGraph(
       
       // see if both variables are annual-only, in which case they visually
       // overlap as well, because both will be graphed as horizontal lines.
-      //const annualOnly = !_.contains(_.pluck(meta, "timescale"), "seasonal")
-      //&& !_.contains(_.pluck(meta, "timescale"), "monthly");
-      const annualOnly = (_.reject(meta, m => {return m.timescale === 'yearly';})).length === 0;
+      const annualOnly = (_.reject(meta, m => m.timescale === 'yearly')).length === 0;
       
       const overlap = (comparandOverlaps && comparandOverlaps.includes(variable_id))
         || (variableOverlaps && variableOverlaps.includes(comparand_id));


### PR DESCRIPTION
Address #267 

Annual-only multi-year means appear as horizontal lines on Annual Cycle Graphs - they have only a single value throughout the year. When graphing two such datasets at once, the lines are hard to see because C3 automatically scales each y-axis to frame data in the graph and draws the two horizontal lines on top of eachother, like this:
![before-shift](https://user-images.githubusercontent.com/4512605/50861254-f4fa5700-134c-11e9-93f7-33c34061e3fa.png)

There are two circumstances under which annual-only means are displayed on the DualAnnualCycleGraph:
1. Both variables being compared have only annual resolutions. This is true for the Degree Day datasets and the Return Period Datasets.
2. The primary variable has an annual-only resolution. DualAnnualCycleGraph matches the displayed resolution of the secondary variable, as much as possible, to the primary variable, so if a user selected Cooling Degree Days (annual only) as the primary variable, and Precipitation (Monthly, Seasonal, and Annual) as the secondary variable, only the annual precipitation will be shown, for easier comparison with Cooling Degree Days. (Is this time resolution matching the way it _should_ be? An open question, #144  )

We already have a mechanism for visually separating graph lines that are too close together to read by padding the graph y-axis to shift datalines vertically, added in PR #235 . This adds a check on whether all data being displayed has annual resolution to the algorithm that decides whether to visually separate graph lines.

Graph from above, with additional annual-only check in place:
![after-shift](https://user-images.githubusercontent.com/4512605/50861684-4b1bca00-134e-11e9-88c3-2f00f22b35c0.png)

Still not an _interesting_ graph - viewing the annual cycle of a variable at annual resolution is not terribly enlightening - but it no longer looks like one of the data series is missing entirely.