### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 node {
-    stage('Collecting Code') {
+    stage('Code Collection') {
         checkout scm
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,12 +15,7 @@ node {
 
     stage ('Build Image') {
         String image_name = 'climate-explorer-frontend'
-        String branch_name = BRANCH_NAME
-
-        // If branch is under PR review we need to get the name from elsewhere
-        if (branch_name.toLowerCase().contains('pr')) {
-            branch_name = CHANGE_BRANCH
-        }
+        String branch_name = BRANCH_NAME.toLowerCase()
 
         // Update image name if we are not on the master branch
         if (branch_name != 'master') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,30 +1,34 @@
 node {
-    sh 'printenv'
-    // stage('Collecting Code') {
-    //     checkout scm
-    // }
-    //
-    // nodejs('node') {
-    //     stage('Installation') {
-    //         sh 'npm install'
-    //     }
-    //
-    //     stage('Test Suite') {
-    //         sh 'npm run jenkins-test'
-    //     }
-    // }
-    //
-    // stage ('Build Image') {
-    //     String image_name = 'climate-explorer-frontend'
-    //     String branch_name = env.BRANCH_NAME
-    //
-    //     // Update image name if we are not on the master branch
-    //     if (branch_name != 'master') {
-    //         image_name = image_name + '/' + branch_name
-    //     }
-    //
-    //     withDockerServer([uri: env.PCIC_DOCKER]) {
-    //         def image = docker.build(image_name)
-    //     }
-    // }
+    stage('Collecting Code') {
+        checkout scm
+    }
+
+    nodejs('node') {
+        stage('Installation') {
+            sh 'npm install'
+        }
+
+        stage('Test Suite') {
+            sh 'npm run jenkins-test'
+        }
+    }
+
+    stage ('Build Image') {
+        String image_name = 'climate-explorer-frontend'
+        String branch_name = BRANCH_NAME
+
+        // If branch is under PR review we need to get the name from elsewhere
+        if (branch_name.toLowerCase().contains('pr')) {
+            branch_name = CHANGE_NAME
+        }
+
+        // Update image name if we are not on the master branch
+        if (branch_name != 'master') {
+            image_name = image_name + '/' + branch_name
+        }
+
+        withDockerServer([uri: PCIC_DOCKER]) {
+            def image = docker.build(image_name)
+        }
+    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ node {
         }
 
         stage('Test Suite') {
-            sh 'npm run ci'
+            sh 'npm run jenkins-test'
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,28 +1,30 @@
 node {
-    stage('Collecting Code') {
-        checkout scm
-    }
-    nodejs('node') {
-        stage('Installation') {
-            sh 'npm install'
-        }
-
-        stage('Test Suite') {
-            sh 'npm run jenkins-test'
-        }
-    }
-
-    stage ('Build Image') {
-        String image_name = 'climate-explorer-frontend'
-        String branch_name = env.BRANCH_NAME
-
-        // Update image name if we are not on the master branch
-        if (branch_name != 'master') {
-            image_name = image_name + '/' + branch_name
-        }
-
-        withDockerServer([uri: env.PCIC_DOCKER]) {
-            def image = docker.build(image_name)
-        }
-    }
+    sh 'printenv'
+    // stage('Collecting Code') {
+    //     checkout scm
+    // }
+    //
+    // nodejs('node') {
+    //     stage('Installation') {
+    //         sh 'npm install'
+    //     }
+    //
+    //     stage('Test Suite') {
+    //         sh 'npm run jenkins-test'
+    //     }
+    // }
+    //
+    // stage ('Build Image') {
+    //     String image_name = 'climate-explorer-frontend'
+    //     String branch_name = env.BRANCH_NAME
+    //
+    //     // Update image name if we are not on the master branch
+    //     if (branch_name != 'master') {
+    //         image_name = image_name + '/' + branch_name
+    //     }
+    //
+    //     withDockerServer([uri: env.PCIC_DOCKER]) {
+    //         def image = docker.build(image_name)
+    //     }
+    // }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+node {
+    nodejs('node') {
+        stage('Installation') {
+            sh 'npm install'
+        }
+        stage('Test Suite') {
+            sh 'npm run ci'
+        }
+    }
+    stage ('Build Image') {
+        withDockerServer([uri: env.PCIC_DOCKER]) {
+            def freshImage = docker.build("testimage")
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
 
         // If branch is under PR review we need to get the name from elsewhere
         if (branch_name.toLowerCase().contains('pr')) {
-            branch_name = CHANGE_NAME
+            branch_name = CHANGE_BRANCH
         }
 
         // Update image name if we are not on the master branch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,13 +3,23 @@ node {
         stage('Installation') {
             sh 'npm install'
         }
+
         stage('Test Suite') {
             sh 'npm run ci'
         }
     }
+
     stage ('Build Image') {
+        String image_name = 'climate-explorer-frontend'
+        String branch_name = env.BRANCH_NAME
+
+        // Update image name if we are not on the master branch
+        if (branch_name != 'master') {
+            image_name = image_name + '/' + branch_name
+        }
+
         withDockerServer([uri: env.PCIC_DOCKER]) {
-            def freshImage = docker.build("testimage")
+            def image = docker.build(image_name)
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
 node {
+    stage('Collecting Code') {
+        checkout scm
+    }
     nodejs('node') {
         stage('Installation') {
             sh 'npm install'

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you *really* want to skip the linting during a commit, you can always run `gi
 
 #### Jenkins
 
-To be filled
+Jenkins automatically handles the generation of docker images.
 
 ##### Configuration, environment variables, and Docker
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ In a Create React App app, [environment variables are managed carefully](https:/
 Therefore, most of the environment variables below begin with `REACT_APP_`, as required by CRA.
 
 CRA also provides a convenient system for setting default values of environment variables
-in various contexts (development, production, etc.). 
+in various contexts (development, production, etc.).
 
 Brief summary:
- 
+
 * `.env`: Global default settings
 * `.env.development`: Development-specific settings (`npm start`)
 * `.env.production`: Production-specific settings (`npm run build`)
 
-For more details, see the 
+For more details, see the
 [CRA documentation](https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables)).
 
 Environment variables for configuring the app are:
@@ -46,7 +46,7 @@ Environment variables for configuring the app are:
 * **WARNING**: The path component of this value **MUST** match `REACT_APP_CE_BASE_PATH` (see below).
 
 `REACT_APP_CE_BASE_PATH`
-* Base **path** of the URL for the CE frontend app; 
+* Base **path** of the URL for the CE frontend app;
 * For production, set this to the path component of the URL for CE configured in our proxy server.
 * **WARNING**: This **MUST** match the path component of `PUBLIC_URL` (see above).
 
@@ -90,9 +90,9 @@ See Production section below for information on "live updating" this file.
 
 ## Development
 
-This project is now based on [Create React App](https://github.com/facebook/create-react-app). 
-Originally it was a manually managed Webpack/Babel project, 
-but, for a variety of reasons you can read about in [issue 297](https://github.com/pacificclimate/climate-explorer-frontend/issues/297), 
+This project is now based on [Create React App](https://github.com/facebook/create-react-app).
+Originally it was a manually managed Webpack/Babel project,
+but, for a variety of reasons you can read about in [issue 297](https://github.com/pacificclimate/climate-explorer-frontend/issues/297),
 we "rebased" it on CRA.
 
 ### Installation
@@ -100,7 +100,7 @@ we "rebased" it on CRA.
 You **must** use a version of `npm` >= 5.5.1. This version of `npm` comes with `node` 9.2.0.
 If you are using nvm, then run `nvm use 9.2.0` (or higher; ver 11.13 works fine too).
 
-(`npm` 5.5.1 / `node` 9.2.0 is known to work; `npm` 3.5.2 / `node` 8.10.0 is known to fail to install certain required dependencies. 
+(`npm` 5.5.1 / `node` 9.2.0 is known to work; `npm` 3.5.2 / `node` 8.10.0 is known to fail to install certain required dependencies.
 Intermediate versions may or may not work.)
 
 With the appropriate versions of `node`/`npm` in use:
@@ -109,7 +109,7 @@ With the appropriate versions of `node`/`npm` in use:
 npm install
 ```
 
-If you need to start fresh after much messing about, the `reinstall` script 
+If you need to start fresh after much messing about, the `reinstall` script
 deletes `./node_modules/` and then installs:
 
 ```bash
@@ -145,14 +145,18 @@ If you *really* want to skip the linting during a commit, you can always run `gi
 
 ### Notes
 
+#### Jenkins
+
+To be filled
+
 ##### Configuration, environment variables, and Docker
 
-It is best practice to configure a web app externally, at run-time, typically using environment variables for any 
+It is best practice to configure a web app externally, at run-time, typically using environment variables for any
 simple (atomic, e.g., string) configuration values.
 
-Here we run into a problem introduced by CRA: 
-CRA injects environment variables only at _build time_, not at run time. 
-["The environment variables are embedded during the build time. Since Create React App produces a static 
+Here we run into a problem introduced by CRA:
+CRA injects environment variables only at _build time_, not at run time.
+["The environment variables are embedded during the build time. Since Create React App produces a static
 HTML/CSS/JS bundle, it can’t possibly read them at runtime."](https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables).
 
 We containerize our apps with Docker. A natural approach to deploying apps with Docker is to build the app as
@@ -166,25 +170,25 @@ these Dockerized applications. There are two basic approaches:
 1. Build the app, and inject run-time environment variables, as part of the image run (i.e., the command run
 by the image includes building the app, which then has access to environment variables provided via the `docker run`
 command).
-    * This is simple but it means that containers are slow to start up and contain a lot of infrastructure 
+    * This is simple but it means that containers are slow to start up and contain a lot of infrastructure
     (Node.js, etc.) needed to build the image. This isn't an issue for us, because we don't start many instances and
     we don't do it often.
 
-2. Fetch the environment variables (or a configuration file) from the server. 
-    * This approach has several variants, which are outlined in this 
-    [CRA issue](https://github.com/facebook/create-react-app/issues/2353). 
+2. Fetch the environment variables (or a configuration file) from the server.
+    * This approach has several variants, which are outlined in this
+    [CRA issue](https://github.com/facebook/create-react-app/issues/2353).
     * The way we load the external text and variable options files falls under into this category.
 
 A key requirement is to be able to configure at run time the the URL at which the app is deployed.
-CRA provides a (build-time) environment variable for this, `PUBLIC_URL`. 
+CRA provides a (build-time) environment variable for this, `PUBLIC_URL`.
 (Climate Explorer also, as a legacy from pre-CRA versions, uses an overlapping environment variable
 `REACT_APP_CE_BASE_PATH`. See Configuration > Environment variables, above.)
 
 Option 2 makes setting `PUBLIC_URL` _much_ harder to accomplish, and would require significant changes to the
-codebase. 
- 
-Option 1 makes setting `PUBLIC_URL` simple and requires almost no change to the codebase; 
-as noted we don't care about the cost of using such containers. 
+codebase.
+
+Option 1 makes setting `PUBLIC_URL` simple and requires almost no change to the codebase;
+as noted we don't care about the cost of using such containers.
 
 Therefore we have chosen option 1.
 
@@ -193,24 +197,24 @@ Therefore we have chosen option 1.
 A key requirement is to be able to configure at run time the the URL at which the app is deployed.
 
 Because we are using React Router v4 (react-router-dom), and therefore the HTML5 `pushState` history API via
-its [dependency](https://reacttraining.com/react-router/web/api/history) 
-[`history`](https://github.com/ReactTraining/history), 
+its [dependency](https://reacttraining.com/react-router/web/api/history)
+[`history`](https://github.com/ReactTraining/history),
 we [cannot use](https://facebook.github.io/create-react-app/docs/deployment#serving-the-same-build-from-different-paths) t
 he relatively simple `package.json` `homepage` property.
 
 Instead we must use CRA-provided build-time environment variable `PUBLIC_URL`.
 
-* It is [discussed briefly](https://facebook.github.io/create-react-app/docs/using-the-public-folder) 
+* It is [discussed briefly](https://facebook.github.io/create-react-app/docs/using-the-public-folder)
 as the URL for the `public` folder, of which we make use for dynamic configuration assets such as
 external text and variable configuration files.
 
-* `PUBLIC_URL` is also discussed more interestingly in 
+* `PUBLIC_URL` is also discussed more interestingly in
 [Advanced Configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration):
 
-    > Create React App assumes your application is hosted at the serving web server's root or a subpath as 
-specified in package.json (homepage). Normally, Create React App ignores the 
-hostname. You may use this variable to force assets to be referenced verbatim 
-to the url you provide (hostname included). This may be particularly useful 
+    > Create React App assumes your application is hosted at the serving web server's root or a subpath as
+specified in package.json (homepage). Normally, Create React App ignores the
+hostname. You may use this variable to force assets to be referenced verbatim
+to the url you provide (hostname included). This may be particularly useful
 when using a CDN to host your application.
 
 `PUBLIC_URL` serves much the same purpose as our custom env variable `REACT_APP_CE_BASE_PATH`.
@@ -219,7 +223,7 @@ This redundancy will be eliminated in a future verison of CE.
 ### Setup using Docker
 
 We use Docker for production deployment.
- 
+
 It can also be useful in development; for example, to test a proposed volume mounting for the container.
 
 #### Build docker image manually
@@ -242,7 +246,7 @@ docker build -t climate-explorer-frontend \
 
 Setting build arg `REACT_APP_CE_CURRENT_VERSION` as above is the most reliable
 way to inject an accurate version into the final app. This value can be overridden
-when the image is run, but it is not recommended, as it introduces the possibility 
+when the image is run, but it is not recommended, as it introduces the possibility
 of error.
 
 #### Tag docker image
@@ -250,7 +254,7 @@ of error.
 Dockerhub automatically assigned the tag `latest` to the latest build.
 That was convenient, but ...
 
-For manual build procedures, 
+For manual build procedures,
 [tagging with `latest` is not considered a good idea](https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375).
 It is better (and easy and immediately obvious) to tag with version/release
 numbers. In this example, we will tag with version 1.2.3.
@@ -263,14 +267,14 @@ numbers. In this example, we will tag with version 1.2.3.
    climate-explorer-frontend                                          latest              14cb66d3d145        22 seconds ago      867MB
 
    ```
-   
+
 1. Tag the image:
 
    ```bash
    Tag the image
    $ docker tag 1040e7f07e5d docker-registry01.pcic.uvic.ca:5000/climate-explorer-frontend:1.2.3
    ```
-   
+
 #### Push docker image to PCIC docker registry
 
 [PCIC maintains its own docker registry](https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=3506599). We place manual builds in this registry:
@@ -288,17 +292,17 @@ All are given standard development and production values in the files
 These can be overridden at run time by providing them in the `docker run` command (`-e` option).
 
 In addition, we mount the configuration files as volumes in the container.
-This enables us to update these files without rebuilding or redeploying the app. 
+This enables us to update these files without rebuilding or redeploying the app.
 See the section below for details.
 
 Typical production run:
 
 ```bash
-docker run --restart=unless-stopped -d 
+docker run --restart=unless-stopped -d
   -e PUBLIC_URL=<deployment url, including base path>
   -e REACT_APP_CE_BASE_PATH=<deployment base path>
   -e <other env variable>=<value>
-  -p <external port>:8080 
+  -p <external port>:8080
   --name climate-explorer-frontend
   - v /path/to/external/variable-options.yaml:/app/build/variable-options.yaml
   - v /path/to/external/external-texts/default.yaml:/app/build/external-texts/default.yaml
@@ -317,13 +321,13 @@ Specifically:
 | External texts    | `REACT_APP_EXTERNAL_TEXT`     |  external-text/default.yaml   |
 | Variable options  | `REACT_APP_VARIABLE_OPTIONS`  | variable-options.yaml         |
 
-During a build (`npm run build`), 
+During a build (`npm run build`),
 files in the `public` folder are copied directly, without bundling, to the build directory (normally, `./build`).
 Files in the `build` folder can be updated on the fly, so that changes to them can be made without creating
 a new release of Climate Explorer.
 
-When running the app in a production environment, we mount an external configuration file as a volume 
-in the docker container. (See section above.) 
+When running the app in a production environment, we mount an external configuration file as a volume
+in the docker container. (See section above.)
 This external file can be modified, and the container restarted, to provide an updated version of the
 variable options file without needing to modify source code, create a new release, or rebuild the image.
 
@@ -335,9 +339,9 @@ To change the configuration file without creating a new release of the app:
 Alternatives:
 
 * Stop the app and start it again with a different value for the associated environment variable,
-  and a corresponding volume mount for this new file. 
+  and a corresponding volume mount for this new file.
 
-To prevent tears, hair loss, and the cursing of your name by future developers (including yourself), 
+To prevent tears, hair loss, and the cursing of your name by future developers (including yourself),
 we **strongly recommend also updating** the source configuration files in the repo (in the `public` folder)
 with any changes made, so that they are in fact propagated to later versions. "Hot updates" should not be stored
 outside of the version control system.
@@ -359,20 +363,20 @@ git push --follow-tags
 
 ## Code style standard compliance
 
-We have nominally 
-[adopted](https://github.com/pacificclimate/climate-explorer-frontend/issues/138) 
+We have nominally
+[adopted](https://github.com/pacificclimate/climate-explorer-frontend/issues/138)
 the default ESLint code style.
 We aren't enforcing it right now, unfortunately.
 
 Enforcement aside, we continue to commit code that is in violation of these
-standards, which is undesirable for at least two reasons: 
+standards, which is undesirable for at least two reasons:
 
 - Following a coding standard makes the code _much_ easier to read.
-- For those of us with an IDE plugin that flags standards violations, 
+- For those of us with an IDE plugin that flags standards violations,
   they appear _all over the place_, which is distracting to say the least.
 
 The coding standard we adopted has a lot of rules, but the following are the
-ones we are violating most. A small effort could radically reduce the number 
+ones we are violating most. A small effort could radically reduce the number
 of new violations we introduce. In approximate order of frequency of violation:
 
 1. Limit line length to 80 characters.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you *really* want to skip the linting during a commit, you can always run `gi
 
 #### Jenkins
 
-Jenkins automatically handles the generation of docker images.  Currently it is configured to trigger an image build each push on individual branches.
+Jenkins automatically handles the generation of docker images.  Currently it is configured to trigger an image build for each push on individual branches.  The image generated will have the name `climate-explorer-frontend/[branch_name]`.
 
 ##### Configuration, environment variables, and Docker
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you *really* want to skip the linting during a commit, you can always run `gi
 
 #### Jenkins
 
-Jenkins automatically handles the generation of docker images.
+Jenkins automatically handles the generation of docker images.  Currently it is configured to trigger an image build each push on individual branches.
 
 ##### Configuration, environment variables, and Docker
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "start:rg": "CE_BACKEND_URL=https://services.pacificclimate.org/marmot/api NCWMS_URL=https://services.pacificclimate.org/marmot/ncwms TILECACHE_URL=https://tiles.pacificclimate.org/tilecache/tilecache.py CE_ENSEMBLE_NAME=all_downscale_files CE_CURRENT_VERSION=$(./generate-commitish.sh) react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --transformIgnorePatterns \"node_modules/(?!(leaflet|pcic-react-components)/)\"",
-    "ci": "CI=true react-scripts test --env=jsdom --transformIgnorePatterns \"node_modules/(?!(leaflet|pcic-react-components)/)\"",
+    "jenkins-test": "CI=true react-scripts test --env=jsdom --transformIgnorePatterns \"node_modules/(?!(leaflet|pcic-react-components)/)\"",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "start:rg": "CE_BACKEND_URL=https://services.pacificclimate.org/marmot/api NCWMS_URL=https://services.pacificclimate.org/marmot/ncwms TILECACHE_URL=https://tiles.pacificclimate.org/tilecache/tilecache.py CE_ENSEMBLE_NAME=all_downscale_files CE_CURRENT_VERSION=$(./generate-commitish.sh) react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --transformIgnorePatterns \"node_modules/(?!(leaflet|pcic-react-components)/)\"",
+    "ci": "CI=true react-scripts test --env=jsdom --transformIgnorePatterns \"node_modules/(?!(leaflet|pcic-react-components)/)\"",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
In order to run a pipeline on Jenkins a repo requires a `Jenkinsfile`.  This file is responsible for configuring the stages of a pipeline and the actions it takes.  The `Jenkinsfile` I have created simply runs our unit tests and then creates a docker image.

I added a new `npm run` command for running tests in a CI environment.  The regular testing command required user input to run through the tests which was causing hangups in Jenkins.

The image is named `climate-explorer-frontend` for pushes to master and `climate-explorer-frontend/[branch_name]` for all other branches.  I have not found any strict naming conventions for docker images, so this is open for us to discuss.