### PR TITLE
Add display options for prsn

### DIFF
--- a/src/components/guidance-content/help/HelpGeneral.js
+++ b/src/components/guidance-content/help/HelpGeneral.js
@@ -126,6 +126,9 @@ export default function HelpGeneral() {
                 <ListGroupItem header='tasmin'>
                   Daily minimum near-surface air temperature.
                 </ListGroupItem>
+                <ListGroupItem header='prsn'>
+                  Precipitation at ground level while mean daily temperature is below freezing.
+                </ListGroupItem>
               </ListGroup>
             </Accordion.Item>
 

--- a/variable-options.yaml
+++ b/variable-options.yaml
@@ -62,6 +62,10 @@ pr:
     - kg m-2 d-1: mm/day
     - kg d-1 m-2: mm/day
 
+prsn:
+  overrideLogarithmicScale: true
+  percentageAnomalies: true
+
 #CLIMDEX variables
 altcddETCCDI:
   decimalPrecision: 0


### PR DESCRIPTION
Adds UI / display options for the prsn data:

* prsn data may always be displayed with a logarithmic colour scale on maps
* brief data description in help
* changes in prsn over time show on graphs as percentages, not absolute values

prsn uses the defaults for everything else.

prsn is currently displayed with the unit string `kg m-2 d-1`, which some users find unintuitive. We could replace this with any other unit string with the same meaning, if we think of a better one. _Is_ there a better one, like `kg per square m per day`? That seems even less readable to me. 