### PR TITLE
Migrate underscore to lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "climate-explorer-frontend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8559,9 +8559,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash-es": {
       "version": "4.17.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13664,11 +13664,6 @@
         "invariant": "^2.2.4"
       }
     },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
     "underscore.get": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/underscore.get/-/underscore.get-0.2.9.tgz",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "togeojson": "^0.16.0",
     "togpx": "^0.5.4",
     "tokml": "^0.4.0",
-    "underscore": "^1.9.1",
     "underscore.get": "^0.2.9",
     "url-join": "^4.0.0",
     "wellknown": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "leaflet": "^1.3.4",
     "leaflet-draw": "^1.0.4",
     "leaflet-image": "^0.4.0",
+    "lodash": "^4.17.14",
     "moment": "^2.10.6",
     "proj4": "^2.4.4",
     "proj4leaflet": "^1.0.2",

--- a/src/HOCs/compAcontrolsB.js
+++ b/src/HOCs/compAcontrolsB.js
@@ -45,7 +45,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 
 const controlPropNames = 'show open close controls'.split(' ');

--- a/src/components/App/__x_tests__/smoke.js
+++ b/src/components/App/__x_tests__/smoke.js
@@ -8,7 +8,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import App from '../App';
-import { noop } from 'underscore';
 
 it('renders without crashing', () => {
   shallow(

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -93,7 +93,7 @@ var AppMixin = {
         // defaults if available. Otherwise, first available.
         // Default dataset: CanESM2, rcp85, pr
         function specifiedIfAvailable(attribute, value, items) {
-          return _.pluck(items, attribute).includes(value) ? value : items[0][attribute];
+          return _.map(items, attribute).includes(value) ? value : items[0][attribute];
         }
 
         const model_id = this.state.model_id ? this.state.model_id :
@@ -210,7 +210,7 @@ var AppMixin = {
    * would return the list of all variables in datasets from the CanESM2 model.
    */
   getFilteredMetadataItems: function (name, filter) {
-    return _.unique(_.pluck(_.where(this.state.meta, filter), name));
+    return _.unique(_.map(_.where(this.state.meta, filter), name));
   },
 
   /*

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -11,7 +11,7 @@
  * 
  ****************************************************************************/
 
-import _ from 'underscore';
+import _ from 'lodash';
 import urljoin from 'url-join';
 import axios from 'axios';
 import {timestampToYear} from '../../core/util';

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -200,7 +200,7 @@ var AppMixin = {
    * like model or emissions scenario. Used to populate selection menus.
    */
   getMetadataItems: function (name) {
-    return _.unique(this.state.meta.map(function (el) {return el[name];}));
+    return _.uniq(this.state.meta.map(function (el) {return el[name];}));
   },
 
   /*
@@ -210,7 +210,7 @@ var AppMixin = {
    * would return the list of all variables in datasets from the CanESM2 model.
    */
   getFilteredMetadataItems: function (name, filter) {
-    return _.unique(_.map(_.where(this.state.meta, filter), name));
+    return _.uniq(_.map(_.where(this.state.meta, filter), name));
   },
 
   /*

--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -99,11 +99,11 @@ var AppMixin = {
         const model_id = this.state.model_id ? this.state.model_id :
           specifiedIfAvailable("model_id", "CanESM2", models);
         const experiment = this.state.experiment ? this.state.experiment :
-          specifiedIfAvailable("experiment", "historical, rcp85", _.where(models, {model_id: model_id}));
+          specifiedIfAvailable("experiment", "historical, rcp85", _.filter(models, {model_id: model_id}));
         const variable_id = specifiedIfAvailable("variable_id", "pr",
-          _.where(models, {model_id: model_id, experiment: experiment}));
+          _.filter(models, {model_id: model_id, experiment: experiment}));
         // variable_name has no default, because it must match variable_id.
-        const variable_name = _.where(models, {model_id: model_id, experiment: experiment, 
+        const variable_name = _.filter(models, {model_id: model_id, experiment: experiment,
           variable_id: variable_id})[0].variable_name;
 
         this.setState({
@@ -210,7 +210,7 @@ var AppMixin = {
    * would return the list of all variables in datasets from the CanESM2 model.
    */
   getFilteredMetadataItems: function (name, filter) {
-    return _.uniq(_.map(_.where(this.state.meta, filter), name));
+    return _.uniq(_.map(_.filter(this.state.meta, filter), name));
   },
 
   /*

--- a/src/components/Await/Await.js
+++ b/src/components/Await/Await.js
@@ -9,7 +9,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 
 const promiseType = PropTypes.instanceOf(Promise);

--- a/src/components/Await/__tests__/smoke.js
+++ b/src/components/Await/__tests__/smoke.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Await from '../Await';
-import { noop } from 'underscore';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/CanadaBaseMap/CanadaBaseMap.js
+++ b/src/components/CanadaBaseMap/CanadaBaseMap.js
@@ -2,7 +2,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 import L from 'leaflet';
 
 import { Map, TileLayer, WMSTileLayer, FeatureGroup, GeoJSON } from 'react-leaflet';

--- a/src/components/DataControllerMixin/DataControllerMixin.js
+++ b/src/components/DataControllerMixin/DataControllerMixin.js
@@ -22,7 +22,7 @@
  * - filter and manipulate data
  *********************************************************************/
 
-import _ from 'underscore';
+import _ from 'lodash';
 import urljoin from 'url-join';
 import {exportDataToWorksheet, 
         generateDataCellsFromC3Graph} from '../../core/export';

--- a/src/components/DataMap/DataLayer.js
+++ b/src/components/DataMap/DataLayer.js
@@ -5,7 +5,7 @@ import { WMSTileLayer } from 'react-leaflet';
 import {
   getIsolineWMSParams, getRasterWMSParams, getAnnotatedWMSParams,
 } from '../../data-services/ncwms';
-import _ from 'underscore';
+import _ from 'lodash';
 import { layerParamsPropTypes } from '../../types/types.js';
 
 export default class DataLayer extends React.Component {

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -70,7 +70,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import L from 'leaflet';
 import 'proj4';

--- a/src/components/DataMap/__tests__/DataLayer-smoke.js
+++ b/src/components/DataMap/__tests__/DataLayer-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import DataLayer from '../DataLayer';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 import { Map } from 'react-leaflet';
 
 it('renders without crashing', () => {

--- a/src/components/DataMap/__tests__/DataMap-smoke.js
+++ b/src/components/DataMap/__tests__/DataMap-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import DataMap from '../DataMap';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 describe('with single dataset (raster)', () => {
   it('renders without crashing', () => {

--- a/src/components/DataSpecSelector/DataSpecSelector.js
+++ b/src/components/DataSpecSelector/DataSpecSelector.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Selector from '../Selector/Selector';
-import _ from 'underscore';
+import _ from 'lodash';
 import { datasetSelectorLabel } from '../guidance-content/info/InformationItems';
 /******************************************************************
  * DataSpecSelector.js - Data Specification selecting widget

--- a/src/components/DataSpecSelector/DataSpecSelector.js
+++ b/src/components/DataSpecSelector/DataSpecSelector.js
@@ -48,7 +48,7 @@ export default class DataSpecSelector extends React.Component {
         `${el.ensemble_member} ${el.start_date}-${el.end_date}`
       ]
     );
-    ids = _.uniq(ids, false, item => item[1]);
+    ids = _.sortedUniqBy(ids, false, item => item[1]);
     return ids;
   }
 

--- a/src/components/DataSpecSelector/__tests__/DataSpecSelector-smoke.js
+++ b/src/components/DataSpecSelector/__tests__/DataSpecSelector-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import DataSpecSelector from '../DataSpecSelector';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 import { meta } from '../../../test_support/data';
 
 it('renders without crashing', () => {

--- a/src/components/DataTool.js
+++ b/src/components/DataTool.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import _ from 'underscore';
 
 import NavRoutes from './navigation/NavRoutes/NavRoutes';
 import SingleAppController from './app-controllers/SingleAppController/SingleAppController';

--- a/src/components/ExperimentSelector/ExperimentSelector.js
+++ b/src/components/ExperimentSelector/ExperimentSelector.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import urljoin from 'url-join';
-import _ from 'underscore';
+import _ from 'lodash';
 import axios from 'axios';
 
 import styles from './ExperimentSelector.module.css';

--- a/src/components/GeoExporter/__tests__/GeoExporter-smoke.js
+++ b/src/components/GeoExporter/__tests__/GeoExporter-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import GeoExporter from '../GeoExporter';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 
 it('renders without crashing', () => {

--- a/src/components/GeoExporter/__tests__/GeoExporterDialog-smoke.js
+++ b/src/components/GeoExporter/__tests__/GeoExporterDialog-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import GeoExporterDialog from '../GeoExporterDialog';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 
 it('renders without crashing', () => {

--- a/src/components/GeoLoader/__tests__/GeoLoader-smoke.js
+++ b/src/components/GeoLoader/__tests__/GeoLoader-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import GeoLoader from '../GeoLoader';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 
 it('renders without crashing', () => {

--- a/src/components/GeoLoader/__tests__/GeoLoaderDialogWithError-smoke.js
+++ b/src/components/GeoLoader/__tests__/GeoLoaderDialogWithError-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import GeoLoaderDialogWithError from '../GeoLoaderDialogWithError';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 
 it('renders without crashing', () => {

--- a/src/components/GeoLoader/__tests__/GeoLoaderErrorDialog-smoke.js
+++ b/src/components/GeoLoader/__tests__/GeoLoaderErrorDialog-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import GeoLoaderErrorDialog from '../GeoLoaderErrorDialog';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 
 it('renders without crashing', () => {

--- a/src/components/GeoLoader/__tests__/GeoLoaderMainDialog-smoke.js
+++ b/src/components/GeoLoader/__tests__/GeoLoaderMainDialog-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import GeoLoaderMainDialog from '../GeoLoaderMainDialog';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 
 it('renders without crashing', () => {

--- a/src/components/IndexedSelector/IndexedSelector.js
+++ b/src/components/IndexedSelector/IndexedSelector.js
@@ -22,7 +22,7 @@
 import PropTypes from 'prop-types';
 
 import React from 'react';
-import _ from 'underscore';
+import _ from 'lodash';
 import Selector from '../Selector/Selector';
 
 export default class IndexedSelector extends React.Component {

--- a/src/components/LayerControlledFeatureGroup/__tests__/smoke.js
+++ b/src/components/LayerControlledFeatureGroup/__tests__/smoke.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Map } from 'react-leaflet';
 import LayerControlledFeatureGroup from '../';
-import { noop } from 'underscore';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -4,7 +4,7 @@ import { Grid, Row, Col, Button, Glyphicon } from 'react-bootstrap';
 
 import layersIcon from 'leaflet/dist/images/layers.png';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import InputRange from 'react-input-range';
 

--- a/src/components/LayerOpacityControl/LayerOpacityControl.js
+++ b/src/components/LayerOpacityControl/LayerOpacityControl.js
@@ -22,7 +22,7 @@ export default class LayerOpacityControl extends PureComponent {
     super(props);
     this.state = {
       showControls: false,
-      layerState: _.mapObject(props.layerOpacity, () => ({
+      layerState: _.mapValues(props.layerOpacity, () => ({
         visible: true,
         prevOpacity: 0,
       })),

--- a/src/components/LayerOpacityControl/__tests__/smoke.js
+++ b/src/components/LayerOpacityControl/__tests__/smoke.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Map } from 'react-leaflet';
 import LayerOpacityControl from '../';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/MapLegend/MapLegend.js
+++ b/src/components/MapLegend/MapLegend.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import './MapLegend.css';
 import { sameYear, timestampToTimeOfYear } from '../../core/util';

--- a/src/components/MapSettings/MapSettingsDialog.js
+++ b/src/components/MapSettings/MapSettingsDialog.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Grid, Row, Col, Button, Modal } from 'react-bootstrap';
-import _ from 'underscore';
+import _ from 'lodash';
 
 import DataSpecSelector from '../DataSpecSelector/DataSpecSelector';
 import DataDisplayControls from './DataDisplayControls';

--- a/src/components/MapSettings/TimeSelector.js
+++ b/src/components/MapSettings/TimeSelector.js
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { sameYear, timestampToTimeOfYear } from '../../core/util';
 import NullTimeSelector from './NullTimeSelector';

--- a/src/components/MapSettings/__tests__/DataDisplayControls-smoke.js
+++ b/src/components/MapSettings/__tests__/DataDisplayControls-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import DataDisplayControls from '../DataDisplayControls';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 import { times } from '../../../test_support/data';
 
 it('renders without crashing', () => {

--- a/src/components/MapSettings/__tests__/MapSettings-smoke.js
+++ b/src/components/MapSettings/__tests__/MapSettings-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import MapSettings from '../MapSettings';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 import { meta, times } from '../../../test_support/data';
 
 describe('with one variable', () => {

--- a/src/components/MapSettings/__tests__/MapSettingsDialog-smoke.js
+++ b/src/components/MapSettings/__tests__/MapSettingsDialog-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import MapSettingsDialog from '../MapSettingsDialog';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 import { meta, times } from '../../../test_support/data';
 
 describe('with one variable', () => {

--- a/src/components/MapSettings/__tests__/PaletteSelector-smoke.js
+++ b/src/components/MapSettings/__tests__/PaletteSelector-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PaletteSelector from '../PaletteSelector';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/MapSettings/__tests__/ScaleSelector-smoke.js
+++ b/src/components/MapSettings/__tests__/ScaleSelector-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ScaleSelector from '../ColourMapTypeSelector';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/MapSettings/__tests__/TimeSelector-smoke.js
+++ b/src/components/MapSettings/__tests__/TimeSelector-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TimeSelector from '../TimeSelector';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 import { times } from '../../../test_support/data';
 
 it('renders without crashing', () => {

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 
 import React from 'react';
 import { ControlLabel, MenuItem, Dropdown } from 'react-bootstrap';
-import _ from 'underscore';
+import _ from 'lodash';
 import styles from './Selector.module.css';
 
 class Selector extends React.Component {

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -56,7 +56,7 @@ class Selector extends React.Component {
       //if associated user string cannot be found,
       //just display the original string, on the assumption
       //it's something like "Select a Choice"
-      var item = _.findWhere(items, {0: value});
+      var item = _.find(items, {0: value});
       this.displayString = item ? item[1] : value;
     }
   };

--- a/src/components/StatisticalSummaryTable/StatisticalSummaryTable.js
+++ b/src/components/StatisticalSummaryTable/StatisticalSummaryTable.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col, Panel } from 'react-bootstrap';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import DataTable from '../DataTable/DataTable';
 import TimeOfYearSelector from '../Selector/TimeOfYearSelector';

--- a/src/components/StatisticalSummaryTable/__tests__/smoke.js
+++ b/src/components/StatisticalSummaryTable/__tests__/smoke.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import StatisticalSummaryTable from '../StatisticalSummaryTable';
-import { noop } from 'underscore';
 import { meta } from '../../../test_support/data';
 
 jest.mock('../../../data-services/ce-backend');

--- a/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
+++ b/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
@@ -43,24 +43,24 @@ export default class VariableDescriptionSelector extends React.Component {
   
   //generate items for dropdown.
   update(meta, constraints) {
-	// variables are sorted into groups based on the "menuGroup"
-	// attribute in the variable configuration file.
-	// Within a group, they're alphabetical by variable_id
-	function sortVariables(variables) {
-	  let groups = _.groupBy(variables, v => {
-		const membership = getVariableOptions(v.variable_id, "menuGroup");
-		return _.isUndefined(membership) ? Number.MAX_SAFE_INTEGER : membership;});
-	  groups = _.map(groups, g=> {return _.sortBy(g, 'variable_id');});
-	  return _.flattenDeep(groups);  // deep flattening may not be required here
+    // variables are sorted into groups based on the "menuGroup"
+    // attribute in the variable configuration file.
+    // Within a group, they're alphabetical by variable_id
+    function sortVariables(variables) {
+      let groups = _.groupBy(variables, v => {
+        const membership = getVariableOptions(v.variable_id, "menuGroup");
+        return _.isUndefined(membership) ? Number.MAX_SAFE_INTEGER : membership;
+      });
+      groups = _.map(groups, g => {return _.sortBy(g, 'variable_id');});
+      return _.flattenDeep(groups);  // deep flattening may not be required here
     }
 
     function varDesList(meta, constraints) {
       return sortVariables(
-        _.sortedUniqBy(
+        _.uniqBy(
           _.map(_.filter(meta, constraints), m=> {
             return _.pick(m, "variable_id", "variable_name");
           }),
-          false,
           JSON.stringify
         )
       );

--- a/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
+++ b/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
@@ -51,7 +51,7 @@ export default class VariableDescriptionSelector extends React.Component {
 		const membership = getVariableOptions(v.variable_id, "menuGroup");
 		return _.isUndefined(membership) ? Number.MAX_SAFE_INTEGER : membership;});
 	  groups = _.map(groups, g=> {return _.sortBy(g, 'variable_id');});
-	  return _.flatten(groups);
+	  return _.flattenDeep(groups);  // deep flattening may not be required here
     }
 
     function varDesList(meta, constraints) {

--- a/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
+++ b/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
@@ -57,7 +57,7 @@ export default class VariableDescriptionSelector extends React.Component {
     function varDesList(meta, constraints) {
       return sortVariables(
         _.sortedUniqBy(
-          _.map(_.where(meta, constraints), m=> {
+          _.map(_.filter(meta, constraints), m=> {
             return _.pick(m, "variable_id", "variable_name");
           }),
           false,

--- a/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
+++ b/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
@@ -55,9 +55,15 @@ export default class VariableDescriptionSelector extends React.Component {
     }
 
     function varDesList(meta, constraints) {
-      return sortVariables(_.uniq(_.map(_.where(meta, constraints), m=> {
-        return _.pick(m, "variable_id", "variable_name");
-      }), false, JSON.stringify));
+      return sortVariables(
+        _.sortedUniqBy(
+          _.map(_.where(meta, constraints), m=> {
+            return _.pick(m, "variable_id", "variable_name");
+          }),
+          false,
+          JSON.stringify
+        )
+      );
     } 
     
     const allVars = varDesList(meta, {});

--- a/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
+++ b/src/components/VariableDescriptionSelector/VariableDescriptionSelector.js
@@ -22,7 +22,7 @@
  *   - disabled: true to disable entire dropdown
  *   - label: label to display beside the dropdown
  ************************************************************************/
-import _ from 'underscore';
+import _ from 'lodash';
 import IndexedSelector from '../IndexedSelector';
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/VariableDescriptionSelector/__tests__/VariableDescriptionSelector-smoke.js
+++ b/src/components/VariableDescriptionSelector/__tests__/VariableDescriptionSelector-smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import VariableDescriptionSelector from '../VariableDescriptionSelector';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 import { meta } from '../../../test_support/data';
 
 it('renders without crashing', () => {

--- a/src/components/app-controllers/DualAppController/DualAppController.js
+++ b/src/components/app-controllers/DualAppController/DualAppController.js
@@ -69,7 +69,7 @@ export default createReactClass({
         comparand_name: this.state.variable_name
       });
     }
-    else if(!_.includes(_.pluck(this.state.meta, "variable_id"), this.state.comparand_id)) {
+    else if(!_.includes(_.map(this.state.meta, "variable_id"), this.state.comparand_id)) {
       //comparand leftover from previous ensemble; not present in current one
       this.setState({
         comparand_id: this.state.variable_id,

--- a/src/components/app-controllers/DualAppController/DualAppController.js
+++ b/src/components/app-controllers/DualAppController/DualAppController.js
@@ -87,7 +87,7 @@ export default createReactClass({
     var modOptions = this.getMetadataItems('model_id');
     var expOptions = this.markDisabledMetadataItems(this.getMetadataItems('experiment'),
         this.getFilteredMetadataItems('experiment', {model_id: this.state.model_id}));
-    var selectedVariable = _.findWhere(this.state.meta, { model_id: this.state.model_id,
+    var selectedVariable = _.find(this.state.meta, { model_id: this.state.model_id,
                                                           variable_id: this.state.variable_id,
                                                           experiment: this.state.experiment });
     let comparandConstraints = _.pick(this.state, 'model_id', 'experiment');

--- a/src/components/app-controllers/DualAppController/DualAppController.js
+++ b/src/components/app-controllers/DualAppController/DualAppController.js
@@ -34,7 +34,7 @@ import VariableDescriptionSelector from '../../VariableDescriptionSelector';
 import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
 import FilteredDatasetsSummary from '../../data-presentation/FilteredDatasetsSummary';
 
-import _ from 'underscore';
+import _ from 'lodash';
 import FlowArrow from '../../data-presentation/FlowArrow';
 import UnfilteredDatasetsSummary from '../../data-presentation/UnfilteredDatasetsSummary';
 

--- a/src/components/app-controllers/DualAppController/DualAppController.js
+++ b/src/components/app-controllers/DualAppController/DualAppController.js
@@ -69,7 +69,7 @@ export default createReactClass({
         comparand_name: this.state.variable_name
       });
     }
-    else if(!_.contains(_.pluck(this.state.meta, "variable_id"), this.state.comparand_id)) {
+    else if(!_.includes(_.pluck(this.state.meta, "variable_id"), this.state.comparand_id)) {
       //comparand leftover from previous ensemble; not present in current one
       this.setState({
         comparand_id: this.state.variable_id,

--- a/src/components/app-controllers/PrecipAppController/PrecipAppController.js
+++ b/src/components/app-controllers/PrecipAppController/PrecipAppController.js
@@ -35,7 +35,7 @@ import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
 import FilteredDatasetsSummary from '../../data-presentation/FilteredDatasetsSummary';
 
 
-import _ from 'underscore';
+import _ from 'lodash';
 import FlowArrow from '../../data-presentation/FlowArrow';
 import UnfilteredDatasetsSummary from '../../data-presentation/UnfilteredDatasetsSummary';
 

--- a/src/components/app-controllers/SingleAppController/SingleAppController.js
+++ b/src/components/app-controllers/SingleAppController/SingleAppController.js
@@ -50,8 +50,13 @@ export default createReactClass({
   //Returns metadata for datasets with thethe selected variable + scenario, any model.
   //Passed as a prop for SingleDataController to generate model comparison graphs.
   getModelContextMetadata: function () {
-    return _.where(this.state.meta,
-        { variable_id: this.state.variable_id, experiment: this.state.experiment });
+    return _.filter(
+      this.state.meta,
+      {
+        variable_id: this.state.variable_id,
+        experiment: this.state.experiment
+      }
+    );
   },
 
   render: function () {

--- a/src/components/app-controllers/SingleAppController/SingleAppController.js
+++ b/src/components/app-controllers/SingleAppController/SingleAppController.js
@@ -12,7 +12,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { Grid, Row, Col, Panel } from 'react-bootstrap';
-import _ from 'underscore';
+import _ from 'lodash';
 
 import SingleMapController from '../../map-controllers/SingleMapController';
 import SingleDataController from '../../data-controllers/SingleDataController/SingleDataController';

--- a/src/components/data-controllers/DualDataController/DualDataController.js
+++ b/src/components/data-controllers/DualDataController/DualDataController.js
@@ -38,7 +38,7 @@ import PropTypes from 'prop-types';
 
 import React from 'react';
 import { Panel, Row, Col } from 'react-bootstrap';
-import _ from 'underscore';
+import _ from 'lodash';
 
 import DualAnnualCycleGraph from '../../graphs/DualAnnualCycleGraph';
 import DualLongTermAveragesGraph from '../../graphs/DualLongTermAveragesGraph';

--- a/src/components/data-controllers/MotiDataController/MotiDataController.js
+++ b/src/components/data-controllers/MotiDataController/MotiDataController.js
@@ -46,7 +46,7 @@ import DataControllerMixin from '../../DataControllerMixin';
 import {timeseriesToAnnualCycleGraph,
         timeseriesToTimeseriesGraph} from '../../../core/chart-generators';
 import { getStats } from '../../../data-services/ce-backend';
-import _ from 'underscore';
+import _ from 'lodash';
 
 import AnnualCycleGraph from '../../graphs/AnnualCycleGraph';
 import TimeSeriesGraph from '../../graphs/TimeSeriesGraph';

--- a/src/components/data-controllers/MotiDataController/MotiDataController.js
+++ b/src/components/data-controllers/MotiDataController/MotiDataController.js
@@ -91,7 +91,7 @@ export default createReactClass({
     if(this.multiYearMeanSelected(props)) { //load Annual Cycle graph
       this.setAnnualCycleGraphNoDataMessage("Loading Data");
 
-      var monthlyMetadata = _.findWhere(props.meta,{
+      var monthlyMetadata = _.find(props.meta,{
         model_id: props.model_id,
         variable_id: props.variable_id,
         experiment: props.experiment,
@@ -112,7 +112,7 @@ export default createReactClass({
 
       var params = _.pick(props, 'model_id', 'variable_id', 'experiment');
 
-      var metadata = _.findWhere(props.meta, params);
+      var metadata = _.find(props.meta, params);
 
       var myTimeseriesPromise = this.getTimeseriesPromise(props, metadata.unique_id);
       myTimeseriesPromise.then(response => {

--- a/src/components/data-controllers/SingleDataController/SingleDataController.js
+++ b/src/components/data-controllers/SingleDataController/SingleDataController.js
@@ -34,7 +34,7 @@ import PropTypes from 'prop-types';
 
 import React from 'react';
 import { Row, Col, Panel } from 'react-bootstrap';
-import _ from 'underscore';
+import _ from 'lodash';
 
 import SingleAnnualCycleGraph from '../../graphs/SingleAnnualCycleGraph';
 import SingleLongTermAveragesGraph from '../../graphs/SingleLongTermAveragesGraph';

--- a/src/components/data-presentation/FilteredDatasetsSummary/FilteredDatasetsSummary.js
+++ b/src/components/data-presentation/FilteredDatasetsSummary/FilteredDatasetsSummary.js
@@ -6,7 +6,7 @@ import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 import { MEVSummary } from '../MEVSummary/MEVSummary';
 import { filteredDatasetSummaryPanelLabel } from '../../guidance-content/info/InformationItems';
 
-import _ from 'underscore';
+import _ from 'lodash';
 import { HalfWidthCol } from '../../layout/rb-derived-components';
 
 

--- a/src/components/data-presentation/FilteredDatasetsSummary/__tests__/smoke.js
+++ b/src/components/data-presentation/FilteredDatasetsSummary/__tests__/smoke.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import FilteredDatasetsSummary from '../';
-import { noop } from 'underscore';
 import { meta } from '../../../../test_support/data';
 
 it('renders without crashing', () => {

--- a/src/components/data-presentation/FlowArrow/__tests__/smoke.js
+++ b/src/components/data-presentation/FlowArrow/__tests__/smoke.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import FlowArrow from '../FlowArrow';
-import { noop } from 'underscore';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/data-presentation/UnfilteredDatasetsSummary/UnfilteredDatasetsSummary.js
+++ b/src/components/data-presentation/UnfilteredDatasetsSummary/UnfilteredDatasetsSummary.js
@@ -5,7 +5,7 @@ import Accordion from '../../guidance-tools/Accordion';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 import { unfilteredDatasetSummaryPanelLabel } from '../../guidance-content/info/InformationItems';
 
-import _ from 'underscore';
+import _ from 'lodash';
 import { QuarterWidthCol } from '../../layout/rb-derived-components';
 
 

--- a/src/components/data-presentation/UnfilteredDatasetsSummary/__tests__/smoke.js
+++ b/src/components/data-presentation/UnfilteredDatasetsSummary/__tests__/smoke.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import UnfilteredDatasetsSummary from '../';
-import { noop } from 'underscore';
 import { meta } from '../../../../test_support/data';
 
 it('renders without crashing', () => {

--- a/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
+++ b/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col } from 'react-bootstrap';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import DataSpecSelector from '../../DataSpecSelector/DataSpecSelector';
 import DataGraph from '../DataGraph/DataGraph';

--- a/src/components/graphs/AnomalyAnnualCycleGraph.js
+++ b/src/components/graphs/AnomalyAnnualCycleGraph.js
@@ -15,7 +15,7 @@
 
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { timeseriesToAnnualCycleGraph } from '../../core/chart-generators';
 import { makeAnomalyGraph } from '../../core/chart-transformers';

--- a/src/components/graphs/AnomalyAnnualCycleGraph.js
+++ b/src/components/graphs/AnomalyAnnualCycleGraph.js
@@ -59,9 +59,9 @@ export default function AnomalyAnnualCycleGraph(props) {
     historicalMetadatas = _.where(historicalMetadatas, {"end_date": end_date});
 
     //pick the highest-resolution dataset available for that climatology
-    const baselineMetadata = _.findWhere(historicalMetadatas, {timescale: "monthly"})
-                             || _.findWhere(historicalMetadatas, {timescale: "seasonal"})
-                             || _.findWhere(historicalMetadatas, {timescale: "yearly"});
+    const baselineMetadata = _.find(historicalMetadatas, {timescale: "monthly"})
+                             || _.find(historicalMetadatas, {timescale: "seasonal"})
+                             || _.find(historicalMetadatas, {timescale: "yearly"});
 
     //return the baseline dataset and every same-resolution dataset that starts after it.
     if(_.isUndefined(baselineMetadata)) {

--- a/src/components/graphs/AnomalyAnnualCycleGraph.js
+++ b/src/components/graphs/AnomalyAnnualCycleGraph.js
@@ -55,7 +55,7 @@ export default function AnomalyAnnualCycleGraph(props) {
     //used (usually 1981 - 2010). if there are two equally recent datasets
     //(such as 1971-2000 and 1981-2000) for some reason, one will be arbitrarily selected.
     let historicalMetadatas = getDateRangeMetadatas(undefined, currentYear());
-    const end_date = _.max(_.pluck(historicalMetadatas, "end_date"));
+    const end_date = _.max(_.map(historicalMetadatas, "end_date"));
     historicalMetadatas = _.where(historicalMetadatas, {"end_date": end_date});
 
     //pick the highest-resolution dataset available for that climatology

--- a/src/components/graphs/AnomalyAnnualCycleGraph.js
+++ b/src/components/graphs/AnomalyAnnualCycleGraph.js
@@ -56,7 +56,7 @@ export default function AnomalyAnnualCycleGraph(props) {
     //(such as 1971-2000 and 1981-2000) for some reason, one will be arbitrarily selected.
     let historicalMetadatas = getDateRangeMetadatas(undefined, currentYear());
     const end_date = _.max(_.map(historicalMetadatas, "end_date"));
-    historicalMetadatas = _.where(historicalMetadatas, {"end_date": end_date});
+    historicalMetadatas = _.filter(historicalMetadatas, {"end_date": end_date});
 
     //pick the highest-resolution dataset available for that climatology
     const baselineMetadata = _.find(historicalMetadatas, {timescale: "monthly"})
@@ -69,7 +69,7 @@ export default function AnomalyAnnualCycleGraph(props) {
     }
     else {
       let anomalyMetadatas = getDateRangeMetadatas(baselineMetadata.start_date, undefined);
-      anomalyMetadatas = _.where(anomalyMetadatas, {timescale: baselineMetadata.timescale});
+      anomalyMetadatas = _.filter(anomalyMetadatas, {timescale: baselineMetadata.timescale});
       return [baselineMetadata].concat(anomalyMetadatas);
     }
   }

--- a/src/components/graphs/DataGraph/DataGraph.js
+++ b/src/components/graphs/DataGraph/DataGraph.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import _ from 'underscore';
+import _ from 'lodash';
 import styles from './DataGraph.module.css';
 var C3 = require('c3/c3');
 

--- a/src/components/graphs/DualAnnualCycleGraph.js
+++ b/src/components/graphs/DualAnnualCycleGraph.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { timeseriesToAnnualCycleGraph } from '../../core/chart-generators';
 import {

--- a/src/components/graphs/DualLongTermAveragesGraph.js
+++ b/src/components/graphs/DualLongTermAveragesGraph.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { dataToLongTermAverageGraph } from '../../core/chart-generators';
 import { timeKeyToResolutionIndex } from '../../core/util';

--- a/src/components/graphs/DualTimeSeriesGraph.js
+++ b/src/components/graphs/DualTimeSeriesGraph.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { timeseriesToTimeseriesGraph } from '../../core/chart-generators';
 import TimeSeriesGraph from './TimeSeriesGraph';

--- a/src/components/graphs/DualTimeSeriesGraph.js
+++ b/src/components/graphs/DualTimeSeriesGraph.js
@@ -15,14 +15,14 @@ export default function DualTimeSeriesGraph(props) {
     } = props;
 
     // Set up metadata sets for primary variable
-    const primaryVariableMetadata = _.findWhere(meta, {
+    const primaryVariableMetadata = _.find(meta, {
       model_id, experiment, variable_id,
     });
 
     let metadataSets = [primaryVariableMetadata];
 
     // Extend metadata sets with comparand, if present and different from variable
-    const secondaryVariableMetadata = _.findWhere(comparandMeta, {
+    const secondaryVariableMetadata = _.find(comparandMeta, {
       model_id,
       experiment,
       variable_id: comparand_id,

--- a/src/components/graphs/DualVariableResponseGraph.js
+++ b/src/components/graphs/DualVariableResponseGraph.js
@@ -37,7 +37,7 @@ export default function DualVariableResponseGraph(props) {
     } = props;
 
     //determine highest resolution data available.
-    const resolutionsAvailable = _.uniq(_.pluck(meta, 'timescale'));
+    const resolutionsAvailable = _.uniq(_.map(meta, 'timescale'));
     const resolution = _.indexOf(resolutionsAvailable, 'monthly') != -1 ? 'monthly' : 
                  _.indexOf(resolutionsAvailable, 'seasonal') != -1 ? 'seasonal' : 'yearly';
     

--- a/src/components/graphs/DualVariableResponseGraph.js
+++ b/src/components/graphs/DualVariableResponseGraph.js
@@ -21,7 +21,7 @@
  *********************************************************************/
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { timeseriesToTimeseriesGraph} from '../../core/chart-generators';
 import { makeVariableResponseGraph } from '../../core/chart-transformers';

--- a/src/components/graphs/ExportButtons/__tests__/smoke.js
+++ b/src/components/graphs/ExportButtons/__tests__/smoke.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ExportButtons from '../ExportButtons';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
+++ b/src/components/graphs/LongTermAveragesGraph/LongTermAveragesGraph.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col } from 'react-bootstrap';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import TimeOfYearSelector from '../../Selector/TimeOfYearSelector';
 import DataGraph from '../DataGraph/DataGraph';

--- a/src/components/graphs/README.md
+++ b/src/components/graphs/README.md
@@ -276,7 +276,7 @@ to disable its tests.
     TypeError: Cannot read property 'prototype' of undefined
 
       3 | var C3 = require('c3/c3');
-      4 | import _ from 'underscore';
+      4 | import _ from 'lodash';
     > 5 | import styles from './DataGraph.css';
       6 | 
       7 | class DataGraph extends React.Component {

--- a/src/components/graphs/SingleAnnualCycleGraph.js
+++ b/src/components/graphs/SingleAnnualCycleGraph.js
@@ -22,7 +22,7 @@ export default function SingleAnnualCycleGraph(props) {
     } = props;
     
     var findMetadataForResolution = function (resolution) {
-      return _.findWhere(meta, {
+      return _.find(meta, {
         model_id, experiment, variable_id,
         ...dataSpec,
         timescale: resolution,

--- a/src/components/graphs/SingleAnnualCycleGraph.js
+++ b/src/components/graphs/SingleAnnualCycleGraph.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { timeseriesToAnnualCycleGraph } from '../../core/chart-generators';
 import { sortSeriesByRank } from '../../core/chart-formatters';

--- a/src/components/graphs/SingleContextGraph.js
+++ b/src/components/graphs/SingleContextGraph.js
@@ -22,7 +22,7 @@ export default function SingleContextGraph(props) {
     //used to provide broad context, not detailed data. But if the
     //selected dataset doesn't have yearly data, use whatever resolution it has.
     const model_metadata = _.where(contextMeta, {model_id: model_id, multi_year_mean: true});
-    const resolutions = _.unique(_.map(model_metadata, "timescale")).sort();
+    const resolutions = _.uniq(_.map(model_metadata, "timescale")).sort();
     const timescale = resolutions[resolutions.length - 1]; 
 
     const baseMetadata = {

--- a/src/components/graphs/SingleContextGraph.js
+++ b/src/components/graphs/SingleContextGraph.js
@@ -21,7 +21,7 @@ export default function SingleContextGraph(props) {
     //we prefer the lowest possible time resolution for this graph, since it's
     //used to provide broad context, not detailed data. But if the
     //selected dataset doesn't have yearly data, use whatever resolution it has.
-    const model_metadata = _.where(contextMeta, {model_id: model_id, multi_year_mean: true});
+    const model_metadata = _.filter(contextMeta, {model_id: model_id, multi_year_mean: true});
     const resolutions = _.uniq(_.map(model_metadata, "timescale")).sort();
     const timescale = resolutions[resolutions.length - 1]; 
 
@@ -39,7 +39,7 @@ export default function SingleContextGraph(props) {
         .map(model_id => ({ ...baseMetadata, model_id }))
         .filter(metadata =>
           // Note: length > 0 guaranteed for item containing props.model_id
-          _.where(contextMeta,
+          _.filter(contextMeta,
             _.omit(metadata, 'ensemble_name', 'timeidx', 'area')
           ).length > 0
         );

--- a/src/components/graphs/SingleContextGraph.js
+++ b/src/components/graphs/SingleContextGraph.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { dataToLongTermAverageGraph } from '../../core/chart-generators';
 import { emphasizeSeries } from './graph-helpers';

--- a/src/components/graphs/SingleContextGraph.js
+++ b/src/components/graphs/SingleContextGraph.js
@@ -16,13 +16,13 @@ export default function SingleContextGraph(props) {
     } = props;
 
     // Array of unique model_id's
-    const uniqueContextModelIds = _.uniq(_.pluck(contextMeta, 'model_id'));
+    const uniqueContextModelIds = _.uniq(_.map(contextMeta, 'model_id'));
 
     //we prefer the lowest possible time resolution for this graph, since it's
     //used to provide broad context, not detailed data. But if the
     //selected dataset doesn't have yearly data, use whatever resolution it has.
     const model_metadata = _.where(contextMeta, {model_id: model_id, multi_year_mean: true});
-    const resolutions = _.unique(_.pluck(model_metadata, "timescale")).sort();
+    const resolutions = _.unique(_.map(model_metadata, "timescale")).sort();
     const timescale = resolutions[resolutions.length - 1]; 
 
     const baseMetadata = {

--- a/src/components/graphs/SingleLongTermAveragesGraph.js
+++ b/src/components/graphs/SingleLongTermAveragesGraph.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { dataToLongTermAverageGraph } from '../../core/chart-generators';
 import { timeKeyToResolutionIndex } from '../../core/util';

--- a/src/components/graphs/SingleTimeSeriesGraph.js
+++ b/src/components/graphs/SingleTimeSeriesGraph.js
@@ -13,7 +13,7 @@ export default function SingleTimeSeriesGraph(props) {
       variable_id, meta,
     } = props;
 
-    const primaryVariableMetadata = _.findWhere(meta, {
+    const primaryVariableMetadata = _.find(meta, {
       model_id, experiment, variable_id,
     });
     // Yes, the value of this function is an array of one element.

--- a/src/components/graphs/SingleTimeSeriesGraph.js
+++ b/src/components/graphs/SingleTimeSeriesGraph.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { timeseriesToTimeseriesGraph } from '../../core/chart-generators';
 import TimeSeriesGraph from './TimeSeriesGraph';

--- a/src/components/graphs/SingleTimeSliceGraph.js
+++ b/src/components/graphs/SingleTimeSliceGraph.js
@@ -12,7 +12,7 @@
  *****************************************************************/
 import React from 'react';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { dataToLongTermAverageGraph } from '../../core/chart-generators';
 import { makeTimeSliceGraph } from '../../core/chart-transformers';

--- a/src/components/graphs/SingleTimeSliceGraph.js
+++ b/src/components/graphs/SingleTimeSliceGraph.js
@@ -35,7 +35,7 @@ export default function SingleTimeSliceGraph(props) {
     //used to provide broad context, not detailed data. But if the
     //selected dataset doesn't have yearly data, use whatever resolution it has.
     const model_metadata = _.where(contextMeta, {model_id: model_id, multi_year_mean: true});
-    const resolutions = _.unique(_.map(model_metadata, "timescale")).sort();
+    const resolutions = _.uniq(_.map(model_metadata, "timescale")).sort();
     const timescale = resolutions[resolutions.length - 1];
 
     // Array of unique model_id's

--- a/src/components/graphs/SingleTimeSliceGraph.js
+++ b/src/components/graphs/SingleTimeSliceGraph.js
@@ -35,11 +35,11 @@ export default function SingleTimeSliceGraph(props) {
     //used to provide broad context, not detailed data. But if the
     //selected dataset doesn't have yearly data, use whatever resolution it has.
     const model_metadata = _.where(contextMeta, {model_id: model_id, multi_year_mean: true});
-    const resolutions = _.unique(_.pluck(model_metadata, "timescale")).sort();
+    const resolutions = _.unique(_.map(model_metadata, "timescale")).sort();
     const timescale = resolutions[resolutions.length - 1];
 
     // Array of unique model_id's
-    const uniqueContextModelIds = _.uniq(_.pluck(contextMeta, 'model_id'));
+    const uniqueContextModelIds = _.uniq(_.map(contextMeta, 'model_id'));
     const baseMetadata = {
       ensemble_name,
       experiment,

--- a/src/components/graphs/SingleTimeSliceGraph.js
+++ b/src/components/graphs/SingleTimeSliceGraph.js
@@ -34,7 +34,7 @@ export default function SingleTimeSliceGraph(props) {
     //we prefer the lowest possible time resolution for this graph, since it's
     //used to provide broad context, not detailed data. But if the
     //selected dataset doesn't have yearly data, use whatever resolution it has.
-    const model_metadata = _.where(contextMeta, {model_id: model_id, multi_year_mean: true});
+    const model_metadata = _.filter(contextMeta, {model_id: model_id, multi_year_mean: true});
     const resolutions = _.uniq(_.map(model_metadata, "timescale")).sort();
     const timescale = resolutions[resolutions.length - 1];
 
@@ -54,7 +54,7 @@ export default function SingleTimeSliceGraph(props) {
         .map(model_id => ({ ...baseMetadata, model_id }))
         .filter(metadata =>
           // Note: length > 0 guaranteed for item containing props.model_id
-          _.where(contextMeta,
+          _.filter(contextMeta,
             _.omit(metadata, 'ensemble_name', 'timeidx', 'area')
           ).length > 0
         );

--- a/src/components/graphs/TimeSeriesGraph/TimeSeriesGraph.js
+++ b/src/components/graphs/TimeSeriesGraph/TimeSeriesGraph.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col, ControlLabel } from 'react-bootstrap';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import DataGraph from '../DataGraph/DataGraph';
 import ExportButtons from '../ExportButtons';

--- a/src/components/graphs/graph-helpers.js
+++ b/src/components/graphs/graph-helpers.js
@@ -1,4 +1,4 @@
-import _ from 'underscore';
+import _ from 'lodash';
 import {
   assignColoursByGroup, fadeSeriesByRank,
   hideSeriesInLegend, sortSeriesByRank

--- a/src/components/graphs/graph-helpers.js
+++ b/src/components/graphs/graph-helpers.js
@@ -21,7 +21,7 @@ function multiYearMeanSelected({ model_id, variable_id, experiment, meta }) {
   if (meta && meta.length === 0) {
     return undefined;
   }
-  var selectedMetadata = _.findWhere(meta, { model_id, variable_id, experiment });
+  var selectedMetadata = _.find(meta, { model_id, variable_id, experiment });
   return selectedMetadata.multi_year_mean;
 }
 
@@ -77,7 +77,7 @@ function findMatchingMetadata(example, difference, meta) {
       template[att] = difference[att] ? difference[att] : example[att];
     }
   }
-  return _.findWhere(meta, template);
+  return _.find(meta, template);
 }
 
 export function errorMessage(error) {

--- a/src/components/guidance-content/help/FAQ.js
+++ b/src/components/guidance-content/help/FAQ.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid, Row } from 'react-bootstrap';
 import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
 import Accordion from '../../guidance-tools/Accordion';
-import _ from 'underscore';
+import _ from 'lodash';
 import T from '../../../utils/external-text';
 
 

--- a/src/components/guidance-content/help/Glossary.js
+++ b/src/components/guidance-content/help/Glossary.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid, Row, ListGroup, ListGroupItem } from 'react-bootstrap';
 import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 
 // Items are sorted automatically here.

--- a/src/components/guidance-tools/Information/__tests__/smoke.js
+++ b/src/components/guidance-tools/Information/__tests__/smoke.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Information from '../Information';
-import { noop } from 'underscore';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/guidance-tools/List.js
+++ b/src/components/guidance-tools/List.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ListGroup, ListGroupItem } from 'react-bootstrap';
 import T from '../../utils/external-text';
-import _ from 'underscore';
+import _ from 'lodash';
 
 export function Item({ header, href, body }) {
   return (

--- a/src/components/map-controllers/DualMapController/DualMapController.js
+++ b/src/components/map-controllers/DualMapController/DualMapController.js
@@ -26,7 +26,7 @@ import React from 'react';
 import Loader from 'react-loader';
 import { Panel, Row, Col } from 'react-bootstrap';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import '../MapController.module.css';
 import DataMap from '../../DataMap';

--- a/src/components/map-controllers/DualMapController/DualMapController.js
+++ b/src/components/map-controllers/DualMapController/DualMapController.js
@@ -135,8 +135,8 @@ export default class DualMapController extends React.Component {
     
     Promise.all([rasterParamsPromise, isolineParamsPromise]).then(params => {
             
-      let rasterParams = _.findWhere(params, {variableId: props.variable_id});
-      let isolineParams = _.findWhere(params, {variableId: props.comparand_id});
+      let rasterParams = _.find(params, {variableId: props.variable_id});
+      let isolineParams = _.find(params, {variableId: props.comparand_id});
       
       if(rasterParams === isolineParams) {
         // needed when comparand and variable are the same

--- a/src/components/map-controllers/PrecipMapController/PrecipMapController.js
+++ b/src/components/map-controllers/PrecipMapController/PrecipMapController.js
@@ -28,7 +28,7 @@ import React from 'react';
 import Loader from 'react-loader';
 import { Row, Col, Panel } from 'react-bootstrap';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import '../MapController.module.css';
 import DataMap from '../../DataMap';

--- a/src/components/map-controllers/PrecipMapController/PrecipMapController.js
+++ b/src/components/map-controllers/PrecipMapController/PrecipMapController.js
@@ -124,8 +124,8 @@ export default class PrecipMapController extends React.Component {
     
     Promise.all([rasterParamsPromise, annotatedParamsPromise]).then(params => {
       
-      let rasterParams = _.findWhere(params, {variableId: props.variable_id});
-      let annotatedParams = _.findWhere(params, {variableId: props.comparand_id});
+      let rasterParams = _.find(params, {variableId: props.variable_id});
+      let annotatedParams = _.find(params, {variableId: props.comparand_id});
       
       // if the variable has changed, go back to the default palette and logscale,
       // otherwise use the previous (user-selected) values in state.

--- a/src/components/map-controllers/SingleMapController/SingleMapController.js
+++ b/src/components/map-controllers/SingleMapController/SingleMapController.js
@@ -23,7 +23,7 @@ import React from 'react';
 import Loader from 'react-loader';
 import { Panel, Row, Col } from 'react-bootstrap';
 
-import _ from 'underscore';
+import _ from 'lodash';
 
 import '../MapController.module.css';
 import DataMap from '../../DataMap';

--- a/src/components/map-controllers/SingleMapController/SingleMapController.js
+++ b/src/components/map-controllers/SingleMapController/SingleMapController.js
@@ -130,7 +130,7 @@ export default class SingleMapController extends React.Component {
     if (encodedVarTimeIdx) {
       if (hasValidData(varSymbol, this.props)) {
         const timeIndex = JSON.parse(encodedVarTimeIdx);
-        dataset = _.findWhere(varMeta, {
+        dataset = _.find(varMeta, {
           ensemble_member: this.state.run,
           start_date: this.state.start_date,
           end_date: this.state.end_date,

--- a/src/components/map-controllers/__tests__/smoke.js
+++ b/src/components/map-controllers/__tests__/smoke.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import DualMapController from '../DualMapController';
 import SingleMapController from '../SingleMapController';
 import PrecipMapController from '../PrecipMapController';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 
 /*********************************************************************

--- a/src/components/map-controllers/__tests__/smoke.js
+++ b/src/components/map-controllers/__tests__/smoke.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import DualMapController from '../DualMapController';
 import SingleMapController from '../SingleMapController';
 import PrecipMapController from '../PrecipMapController';
-import noop from 'underscore';
+import { noop } from 'underscore';
 
 
 /*********************************************************************

--- a/src/components/map-controllers/map-helpers.js
+++ b/src/components/map-controllers/map-helpers.js
@@ -46,7 +46,7 @@ function getDatasetId(varSymbol, varMeta, encodedVarTimeIdx) {
   if (encodedVarTimeIdx) {
     if (hasValidData(varSymbol, this.props)) {
       const timeIndex = JSON.parse(encodedVarTimeIdx);
-      dataset = _.findWhere(varMeta, {
+      dataset = _.find(varMeta, {
         ensemble_member: this.state.run,
         start_date: this.state.start_date,
         end_date: this.state.end_date,

--- a/src/components/map-controllers/map-helpers.js
+++ b/src/components/map-controllers/map-helpers.js
@@ -11,7 +11,7 @@
  *      
  *   2. State and handler functions shared by multiple MapControllers
  ************************************************************************/
-import _ from 'underscore';
+import _ from 'lodash';
 
 import { getTimeMetadata } from '../../data-services/ce-backend';
 import { getVariableOptions } from '../../core/util';

--- a/src/components/navigation/NavRoutes/__tests__/smoke.js
+++ b/src/components/navigation/NavRoutes/__tests__/smoke.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { MemoryRouter } from 'react-router-dom';
 import NavRoutes from '../';
-import { noop } from 'underscore';
+import { noop } from 'lodash';
 
 const navSpec = {
   basePath: '/basePath',

--- a/src/core/__test_data__/sample-API-results.js
+++ b/src/core/__test_data__/sample-API-results.js
@@ -18,7 +18,7 @@
  *  - addRunToStats() copies the "run" attribute to stats data objects
  *  from the associated metadata.
  *********************************************************************/
-import _ from 'underscore';
+import _ from 'lodash';
 
 /**************************************************************
  * Sample results from the timeseries API call.

--- a/src/core/__tests__/chart-accessor-tests.js
+++ b/src/core/__tests__/chart-accessor-tests.js
@@ -71,7 +71,6 @@ describe('yAxisRange', function () {
   const monthlyTasmaxTimeseriesData = _.map(monthlyTasmaxTimeseries.data);
   const monthlyPrTimeseriesData = _.map(monthlyPrTimeseries.data);
   it('calculates the min and max of data associated with a y-axis', function () {
-    console.log('### monthlyTasmaxTimeseriesData', monthlyTasmaxTimeseriesData)
     expect(yAxisRange(graph, 'y').min).toBe(_.min(monthlyTasmaxTimeseriesData));
     expect(yAxisRange(graph, 'y').max).toBe(_.max(monthlyTasmaxTimeseriesData));
     expect(yAxisRange(graph, 'y2').min).toBe(_.min(monthlyPrTimeseriesData));

--- a/src/core/__tests__/chart-accessor-tests.js
+++ b/src/core/__tests__/chart-accessor-tests.js
@@ -68,10 +68,13 @@ describe('yAxisRange', function () {
   const graph = timeseriesToAnnualCycleGraph(metadataToArray(),
       monthlyTasmaxTimeseries,
       monthlyPrTimeseries);
+  const monthlyTasmaxTimeseriesData = _.map(monthlyTasmaxTimeseries.data);
+  const monthlyPrTimeseriesData = _.map(monthlyPrTimeseries.data);
   it('calculates the min and max of data associated with a y-axis', function () {
-    expect(yAxisRange(graph, 'y').min).toBe(_.min(monthlyTasmaxTimeseries.data));
-    expect(yAxisRange(graph, 'y').max).toBe(_.max(monthlyTasmaxTimeseries.data));
-    expect(yAxisRange(graph, 'y2').min).toBe(_.min(monthlyPrTimeseries.data));
-    expect(yAxisRange(graph, 'y2').max).toBe(_.max(monthlyPrTimeseries.data));
+    console.log('### monthlyTasmaxTimeseriesData', monthlyTasmaxTimeseriesData)
+    expect(yAxisRange(graph, 'y').min).toBe(_.min(monthlyTasmaxTimeseriesData));
+    expect(yAxisRange(graph, 'y').max).toBe(_.max(monthlyTasmaxTimeseriesData));
+    expect(yAxisRange(graph, 'y2').min).toBe(_.min(monthlyPrTimeseriesData));
+    expect(yAxisRange(graph, 'y2').max).toBe(_.max(monthlyPrTimeseriesData));
   });
 });

--- a/src/core/__tests__/chart-accessor-tests.js
+++ b/src/core/__tests__/chart-accessor-tests.js
@@ -18,10 +18,10 @@ import {monthlyTasmaxTimeseries,
         annualTasmaxTimeseries,
         monthlyPrTimeseries,
         metadataToArray} from '../__test_data__/sample-API-results';
-import _ from 'underscore';
+import _ from 'lodash';
 
 jest.dontMock('../chart-accessors');
-jest.dontMock('underscore');
+jest.dontMock('lodash');
 
 describe('hasTwoYAxes', function () {
   const metadata = metadataToArray();

--- a/src/core/__tests__/chart-formatter-tests.js
+++ b/src/core/__tests__/chart-formatter-tests.js
@@ -18,7 +18,7 @@ import * as mockAPI from '../__test_data__/sample-API-results';
 jest.dontMock('../chart-generators');
 jest.dontMock('../chart-formatters');
 jest.dontMock('../util');
-jest.dontMock('underscore');
+jest.dontMock('lodash');
 
 describe('assignColoursByGroup', function () {
   const metadata = mockAPI.metadataToArray();

--- a/src/core/__tests__/chart-generator-tests.js
+++ b/src/core/__tests__/chart-generator-tests.js
@@ -35,7 +35,7 @@ import {monthlyTasmaxTimeseries,
 
 jest.dontMock('../chart-generators');
 jest.dontMock('../util');
-jest.dontMock('underscore');
+jest.dontMock('lodash');
 
 describe('formatYAxis', function () {
   it('formats a c3 y axis with units label', function () {

--- a/src/core/__tests__/chart-transformer-tests.js
+++ b/src/core/__tests__/chart-transformer-tests.js
@@ -19,7 +19,7 @@ import * as mockAPI from '../__test_data__/sample-API-results';
 jest.dontMock('../chart-generators');
 jest.dontMock('../chart-transformers');
 jest.dontMock('../util');
-jest.dontMock('underscore');
+jest.dontMock('lodash');
 
 
 describe('makeVariableResponseGraph', function () {

--- a/src/core/__tests__/export-test.js
+++ b/src/core/__tests__/export-test.js
@@ -9,7 +9,7 @@
  * validation functions from ./test-validators.js
  ******************************************************************/
 
-import _ from 'underscore';
+import _ from 'lodash';
 import xlsx from 'xlsx';
 import * as exportdata from '../export';
 import * as validate from '../__test_data__/test-validators';
@@ -21,7 +21,7 @@ import * as chart from '../chart-generators';
 jest.dontMock('../util');
 jest.dontMock('../chart-generators');
 jest.dontMock('../export');
-jest.dontMock('underscore');
+jest.dontMock('lodash');
 jest.dontMock('xlsx');
 
 /*

--- a/src/core/__tests__/util-test.js
+++ b/src/core/__tests__/util-test.js
@@ -10,14 +10,14 @@
  ********************************************************/
 
 
-import _ from 'underscore';
+import _ from 'lodash';
 import xlsx from 'xlsx';
 import * as util from '../util';
 import * as mockAPI from '../__test_data__/sample-API-results';
 
 jest.dontMock('../util');
 jest.dontMock('../export');
-jest.dontMock('underscore');
+jest.dontMock('lodash');
 jest.dontMock('xlsx');
 jest.mock('../../data-services/public.js');
 

--- a/src/core/chart-accessors.js
+++ b/src/core/chart-accessors.js
@@ -8,6 +8,12 @@
  ***************************************************************************/
 import _ from 'lodash';
 
+
+// C3 data series are an array containing a string axis label followed by the
+// (numeric) data values for the axis. This function returns the data.
+export const seriesData = series => _.drop(series, 1);
+
+
 export function hasTwoYAxes(graph) {
   // returns a truthy object if this graph has a both a y and y2 axis defined
   return !!(graph.axis.y && graph.axis.y2);
@@ -37,12 +43,16 @@ export function yAxisRange(graph, axis) {
   // y-axis. The axis argument is typically either "y" or "y2".
   // Return value has the format {max: 10, min: 0}
   checkYAxisValidity(graph, axis);
-  
-  //filter to just the data points associated with this y axis
-  const axisData = _.flattenDeep(  // deep flattening may not be required here
-    graph.data.columns.filter(ser => axis === graph.data.axes[ser[0]])
-  );
-  
+
+  // Filter to just the data points associated with this y axis.
+  const axisData =
+    _.flattenDeep(  // deep flattening may not be required here
+      _.map(
+        graph.data.columns.filter(ser => axis === graph.data.axes[ser[0]]),
+        seriesData
+      )
+    );
+
   return {
     min: _.min(axisData),
     max: _.max(axisData),

--- a/src/core/chart-accessors.js
+++ b/src/core/chart-accessors.js
@@ -39,7 +39,9 @@ export function yAxisRange(graph, axis) {
   checkYAxisValidity(graph, axis);
   
   //filter to just the data points associated with this y axis
-  const axisData = _.flatten(graph.data.columns.filter(ser => axis === graph.data.axes[ser[0]]));
+  const axisData = _.flattenDeep(  // deep flattening may not be required here
+    graph.data.columns.filter(ser => axis === graph.data.axes[ser[0]])
+  );
   
   return {
     min: _.min(axisData),

--- a/src/core/chart-accessors.js
+++ b/src/core/chart-accessors.js
@@ -6,7 +6,7 @@
  *
  * Reference on the C3 chart spec format can be found at https://c3js.org
  ***************************************************************************/
-import _ from 'underscore';
+import _ from 'lodash';
 
 export function hasTwoYAxes(graph) {
   // returns a truthy object if this graph has a both a y and y2 axis defined

--- a/src/core/chart-formatters.js
+++ b/src/core/chart-formatters.js
@@ -32,12 +32,15 @@
  *    data range
  ***************************************************************************/
 import _ from 'lodash';
-import {PRECISION,
-        extendedDateToBasicDate,
-        capitalizeWords,
-        caseInsensitiveStringSearch,
-        nestedAttributeIsDefined,
-        getVariableOptions} from './util';
+import {
+  PRECISION,
+  extendedDateToBasicDate,
+  capitalizeWords,
+  caseInsensitiveStringSearch,
+  nestedAttributeIsDefined,
+  getVariableOptions
+} from './util';
+import { seriesData } from './chart-accessors';
 import chroma from 'chroma-js';
 
 
@@ -271,13 +274,13 @@ function padYAxis (graph, axis = "y", direction = "top", padding = 1) {
   let min = graph.axis[axis].min;
   let max = graph.axis[axis].max
   const axisSeries = getDataSeriesByAxis(graph, axis);
-  
+
   if(_.isUndefined(min)) {
-    min = _.min(_.map(axisSeries, series => _.min(series)));
+    min = _.min(_.map(axisSeries, series => _.min(seriesData(series))));
   }    
   
   if(_.isUndefined(max)) {
-    max = _.max(_.map(axisSeries, series => _.max(series)));
+    max = _.max(_.map(axisSeries, series => _.max(seriesData(series))));
   }
   
   if(direction === "top") {
@@ -308,10 +311,10 @@ function matchYAxisRange(graph) {
     throw new Error("Error: cannot match single axis range");
   }
 
-  const ymin = y.min ? y.min : _.min(_.map(getDataSeriesByAxis(graph, "y"), series => _.min(series)));
-  const ymax = y.max ? y.max : _.max(_.map(getDataSeriesByAxis(graph, "y"), series => _.max(series)));
-  const y2min = y2.min ? y2.min : _.min(_.map(getDataSeriesByAxis(graph, "y2"), series => _.min(series)));
-  const y2max = y2.max ? y2.max : _.max(_.map(getDataSeriesByAxis(graph, "y2"), series => _.max(series)));
+  const ymin = y.min ? y.min : _.min(_.map(getDataSeriesByAxis(graph, "y"), series => _.min(seriesData(series))));
+  const ymax = y.max ? y.max : _.max(_.map(getDataSeriesByAxis(graph, "y"), series => _.max(seriesData(series))));
+  const y2min = y2.min ? y2.min : _.min(_.map(getDataSeriesByAxis(graph, "y2"), series => _.min(seriesData(series))));
+  const y2max = y2.max ? y2.max : _.max(_.map(getDataSeriesByAxis(graph, "y2"), series => _.max(seriesData(series))));
 
   graph.axis.y.min = Math.min(ymin, y2min);
   graph.axis.y2.min = Math.min(ymin, y2min);
@@ -340,8 +343,8 @@ function hideTicksByRange(graph, axis = "y", min, max) {
   //if a range is not supplied, generate one from the data
   const genMin = _.isUndefined(min);
   const genMax = _.isUndefined(max);
-  min = genMin ? _.min(_.map(axisSeries, series => _.min(series))) : min;
-  max = genMax ? _.max(_.map(axisSeries, series => _.max(series))) : max;
+  min = genMin ? _.min(_.map(axisSeries, series => _.min(seriesData(series)))) : min;
+  max = genMax ? _.max(_.map(axisSeries, series => _.max(seriesData(series)))) : max;
   //expand generated axis range to include a ceiling or floor tick
   //(may not matter in very short or very tall graphs)
   min = genMin ? min - (max - min) / 4 : min;

--- a/src/core/chart-formatters.js
+++ b/src/core/chart-formatters.js
@@ -208,7 +208,7 @@ function sortSeriesByRank (graph, ranker) {
  */
 function hideSeriesInTooltip (graph, predicate) {
   //determine which series do not appear in the tooltip
-  const hidden = _.pluck(_.filter(graph.data.columns, predicate),0);
+  const hidden = _.map(_.filter(graph.data.columns, predicate),0);
 
   //in order to have a value not show up in the tooltip, it needs to
   //render as undefined in the tooltip value formatting function. 

--- a/src/core/chart-formatters.js
+++ b/src/core/chart-formatters.js
@@ -31,7 +31,7 @@
  *  - displayTicksByRange: only display axis ticks for specific parts of the
  *    data range
  ***************************************************************************/
-import _ from 'underscore';
+import _ from 'lodash';
 import {PRECISION,
         extendedDateToBasicDate,
         capitalizeWords,

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -20,7 +20,7 @@
  *
  ***************************************************************************/
 
-import _ from 'underscore';
+import _ from 'lodash';
 import { PRECISION,
         extendedDateToBasicDate,
         capitalizeWords,

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -20,7 +20,7 @@
  *    and a timestamp, returns a simplified narrow vertical graph showing
  *    only that timestamp. Intended for use as a sidebar.
  ***************************************************************************/
-import _ from 'underscore';
+import _ from 'lodash';
 import {caseInsensitiveStringSearch, getVariableOptions} from './util';
 import {fixedPrecision} from './chart-generators';
 import {assignColoursByGroup, hideSeriesInTooltip,

--- a/src/core/debug-utils.js
+++ b/src/core/debug-utils.js
@@ -1,4 +1,4 @@
-import _ from 'underscore';
+import _ from 'lodash';
 
 function shallowDiff(a, b) {
   // Compute the shallow difference between two objects `a` and `b`.

--- a/src/core/export.js
+++ b/src/core/export.js
@@ -8,7 +8,7 @@
  * Built around the js-xlsx library
  *******************************************************************/
 
-import _ from 'underscore';
+import _ from 'lodash';
 import XLSX from 'xlsx';
 import * as filesaver from 'filesaver.js';
 import axios from 'axios';

--- a/src/core/geo.js
+++ b/src/core/geo.js
@@ -1,4 +1,4 @@
-import _ from 'underscore';
+import _ from 'lodash';
 import { saveAs } from 'filesaver.js';
 import togeojson from 'togeojson';
 import { parse, stringify } from 'wellknown';

--- a/src/core/geo.js
+++ b/src/core/geo.js
@@ -184,7 +184,7 @@ var g = {
     /* All load functions must call `success` handler with a GeoJSON feature */
     var ext = file.name.split('.')[1];
 
-    if (_.contains(['geojson', 'json'], ext)) {
+    if (_.includes(['geojson', 'json'], ext)) {
       this.loadTextFormat(file, success);
     } else if (ext === 'zip') {
       this.loadShapefile(file, success);

--- a/src/core/lodash.mixins.js
+++ b/src/core/lodash.mixins.js
@@ -12,14 +12,16 @@ const assert = (cond, msg) => {
 
 
 _.mixin({
-  // Replace _.max with a version that requires numeric arguments
+  // Replace _.max with a version that requires an array of numbers
   'max': (a) => {
+    assert(_.isArrayLike(a), '_.max(): argument is not an array');
     assert(_.every(a, _.isNumber), '_.max(): argument contains non-numbers');
     return orig.max(a);
   },
 
-  // Replace _.min with a version that requires numeric arguments
+  // Replace _.min with a version that requires an array of numbers
   'min': (a) => {
+    assert(_.isArrayLike(a), '_.min(): argument is not an array');
     assert(_.every(a, _.isNumber), '_.min(): argument contains non-numbers');
     return orig.min(a);
   }

--- a/src/core/lodash.mixins.js
+++ b/src/core/lodash.mixins.js
@@ -1,0 +1,26 @@
+import _ from 'lodash';
+
+
+const orig = _.pick(_, ['min', 'max']);
+
+const assert = (cond, msg) => {
+  console.assert(cond, msg);
+  if (!cond) {
+    throw new Error(msg);
+  }
+} ;
+
+
+_.mixin({
+  // Replace _.max with a version that requires numeric arguments
+  'max': (a) => {
+    assert(_.every(a, _.isNumber), '_.max(): argument contains non-numbers');
+    return orig.max(a);
+  },
+
+  // Replace _.min with a version that requires numeric arguments
+  'min': (a) => {
+    assert(_.every(a, _.isNumber), '_.min(): argument contains non-numbers');
+    return orig.min(a);
+  }
+});

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -3,7 +3,7 @@
  ***********************************************************/
 
 import moment from 'moment/moment';
-import _ from 'underscore';
+import _ from 'lodash';
 import yaml from 'js-yaml';
 import { getVariableOptions as httpGetVariableOptions } from '../data-services/public'
 

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -357,7 +357,7 @@ export function timeResolutions(meta) {
   // return an object containing flags indicating whether each of the
   // 3 standard timescales are present in the datasets described by
   // the metadata.
-  const timescales = _.pluck(meta, 'timescale');
+  const timescales = _.map(meta, 'timescale');
   return {
     monthly: _.includes(timescales, 'monthly'),
     seasonal: _.includes(timescales, 'seasonal'),

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -257,7 +257,7 @@ export const findMatchingMetadata = (
 ) =>
   _.find(metadata, metadatum =>
     // Match exactly on these parameters
-    _.matcher(
+    _.matches(
       { model_id, experiment, variable_id, timescale, ensemble_member }
     )(metadatum) &&
     // Match within `tolerance` on start and end date

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -359,9 +359,9 @@ export function timeResolutions(meta) {
   // the metadata.
   const timescales = _.pluck(meta, 'timescale');
   return {
-    monthly: _.contains(timescales, 'monthly'),
-    seasonal: _.contains(timescales, 'seasonal'),
-    yearly: _.contains(timescales, 'yearly'),
+    monthly: _.includes(timescales, 'monthly'),
+    seasonal: _.includes(timescales, 'seasonal'),
+    yearly: _.includes(timescales, 'yearly'),
   };
 }
 

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -236,7 +236,7 @@ export function getDataUnits(data, variable_id) {
 export function defaultDataSpec({ meta, model_id, variable_id, experiment }) {
   for (const timescale of ['monthly', 'seasonal', 'yearly']) {
     const matchingMetadata =
-      _.findWhere(meta, { model_id, variable_id, experiment, timescale });
+      _.find(meta, { model_id, variable_id, experiment, timescale });
     if (matchingMetadata) {
       return _.pick(matchingMetadata,
         'start_date', 'end_date', 'ensemble_member');

--- a/src/data-services/ncwms.js
+++ b/src/data-services/ncwms.js
@@ -2,7 +2,7 @@
 // Includes both HTTP request functions and supporting functions.
 
 import axios from 'axios/index';
-import _ from 'underscore';
+import _ from 'lodash';
 
 
 export function getBaseWMSParams(

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ import ExternalText from './utils/external-text';
 import App from './components/App';
 import * as serviceWorker from './serviceWorker';
 
+import './core/lodash.mixins';
+
 
 const loadTexts = ExternalText.makeYamlLoader(
   `${process.env.PUBLIC_URL}/${process.env.REACT_APP_EXTERNAL_TEXT}`

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,6 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import './core/lodash.mixins';
 
 configure({ adapter: new Adapter() });
 

--- a/src/utils/external-text.js
+++ b/src/utils/external-text.js
@@ -104,7 +104,7 @@ _.mixin({
       return _.map(collection, traverseValue);
     }
     if (_.isPlainObject(collection)) {
-      return _.mapObject(collection, traverseValue);
+      return _.mapValues(collection, traverseValue);
     }
     return iteratee(collection);
   }

--- a/src/utils/external-text.js
+++ b/src/utils/external-text.js
@@ -78,26 +78,15 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import _ from 'lodash';
-// TODO: We should just be using lodash. RIP lodash.
-import _get from 'lodash.get';
 import axios from 'axios';
 import yaml from 'js-yaml';
 
-_.mixin(_get);
-
 _.mixin({
-  isPlainObject: value => {
-    // Test whether `value` is a simple object, i.e., not also an array, fn, ...
-    // A bit ragged on the edges, but it will do until we adopt lodash.
-    return _.isObject(value) && !_.isArray(value) && !_.isFunction(value) &&
-      !_.isNumber(value);
-  },
-
   mapTraverse: (collection, iteratee) => {
     // Recursively traverse a collection and return a collection with the
     // same structure (array, object) as the collection, but with the leaf
     // (non-object) values replaced by applying function `iteratee` to them.
-    // Unlike other _ map functions, `iteratee` is only passed the value
+    // Unlike other `_` map functions, `iteratee` is only passed the value
     // of the leaf, and not a key or index.
     const traverseValue = value => _.mapTraverse(value, iteratee);
     if (_.isArray(collection)) {

--- a/src/utils/external-text.js
+++ b/src/utils/external-text.js
@@ -77,9 +77,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
-import _ from 'underscore';
-// TODO: We should just be using lodash. RIP underscore.
-import _get from 'underscore.get';
+import _ from 'lodash';
+// TODO: We should just be using lodash. RIP lodash.
+import _get from 'lodash.get';
 import axios from 'axios';
 import yaml from 'js-yaml';
 


### PR DESCRIPTION
Resolves #252 

Q: Why?
A1: Packages we want to use depend on it (peer dependency, or ought to be).
A2: [Underscore is not being maintained and is now regarded as deprecated](https://blogs.dropbox.com/tech/2018/09/migrating-from-underscore-to-lodash/).

From [Lodash wiki: Migrating](https://github.com/lodash/lodash/wiki/Migrating):

- [x] Underscore _.any is Lodash _.some
- [x] Underscore _.all is Lodash _.every
- [x] Underscore _.compose is Lodash _.flowRight
- [x] Underscore _.contains is Lodash _.includes
- [x] Underscore _.each doesn’t allow exiting by returning false
- [x] Underscore _.findWhere is Lodash _.find
- [x] Underscore _.flatten is deep by default while Lodash is shallow
- [x] Underscore _.indexOf with 3rd parameter undefined is Lodash _.indexOf
- [x] Underscore _.indexOf with 3rd parameter true is Lodash _.sortedIndexOf
- [x] Underscore _.indexBy is Lodash _.keyBy
- [x] Underscore _.invoke is Lodash _.invokeMap
- [x] Underscore _.mapObject is Lodash _.mapValues
- [x] Underscore _.max combines Lodash _.max & _.maxBy
- [x] Underscore _.min combines Lodash _.min & _.minBy
- [x] Underscore _.sample combines Lodash _.sample & _.sampleSize
- [x] Underscore _.object combines Lodash _.fromPairs and _.zipObject
- [x] Underscore _.omit by a predicate is Lodash _.omitBy
- [x] Underscore _.pairs is Lodash _.toPairs
- [x] Underscore _.pick by a predicate is Lodash _.pickBy
- [x] Underscore _.pluck is Lodash _.map
- [x] Underscore _.uniq by an iteratee is Lodash _.uniqBy
- [x] Underscore _.where is Lodash _.filter
- [x] Underscore _.isFinite doesn’t align with Number.isFinite
      (e.g. _.isFinite('1') returns true in Underscore but false in Lodash)
- [x] Underscore _.matches shorthand doesn’t support deep comparisons
      (e.g. _.filter(objects, { 'a': { 'b': 'c' } }))
- [x] Underscore ≥ 1.7 & Lodash _.template syntax is
      _.template(string, option)(data)
- [x] Lodash _.memoize caches are Map like objects
- [ ] Lodash doesn’t support a context argument for many methods in favor of _.bind
- [x] Lodash supports implicit chaining, lazy chaining, & shortcut fusion
- [x] Lodash split its overloaded _.head, _.last, _.rest, & _.initial out into
      _.take, _.takeRight, _.drop, & _.dropRight 
      (i.e. _.head(array, 2) in Underscore is _.take(array, 2) in Lodash)
    - [x] _.head
    - [x] _.last
    - [x] _.rest
    - [x] _.initial

Additionally:

- [x] Underscore _.uniq with a boolean 2nd param is Lodash _.sortedUniq
- [x] Underscore _.uniq with a boolean 2nd param and iteratee 3rd param is Lodash _.sortedUniqBy

Found during testing:

- [x] Underscore _.min, _.max return min, max of values in an object; Lodash _.min, _.max returns undefined for an object (e.g., Underscore _.min({ a: 2, b: 1}) === 1; Lodash _.min({ a: 2, b: 1}) === undefined)
- [x] Underscore _.min, _.max (apparently) ignore non-number members of the argument; Lodash does not; behaviour is complicated when non-numbers are present, but it will sometimes return a string value (even if it does not evaluate to a number).
- [x] Underscore _.matcher is Lodash _.matches