### PR TITLE
Update Jenkins Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,8 +17,19 @@ node {
     String name = BASE_REGISTRY + 'climate-explorer-frontend'
 
     // tag branch
-    if (BRANCH_NAME != 'master') {
+    if (BRANCH_NAME == 'master') {
+        // figure out how to tag
+    } else {
         name = name + ':' + BRANCH_NAME + "_${BUILD_ID}"
+    }
+
+    stage('testing for payload string') {
+        def payloadString = build.buildVariableResolver.resolve("payload")
+        sh "${payloadString}"
+        payloadObject = new groovy.json.JsonSlurper().parseText(payloadString)
+        sh "${payloadObject}"
+        name_test = payloadObject.pusher.name
+        sh "${name_test}"
     }
 
     stage('Build and Publish Image') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,9 +32,11 @@ node {
     }
 
     stage('Remove Local Image') {
-        sh "docker rmi ${name}"
+        withDockerServer([uri: PCIC_DOCKER]){
+            sh "docker rmi ${name}"
+        }
     }
-    
+
     stage('Security Scan') {
         writeFile file: 'anchore_images', text: name
         anchore name: 'anchore_images', engineRetries: '700'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,6 @@ node {
 
     stage('Security Scan') {
         writeFile file: 'anchore_images', text: name
-        anchore name: 'anchore_images', engineRetries: 700
+        anchore name: 'anchore_images', engineRetries: '700'
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,6 @@ node {
 
     stage('Security Scan') {
         writeFile file: 'anchore_images', text: name
-        anchore name: 'anchore_images'
+        anchore name: 'anchore_images', engineRetries: 700
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ node {
     if (BRANCH_NAME == 'master') {
         // TODO: detect tags and releases for master
     } else {
-        name = name + ':' + BRANCH_NAME + "_${BUILD_ID}"
+        name = name + ':' + BRANCH_NAME
     }
 
     stage('Build and Publish Image') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,9 +16,12 @@ node {
     def image
     String name = BASE_REGISTRY + 'climate-explorer-frontend'
 
+    // tag branch
     if (BRANCH_NAME != 'master') {
         name = name + ':' + BRANCH_NAME + "_${BUILD_ID}"
     }
+
+    sh 'printenv'
 
     stage('Build and Push Image') {
         withDockerServer([uri: PCIC_DOCKER]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,9 +19,16 @@ node {
     // tag branch
     if (BRANCH_NAME != 'master') {
         name = name + ':' + BRANCH_NAME + "_${BUILD_ID}"
+    } else {
+        // check for git tag
+        def tag = sh(returnStdout: true, script: "git tag --contains | head -1").trim()
+        if (tag) {
+            stage('EXTRA STAGE') {
+                sh 'echo "YOU ARE HERE"'
+            }
+        }
     }
 
-    sh 'printenv'
 
     stage('Build and Push Image') {
         withDockerServer([uri: PCIC_DOCKER]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,13 +21,7 @@ node {
         name = name + ':' + BRANCH_NAME + "_${BUILD_ID}"
     }
 
-    stage('Get Tag') {
-        sh "git tag --sort version:refname | tail -1 > version.tmp"
-        String tag = readFile('version.tmp')
-        println tag
-    }
-
-    stage('Build and Push Image') {
+    stage('Build and Publish Image') {
         withDockerServer([uri: PCIC_DOCKER]) {
             image = docker.build(name)
 
@@ -37,6 +31,10 @@ node {
         }
     }
 
+    stage('Remove Local Image') {
+        sh "docker rmi ${name}"
+    }
+    
     stage('Security Scan') {
         writeFile file: 'anchore_images', text: name
         anchore name: 'anchore_images', engineRetries: '700'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,13 +16,12 @@ node {
     def image
     String name = BASE_REGISTRY + 'climate-explorer-frontend'
 
-    if (BRANCH_NAME.toLowerCase() != 'master') {
-        name = name + '-' + BRANCH_NAME
+    if (BRANCH_NAME != 'master') {
+        name = name + ':' + BRANCH_NAME + "_${BUILD_ID}"
     }
 
     stage('Build and Push Image') {
         withDockerServer([uri: PCIC_DOCKER]) {
-            name = name + ":${BUILD_ID}"
             image = docker.build(name)
 
             docker.withRegistry('', 'PCIC_DOCKERHUB_CREDS') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ node {
     }
 
     stage('testing for payload string') {
+        import hudson.model.*
         def payloadString = build.buildVariableResolver.resolve("payload")
         sh "${payloadString}"
         payloadObject = new groovy.json.JsonSlurper().parseText(payloadString)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ node {
 
     stage('Build and Push Image') {
         withDockerServer([uri: PCIC_DOCKER]) {
-            name = name + ':${BUILD_ID}'
+            name = name + ":${BUILD_ID}"
             image = docker.build(name)
 
             docker.withRegistry('', 'PCIC_DOCKERHUB_CREDS') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,16 +19,13 @@ node {
     // tag branch
     if (BRANCH_NAME != 'master') {
         name = name + ':' + BRANCH_NAME + "_${BUILD_ID}"
-    } else {
-        // check for git tag
-        def tag = sh(returnStdout: true, script: "git tag --contains | head -1").trim()
-        if (tag) {
-            stage('EXTRA STAGE') {
-                sh 'echo "YOU ARE HERE"'
-            }
-        }
     }
 
+    stage('Get Tag') {
+        sh "git tag --sort version:refname | tail -1 > version.tmp"
+        String tag = readFile('version.tmp')
+        println tag
+    }
 
     stage('Build and Push Image') {
         withDockerServer([uri: PCIC_DOCKER]) {


### PR DESCRIPTION
Here are the changes in this PR:
- automatically push images to [docker hub](https://hub.docker.com/orgs/pcic/repositories) using jenkins user
- updated naming to accommodate docker hub (ex. `pcic/[tool_name]:[branch_name]_[build_id]`)
- conduct security scan of image
- automate cleanup docker image on `dev01`

A concern I have with this change is the amount of tags that could get pushed to docker hub.  The `build_id` tag suffix refers to the number of pipeline builds which correlates to the number of pushes on that branch.  On the one hand, these unique tags could prove useful if a particular push breaks something, on the other hand, it may be overkill to create so many unique tags. 
