### PR TITLE
Use getScanName feature

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,9 +12,10 @@ node {
 
     def image
     def imageName
+    def imageSuffix = 'climate-explorer-frontend'
 
     stage('Build Image') {
-        (image, imageName) = buildDockerImage('climate-explorer-frontend')
+        (image, imageName) = buildDockerImage(imageSuffix)
     }
 
     stage('Publish Image') {
@@ -23,7 +24,7 @@ node {
 
     if(BRANCH_NAME.contains('PR')) {
         stage('Security Scan') {
-            writeFile file: 'anchore_images', text: imageName
+            writeFile file: 'anchore_images', text: getScanName(imageSuffix)
             anchore name: 'anchore_images', engineRetries: '700'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ node {
         publishDockerImage(image, 'PCIC_DOCKERHUB_CREDS')
     }
 
-    if(BRANCH_NAME.contains('PR')) {
+    if(BRANCH_NAME.contains('PR') || BRANCH_NAME == 'master') {
         stage('Security Scan') {
             writeFile file: 'anchore_images', text: getScanName(imageSuffix)
             anchore name: 'anchore_images', engineRetries: '700'


### PR DESCRIPTION
The pipeline was not specifying a tag in the `imageName` so Anchore was just using the `latest` tag as it's scan target.  This was not the desired behaviour as we would want to scan the image that was just created.  This PR introduces the shared library pipeline step `getScanName` which returns the appropriate image name and tag to scan.