### PR TITLE
Improve deploy version setting mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@
 # In future, as we scale up, we may want to use an Alpine base image, which would reduce
 # the size of the image by about an order of magnitude and reduce the attack surface of
 # the image as well.
+
+# docker build --build-arg REACT_APP_CE_CURRENT_VERSION=$(./generate-commitish.sh)
 FROM node:10.16
 
 ADD . /app
@@ -12,6 +14,12 @@ WORKDIR /app
 
 ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json /app/package.json
+
+# Move the build arg REACT_APP_CE_CURRENT_VERSION into an
+# environment variable of the same name, for consumption
+# by the npm build process in ./entrypoint.sh
+ARG REACT_APP_CE_CURRENT_VERSION
+ENV REACT_APP_CE_CURRENT_VERSION $REACT_APP_CE_CURRENT_VERSION
 
 RUN npm install --quiet
 RUN npm install -g serve

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 # This Dockerfile adapted from https://mherman.org/blog/dockerizing-a-react-app/
 
+# This Dockerfile can (and should) be used to pass through automatically generated
+# version information to the build which is triggered when the image is run.
+# To do this, issue the following build command:
+#
+# docker build --build-arg REACT_APP_CE_CURRENT_VERSION=$(./generate-commitish.sh)
+
 # At this moment, Node.js 10.16 LTS is recommended for most users.
 #
 # In future, as we scale up, we may want to use an Alpine base image, which would reduce
 # the size of the image by about an order of magnitude and reduce the attack surface of
 # the image as well.
 
-# docker build --build-arg REACT_APP_CE_CURRENT_VERSION=$(./generate-commitish.sh)
 FROM node:10.16
 
 ADD . /app
@@ -15,16 +20,16 @@ WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json /app/package.json
 
-# Move the build arg REACT_APP_CE_CURRENT_VERSION into an
-# environment variable of the same name, for consumption
-# by the npm build process in ./entrypoint.sh
-ARG REACT_APP_CE_CURRENT_VERSION
-ENV REACT_APP_CE_CURRENT_VERSION $REACT_APP_CE_CURRENT_VERSION
-
 RUN npm install --quiet
 RUN npm install -g serve
 COPY . /app
 
 EXPOSE 8080
+
+# Move the build arg REACT_APP_CE_CURRENT_VERSION into an
+# environment variable of the same name, for consumption
+# by the npm build process in ./entrypoint.sh
+ARG REACT_APP_CE_CURRENT_VERSION
+ENV REACT_APP_CE_CURRENT_VERSION $REACT_APP_CE_CURRENT_VERSION
 
 CMD ["/bin/bash", "./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # version information to the build which is triggered when the image is run.
 # To do this, issue the following build command:
 #
-# docker build --build-arg REACT_APP_CE_CURRENT_VERSION=$(./generate-commitish.sh)
+# docker build --build-arg REACT_APP_CE_CURRENT_VERSION="$(./generate-commitish.sh)" -t <tag> .
 
 # At this moment, Node.js 10.16 LTS is recommended for most users.
 #

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Environment variables for configuring the app are:
 
 `REACT_APP_CE_CURRENT_VERSION`
 * Current version of the app.
-* This value is set automatically by the Dockerfile (via `./entrypoint.sh`)
+* This value should be set using `generate-commitish.sh` when the Docker image is built (see below).
+* It is not recommended to manually override the automatically generated value when the image is run.
 * No default value for this variable is provided in any `.env` file.
 
 `REACT_APP_CE_BACKEND_URL`
@@ -235,8 +236,14 @@ of the name and just using `climate-explorer-frontend`.
 Build a docker image:
 
 ```bash
-docker build -t climate-explorer-frontend .
+docker build -t climate-explorer-frontend \
+    --build-arg REACT_APP_CE_CURRENT_VERSION="$(./generate-commitish.sh)" .
 ```
+
+Setting build arg `REACT_APP_CE_CURRENT_VERSION` as above is the most reliable
+way to inject an accurate version into the final app. This value can be overridden
+when the image is run, but it is not recommended, as it introduces the possibility 
+of error.
 
 #### Tag docker image
 
@@ -279,12 +286,6 @@ All are given standard development and production values in the files
 `.env`, `.env.development`, and `.env.production`.
 
 These can be overridden at run time by providing them in the `docker run` command (`-e` option).
-
-The only environment variable that must be set outside of the `.env` files is:
-
-* `REACT_APP_CE_CURRENT_VERSION` 
-  * (If no value is set for this variable, the app still works, but the version
-    cannot be displayed in the Help.)
 
 In addition, we mount the configuration files as volumes in the container.
 This enables us to update these files without rebuilding or redeploying the app. 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Environment variables for configuring the app are:
 
 `REACT_APP_CE_CURRENT_VERSION`
 * Current version of the app.
-* In production, suggested value is release semver, e.g., 2.0.1.
+* This value is set automatically by the Dockerfile (via `./entrypoint.sh`)
 * No default value for this variable is provided in any `.env` file.
 
 `REACT_APP_CE_BACKEND_URL`
@@ -296,7 +296,6 @@ Typical production run:
 docker run --restart=unless-stopped -d 
   -e PUBLIC_URL=<deployment url, including base path>
   -e REACT_APP_CE_BASE_PATH=<deployment base path>
-  -e REACT_APP_CE_CURRENT_VERSION=<semver>
   -e <other env variable>=<value>
   -p <external port>:8080 
   --name climate-explorer-frontend

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,11 @@
 # container a lot heavier, but we don't spin up many instances, or often,
 # so it doesn't matter.
 
+# This is a problem because it requres git to be installed in the image
+# Better to feed it in earlier in the build process; i.e., during image build
+#export REACT_APP_CE_CURRENT_VERSION=$(./generate-commitish.sh)
+echo REACT_APP_CE_CURRENT_VERSION "$REACT_APP_CE_CURRENT_VERSION"
+echo PUBLIC_URL "$PUBLIC_URL"
+echo REACT_APP_CE_BASE_PATH "$REACT_APP_CE_BASE_PATH"
 npm run build
 serve -s build -l 8080

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,11 +4,5 @@
 # container a lot heavier, but we don't spin up many instances, or often,
 # so it doesn't matter.
 
-# This is a problem because it requres git to be installed in the image
-# Better to feed it in earlier in the build process; i.e., during image build
-#export REACT_APP_CE_CURRENT_VERSION=$(./generate-commitish.sh)
-echo REACT_APP_CE_CURRENT_VERSION "$REACT_APP_CE_CURRENT_VERSION"
-echo PUBLIC_URL "$PUBLIC_URL"
-echo REACT_APP_CE_BASE_PATH "$REACT_APP_CE_BASE_PATH"
 npm run build
 serve -s build -l 8080

--- a/generate-commitish.sh
+++ b/generate-commitish.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-#Generates a commitish string for climate explorer and stores it in 
-# the CE_CURRENT_VERSION environment variable.
+#Generates a commitish string for climate explorer
 
 VERSIONTAG="$(git describe --tags --abbrev=0)"
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"


### PR DESCRIPTION
Resolves #335 

This PR allows the user to inject, at image build time, a mechanically generated version code into the Nodejs build process that happens when the image is run.

README provides details of how to do this.