### PR TITLE
Fix #296, export data from unstructured timeseries graphs

### DIFF
--- a/src/components/graphs/TimeSeriesGraph/TimeSeriesGraph.js
+++ b/src/components/graphs/TimeSeriesGraph/TimeSeriesGraph.js
@@ -2,7 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col, ControlLabel } from 'react-bootstrap';
 
+import _ from 'underscore';
+
 import DataGraph from '../DataGraph/DataGraph';
+import ExportButtons from '../ExportButtons';
+import { exportDataToWorksheet } from '../../../core/export';
 import styles from './TimeSeriesGraph.css';
 import {
   validateAnnualCycleData,
@@ -103,16 +107,40 @@ export default class TimeSeriesGraph extends React.Component {
     }
   }
 
+  // User event handlers
+  exportData(format) {
+    exportDataToWorksheet(
+      'raw_timeseries',
+      _.pick(this.props, 'model_id', 'variable_id', 'experiment', 'meta'),
+      this.state.graphSpec,
+      format,
+      null
+    );
+  }
+
+  handleExportXlsx = this.exportData.bind(this, 'xlsx');
+  handleExportCsv = this.exportData.bind(this, 'csv');
+ 
   render() {
     return (
-      <Row>
-        <Col>
-          <DataGraph {...this.state.graphSpec}/>
-          <ControlLabel className={styles.graphlabel}>
-            Highlight a time span on lower graph to see more detail
-          </ControlLabel>
-        </Col>
-      </Row>
+      <React.Fragment>
+        <Row>
+          <Col lg={6} md={6} sm={6}>
+            <ExportButtons
+              onExportXlsx={this.handleExportXlsx}
+              onExportCsv={this.handleExportCsv}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <DataGraph {...this.state.graphSpec}/>
+            <ControlLabel className={styles.graphlabel}>
+              Highlight a time span on lower graph to see more detail
+            </ControlLabel>
+          </Col>
+        </Row>
+      </React.Fragment>
     );
   }
 }

--- a/src/core/export.js
+++ b/src/core/export.js
@@ -70,6 +70,12 @@ var exportDataToWorksheet = function(datatype, metadata, data, format, selection
       dataCells = generateDataCellsFromC3Graph(data, "Run", variable);
       outputFilename = `${filenamePrefix}LongTermAverage${filenameInfix}_${timeOfYear}${filenameSuffix}`;
       break;
+    case "raw_timeseries":
+      timeOfYear = 'Annual';
+      summaryCells = createWorksheetSummaryCells(metadata, timeOfYear);
+      dataCells = generateDataCellsFromC3Graph(data, "Run", variable);
+      outputFilename = `${filenamePrefix}RawTimeseries${filenameInfix}_${timeOfYear}${filenameSuffix}`;
+      break;
   }
 
   // assemble the worksheet and add it to the workbook.


### PR DESCRIPTION
We've recently received communication from a user wondering why he or she couldn't export some `prcptot` data to CSV or XLSX.

`Prcptot` is one of the variables we don't currently have climatologies for. If data is not in a climatological format and so cannot be displayed in the Annual Cycle, Long Term Average, or Anomaly graphs, the Unstructured Timeseries graph is displayed instead.

At present, the Unstructured Timeseries graph doesn't allow downloading data. This PR adds buttons to export data from the unstructured timeseries graph to CSV or XLSX format. This affects some annual-only climdex values for which we don't have climatologies.

New buttons look like this:
![export_unstructured](https://user-images.githubusercontent.com/4512605/58274702-3f9ecd80-7d48-11e9-811a-52618aa57a27.png)

Here are two files generated from this graph for export. They're csv, but have been renamed `.txt` because github doesn't allow uploading CSV files:
[PCIC_CE_RawTimeseriesExport_CanESM2_historical, rcp85_altcwdETCCDI_annual.csv.txt](https://github.com/pacificclimate/climate-explorer-frontend/files/3213538/PCIC_CE_RawTimeseriesExport_CanESM2_historical.rcp85_altcwdETCCDI_annual.csv.txt)

[PCIC_CE_RawTimeseriesExport_CanESM2_historical, rcp85_altwsdiETCCDI_annual.csv.txt](https://github.com/pacificclimate/climate-explorer-frontend/files/3213542/PCIC_CE_RawTimeseriesExport_CanESM2_historical.rcp85_altwsdiETCCDI_annual.csv.txt)