### PR TITLE
Fix data / axis mismatch in Variable Response Graph

### DIFF
--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -72,20 +72,20 @@ function makeVariableResponseGraph (x, y, graph) {
   
   const xseries = _.filter(graph.data.columns, series => seriesNameContains(series, x));
   const yseries = _.filter(graph.data.columns, series => seriesNameContains(series, y));
-    
+
   let tuples = [];
   let seriesMatched = false;
-  for(let dependent of xseries) {
+  for(let independent of xseries) {
     //Try to match each dependent variable series with an independent variable series
-    let independent = _.find(yseries, series => {
+    let dependent = _.find(yseries, series => {
       return series[0].toLowerCase().replace(y.toLowerCase(), x.toLowerCase()) === 
-        dependent[0].toLowerCase();
+        independent[0].toLowerCase();
       });
-    if(independent) {
+    if(dependent) {
       seriesMatched = true;
-      for(let d = 1; d < dependent.length; d++) {
-        if(!_.isNull(dependent[d]) && !_.isNull(independent[d])) {
-          tuples.push([independent[d], dependent[d]]);
+      for(let n = 1; n < independent.length; n++) {
+        if(!_.isNull(independent[n]) && !_.isNull(dependent[n])) {
+          tuples.push([independent[n], dependent[n]]);
         }
       }
     }

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -75,7 +75,7 @@ function makeVariableResponseGraph (x, y, graph) {
 
   let tuples = [];
   let seriesMatched = false;
-  for(let independent of xseries) {
+  for(const independent of xseries) {
     //Try to match each dependent variable series with an independent variable series
     let dependent = _.find(yseries, series => {
       return series[0].toLowerCase().replace(y.toLowerCase(), x.toLowerCase()) === 


### PR DESCRIPTION
This fixes an issue in the construction of the variable response graph. The graph "pairs up" data from multiple variable timeseries, to make a time-independent comparison of the variables. For example, for the variables `a` and `b` and timeseries `[t0, t1, t2]`:
 
The input timeseries would be:
```
[(t0, a0), (t1,  a1), (t2, a2)] 
[(t0, b0), (t1, b1), (t2, b2)]
```

And the output would be:
```
[(a0, b0), (a1, b1), (a2, b2)]
```

However, there was a bug where the output of the "pairing up" step was actually:
```
[(b0, a0), (b1, a1), (b2, a2)]
```

Which is valid variable response data, but all the axis labels and general graph formatting expected `a` to be the x-axis and `b` to be the y-axis. The result was graphs with data axes mislabeled. Here's a graph from the live website:
![wrongaxes](https://user-images.githubusercontent.com/4512605/90450906-90ae8600-e09f-11ea-9279-9398a686fba9.png)

As you can see, this graph show mean precipitation of 25 mm per day, and mean tasmax values of less than 2 degrees Celsius. The data are on the wrong axes. Here is the same graph, output by this branch:

![fixedaxes](https://user-images.githubusercontent.com/4512605/90451126-f733a400-e09f-11ea-9e4b-6f5c8a4ca0b6.png)

Resolve #329 