### PR TITLE
Resolve #322; update default model

### DIFF
--- a/src/components/AppMixin/AppMixin.js
+++ b/src/components/AppMixin/AppMixin.js
@@ -97,7 +97,7 @@ var AppMixin = {
         }
 
         const model_id = this.state.model_id ? this.state.model_id :
-          specifiedIfAvailable("model_id", "CanESM2", models);
+          specifiedIfAvailable("model_id", "PCIC12", models);
         const experiment = this.state.experiment ? this.state.experiment :
           specifiedIfAvailable("experiment", "historical, rcp85", _.where(models, {model_id: model_id}));
         const variable_id = specifiedIfAvailable("variable_id", "pr",


### PR DESCRIPTION
Updates the default model to `PCIC12` for all portals. 

(The Extreme Precipitation portal doesn't actually have access to any PCIC12 data, so it falls back onto an arbitrary model, which seems, in practice, to be CanESM2.)