### PR TITLE
Improve UI for degree days. Resolve #289, resolve #277

### DIFF
--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -613,23 +613,30 @@ help:
         3 degree-days. The total degree-days over a given period
         (e.g., a month, a year) is the total degree-days for each day
         in that period, always respecting both the threshold and the
-        condition (above, below) in counting each day.
+        condition (above, below) in counting each day. This means that
+        when both seasonal and annual degree day data are viewed in a
+        chart or table, the annual values will be larger, as they 
+        represent the sum of the seasonal values.
 
         * **`cdd`**
 
-          Cooling Degree Days: Degree-days in one year above 18&deg;C.
+          Cooling Degree Days: Degree-days during the specified time 
+          period above 18&deg;C.
 
         * **`hdd`**
         
-          Heating Degree Days: Degree-days in one year below 18&deg;C.
+          Heating Degree Days: Degree-days during the specified time 
+          period below 18&deg;C.
 
         * **`gdd`**
         
-          Growing Degree Days: Degree-days in one year above 5&deg;C.
+          Growing Degree Days: Degree-days during the specified time 
+          period above 5&deg;C.
 
         * **`fdd`**
         
-          Frost Degree Days: Degree-days in one year below 0&deg;C.
+          Frost Degree Days: Degree-days during the specified time 
+          period below 0&deg;C.
         
         ### Return period variables
 

--- a/public/variable-options.yaml
+++ b/public/variable-options.yaml
@@ -52,6 +52,11 @@
 #        2: degree-days
 #        3: return periods
 #        (default: MAXINT - uncategorized data is listed last)
+#   - seriesLegendString
+#        STRING
+#        This string appears in the legends of charts and graphs
+#        asociated with this variable, such as "2010-2039 STRING".
+#        (default: "Mean")
 ################################################################
 
 #GCM output variables
@@ -118,6 +123,7 @@ dtrETCCDI:
 fdETCCDI:
   decimalPrecision: 0
   menuGroup: 1
+  seriesLegendString: Mean Count
 
 gslETCCDI:
   decimalPrecision: 0
@@ -217,18 +223,22 @@ wsdiETCCDI:
 cdd:
   decimalPrecision: 0
   menuGroup: 2
+  seriesLegendString: Mean Count
 
 fdd:
   decimalPrecision: 0
   menuGroup: 2
+  seriesLegendString: Mean Count
 
 gdd:
   decimalPrecision: 0
   menuGroup: 2
+  seriesLegendString: Mean Count
 
 hdd:
   decimalPrecision: 0
   menuGroup: 2
+  seriesLegendString: Mean Count
 
 #return period variables
 rp20pr:

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -431,12 +431,12 @@ function shortestUniqueTimeseriesNamingFunction(metadata, data) {
   // Build a dictionary with the base name for each variable (typically
   // either "Mean" or "Mean Count") from the variable config file. 
   // Defaults to "Mean" since all data displayed by this graph is MYMs.
-  const variables = _.uniq(_.pluck(metadata, "variable_id"));
+  const variables = _.uniq(_.map(metadata, 'variable_id'));
   function getVarBasename(v) {
     const fromConfig = getVariableOptions(v, 'seriesLegendString');
     return _.isUndefined(fromConfig) ? "Mean" : fromConfig;
   }
-  const basenameByVariable = _.object(variables, _.map(variables, getVarBasename));
+  const basenameByVariable = _.zipObject(variables, _.map(variables, getVarBasename));
 
   return function (m) {
     let name = '';


### PR DESCRIPTION
Makes two minor UI changes intended to clarify the meaning of degree day variables:

1. Adds a new configurable variable display option named `seriesLegendString`. This option affects the caption that will be given as the name of each data series in the Annual Cycle, Change From Baseline, and Timeseries graphs. 
Previously, because these graphs display multi year means, all legends on these graphs were hardcoded to use the word "Mean" as a base name, such as "Tasmax Mean", "r1i1p1 Mean", or "Tasmax r1i1p1 Mean". With this change, the base name of a data series description can be set in the variable configuration file, but if no base name is set, the default is still "Mean." The basename for frost days and all degree day variables has been set to "Mean Count." All other variables default to "Mean."

2. Adds a sentence to the description of degree days in the Help explicitly noting that if you look at a graph for degree days, the annual values will be larger than the seasonal values (since annual values are the sum, not the mean, of seasonal values).

We haven't received any complaints that degree days were confusing, but they do behave differently from some other data types, and I've made some mistakes, so I wanted the UI to clarify their workings a bit.

Addresses #289 
Addresses #277