### PR TITLE
Add a new data portal for flood frequency data

### DIFF
--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -106,11 +106,13 @@ class DataMap extends React.Component {
     activeGeometryStyle: PropTypes.object.isRequired,
     inactiveGeometryStyle: PropTypes.object.isRequired,
     children: PropTypes.node,
+    pointSelect: PropTypes.bool,
   };
 
   static defaultProps = {
     activeGeometryStyle: { color: '#3388ff' },
     inactiveGeometryStyle: { color: '#777777' },
+    pointSelect: false,
   };
 
   static layerTypes = ['raster', 'isoline', 'annotated'];
@@ -349,14 +351,14 @@ class DataMap extends React.Component {
             position='topleft'
             draw={{
               marker: false,
-              circlemarker: false,
+              circlemarker: allowGeometryDraw && this.props.pointSelect,
               circle: false,
               polyline: false,
-              polygon: allowGeometryDraw && {
+              polygon: allowGeometryDraw && !this.props.pointSelect && {
                 showArea: false,
                 showLength: false,
               },
-              rectangle: allowGeometryDraw && {
+              rectangle: allowGeometryDraw && !this.props.pointSelect && {
                 showArea: false,
                 showLength: false,
               },

--- a/src/components/DataTool.js
+++ b/src/components/DataTool.js
@@ -5,6 +5,7 @@ import NavRoutes from './navigation/NavRoutes/NavRoutes';
 import SingleAppController from './app-controllers/SingleAppController';
 import PrecipAppController from './app-controllers/PrecipAppController';
 import DualAppController from './app-controllers/DualAppController';
+import FloodAppController from './app-controllers/FloodAppController';
 import { loadVariableOptions } from '../core/util';
 import Await from './Await';
 
@@ -32,6 +33,13 @@ const navSpec = {
       subpath: 'precipitation/:ensemble_name(extreme_precipitation)',
       navSubpath: 'precipitation/extreme_precipitation',
       render: (props) => <PrecipAppController {...props} />,
+    },
+    {
+      label: 'Upper Fraser',
+      info: 'View flood frequency data for the Upper Fraser',
+      subpath: 'flood/:ensemble_name(upper_fraser)',
+      navSubpath: 'flood/upper_fraser',
+      render: (props) => <FloodAppController {...props} />,
     },
   ],
 };

--- a/src/components/app-controllers/FloodAppController/FloodAppController.js
+++ b/src/components/app-controllers/FloodAppController/FloodAppController.js
@@ -1,0 +1,230 @@
+/***************************************************************
+ * FloodAppController.js 
+ * 
+ * This controller displays streamflow return period data.
+ * Its differences from regular data display (SingleAppContoller) 
+ * are:
+ *  - all data is annual (different graphs)
+ *  - displays ensemble percentiles
+ *  - point selectionon map
+ ***************************************************************/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Col, ControlLabel, Grid, Panel, Row } from 'react-bootstrap';
+
+import SingleMapController from '../../map-controllers/SingleMapController';
+import FloodDataController
+  from '../../data-controllers/FloodDataController/FloodDataController';
+import {
+  EmissionsScenarioSelector,
+  ModelSelector,
+  VariableSelector,
+} from 'pcic-react-components';
+import {
+  datasetFilterPanelLabel,
+  emissionScenarioSelectorLabel,
+  modelSelectorLabel,
+  variableSelectorLabel,
+} from '../../guidance-content/info/InformationItems';
+
+import g from '../../../core/geo';
+import { FullWidthCol, HalfWidthCol } from '../../layout/rb-derived-components';
+import FilteredDatasetsSummary
+  from '../../data-presentation/FilteredDatasetsSummary';
+import FlowArrow from '../../data-presentation/FlowArrow';
+import UnfilteredDatasetsSummary
+  from '../../data-presentation/UnfilteredDatasetsSummary';
+
+import {
+  ensemble_name,
+} from '../common';
+import { setNamedState } from '../../../core/react-component-utils';
+import withAsyncMetadata from '../../../HOCs/withAsyncMetadata'
+import {
+  findModelNamed, findScenarioIncluding, findVariableMatching,
+  representativeValue, constraintsFor, filterMetaBy,
+} from '../../../core/selectors';
+
+
+class FloodAppControllerDisplay extends React.Component {
+  // This is a pure (state-free), controlled component that renders the
+  // entire content of FloodAppController, including the controls.
+  // It is wrapped by `withAsyncMetadata` to inject the asynchronously fetched
+  // metadata that it needs.
+
+  static propTypes = {
+    ensemble_name: PropTypes.string,
+    model: PropTypes.object,
+    scenario: PropTypes.object,
+    variable: PropTypes.object,
+    area: PropTypes.object,
+    onChangeModel: PropTypes.func,
+    onChangeScenario: PropTypes.func,
+    onChangeVariable: PropTypes.func,
+    onChangeArea: PropTypes.func,
+    meta: PropTypes.array,
+  };
+
+  replaceInvalidModel = findModelNamed('PCIC12');
+  replaceInvalidScenario = findScenarioIncluding('rcp85');
+  replaceInvalidVariable = findVariableMatching(opt => !opt.isDisabled);
+
+  representativeValue = (...args) => representativeValue(...args)(this.props);
+  constraintsFor = (...args) => constraintsFor(...args)(this.props);
+  filterMetaBy = (...args) =>
+    filterMetaBy(...args)(this.props)(this.props.meta);
+
+  render() {
+    const filteredMeta = this.filterMetaBy('model', 'scenario', 'variable');
+    const modelContextMetadata = this.filterMetaBy('scenario', 'variable');
+
+    const model_id = this.representativeValue('model', 'model_id');
+    const experiment = this.representativeValue('scenario', 'experiment');
+    const variable_id = this.representativeValue('variable', 'variable_id');
+
+    return (
+      <Grid fluid>
+        <Row>
+          <FullWidthCol>
+            <UnfilteredDatasetsSummary meta={this.props.meta} />
+          </FullWidthCol>
+        </Row>
+
+        <Row>
+          <FullWidthCol>
+            <FlowArrow pullUp />
+          </FullWidthCol>
+        </Row>
+
+        <Row>
+          <FullWidthCol>
+            <Panel>
+              <Panel.Heading>
+                <Panel.Title>{datasetFilterPanelLabel}</Panel.Title>
+              </Panel.Heading>
+              <Panel.Body>
+                <Row>
+                  <Col lg={2} md={2}>
+                    <ControlLabel>{modelSelectorLabel}</ControlLabel>
+                    <ModelSelector
+                      bases={this.props.meta}
+                      value={this.props.model}
+                      onChange={this.props.onChangeModel}
+                      replaceInvalidValue={this.replaceInvalidModel}
+                    />
+                  </Col>
+                  <Col lg={2} md={2}>
+                    <ControlLabel>{emissionScenarioSelectorLabel}</ControlLabel>
+                    <EmissionsScenarioSelector
+                      bases={this.props.meta}
+                      constraint={this.constraintsFor('model')}
+                      value={this.props.scenario}
+                      onChange={this.props.onChangeScenario}
+                      replaceInvalidValue={this.replaceInvalidScenario}
+                    />
+                  </Col>
+                  <Col lg={4} md={4}>
+                    <ControlLabel>{variableSelectorLabel}</ControlLabel>
+                    <VariableSelector
+                      bases={this.props.meta}
+                      constraint={this.constraintsFor('model', 'scenario')}
+                      value={this.props.variable}
+                      onChange={this.props.onChangeVariable}
+                      replaceInvalidValue={this.replaceInvalidVariable}
+                    />
+                  </Col>
+                </Row>
+              </Panel.Body>
+            </Panel>
+          </FullWidthCol>
+        </Row>
+
+        <Row>
+          <FullWidthCol>
+            <FlowArrow pullUp />
+          </FullWidthCol>
+        </Row>
+
+        <Row>
+          <FullWidthCol>
+            <FilteredDatasetsSummary
+              model_id={model_id}
+              experiment={experiment}
+              variable_id={variable_id}
+              meta = {filteredMeta}
+            />
+          </FullWidthCol>
+        </Row>
+
+        <Row>
+          <HalfWidthCol>
+            <FlowArrow pullUp />
+          </HalfWidthCol>
+          <HalfWidthCol>
+            <FlowArrow pullUp />
+          </HalfWidthCol>
+        </Row>
+
+        <Row>
+          <HalfWidthCol>
+            <SingleMapController
+              model_id={model_id}
+              experiment={experiment}
+              variable_id={variable_id}
+              meta = {filteredMeta}
+              area={this.props.area}
+              onSetArea={this.props.onChangeArea}
+            />
+          </HalfWidthCol>
+          <HalfWidthCol>
+            <FloodDataController
+              ensemble_name={this.props.ensemble_name}
+              model_id={model_id}
+              variable_id={variable_id}
+              experiment={experiment}
+              area={g.geojson(this.props.area).toWKT()}
+              meta = {filteredMeta}
+              contextMeta={modelContextMetadata} //to generate Model Context graph
+            />
+          </HalfWidthCol>
+        </Row>
+      </Grid>
+    );
+  }
+}
+
+
+// Inject asynchronously fetched metadata into controlled component.
+const WmdFloodAppControllerDisplay = withAsyncMetadata(FloodAppControllerDisplay);
+
+
+export default class FloodAppController extends React.Component {
+  // This manages the state of selectors and renders the display component.
+
+  state = {
+    model: undefined,
+    scenario: undefined,
+    variable: undefined,
+    area: undefined,  // geojson object
+  };
+
+  // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/122
+  handleChangeArea = setNamedState(this, 'area');
+  handleChangeModel = setNamedState(this, 'model');
+  handleChangeScenario = setNamedState(this, 'scenario');
+  handleChangeVariable = setNamedState(this, 'variable');
+
+  render() {
+    return (
+      <WmdFloodAppControllerDisplay
+        ensemble_name={ensemble_name(this.props)}
+        {...this.state}
+        onChangeArea={this.handleChangeArea}
+        onChangeModel={this.handleChangeModel}
+        onChangeScenario={this.handleChangeScenario}
+        onChangeVariable={this.handleChangeVariable}
+      />
+    );
+  }
+}

--- a/src/components/app-controllers/FloodAppController/FloodAppController.js
+++ b/src/components/app-controllers/FloodAppController/FloodAppController.js
@@ -175,6 +175,7 @@ class FloodAppControllerDisplay extends React.Component {
               meta = {filteredMeta}
               area={this.props.area}
               onSetArea={this.props.onChangeArea}
+              pointSelect={true}
             />
           </HalfWidthCol>
           <HalfWidthCol>

--- a/src/components/app-controllers/FloodAppController/package.json
+++ b/src/components/app-controllers/FloodAppController/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "Flood App Controller",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./FloodAppController.js"
+}

--- a/src/components/app-controllers/MotiAppController/MotiAppController.js
+++ b/src/components/app-controllers/MotiAppController/MotiAppController.js
@@ -87,6 +87,7 @@ export default createReactClass({
               meta = {this.getFilteredMeta()}
               area={this.state.area}
               onSetArea={this.handleSetArea}
+              pointSelect={false}
             />
           </Col>
           <Col lg={6}>

--- a/src/components/app-controllers/SingleAppController/SingleAppController.js
+++ b/src/components/app-controllers/SingleAppController/SingleAppController.js
@@ -175,6 +175,7 @@ class SingleAppControllerDisplay extends React.Component {
               meta = {filteredMeta}
               area={this.props.area}
               onSetArea={this.props.onChangeArea}
+              pointSelect={false}
             />
           </HalfWidthCol>
           <HalfWidthCol>

--- a/src/components/data-controllers/FloodDataController/FloodDataController.js
+++ b/src/components/data-controllers/FloodDataController/FloodDataController.js
@@ -27,8 +27,11 @@ import React from 'react';
 import { Row, Col, Panel } from 'react-bootstrap';
 import _ from 'lodash';
 
+import SingleTimeSeriesGraph from '../../graphs/SingleTimeSeriesGraph';
 import SingleLongTermAveragesGraph from '../../graphs/SingleLongTermAveragesGraph';
-import {singleLtaTabLabel, graphsPanelLabel} from '../../guidance-content/info/InformationItems';
+import {
+    singleLtaTabLabel, graphsPanelLabel, timeSeriesTabLabel,
+    } from '../../guidance-content/info/InformationItems';
 
 import styles from '../DataController.module.css';
 import { MEVSummary } from '../../data-presentation/MEVSummary';
@@ -67,6 +70,9 @@ export default class FloodDataController extends React.Component {
   static graphTabsSpecs = {
     mym: [
       { title: singleLtaTabLabel, graph: SingleLongTermAveragesGraph },
+    ],
+    notMym: [
+      { title: timeSeriesTabLabel, graph: SingleTimeSeriesGraph },
     ],
   };
 

--- a/src/components/data-controllers/FloodDataController/FloodDataController.js
+++ b/src/components/data-controllers/FloodDataController/FloodDataController.js
@@ -1,0 +1,112 @@
+/*******************************************************************
+ * FloodDataController.js - controller for numerical visualization of
+ * flood frequency data.
+ * This data is very simple - there is only one "model" (actually an 
+ * ensemble mean) and all data is annual. 
+ * So it doesn't display a time slice graph or a context graph - these
+ * are used to compare models. It also doesn't display a timeseries
+ * graph or anomaly annual cycle graph - these show monthly and
+ * seasonal changes. In fact, there is only one graph, a long term 
+ * average graph.
+ * 
+ * Receives a model, an experiment, and a variable from its parent,
+ * FloodAppController. Manages viewer components that display data as
+ * graphs or tables. 
+ *
+ * Child component:
+ *  - a SingleLongTermAverageGraph showing the mean of each climatology
+ *    period as a seperate data point.
+ *
+ * A Data Table viewer component showing statistical information for each
+ * climatology period or timeseries is also generated. 
+ *******************************************************************/
+
+import PropTypes from 'prop-types';
+
+import React from 'react';
+import { Row, Col, Panel } from 'react-bootstrap';
+import _ from 'lodash';
+
+import SingleLongTermAveragesGraph from '../../graphs/SingleLongTermAveragesGraph';
+import {singleLtaTabLabel, graphsPanelLabel} from '../../guidance-content/info/InformationItems';
+
+import styles from '../DataController.module.css';
+import { MEVSummary } from '../../data-presentation/MEVSummary';
+import FlowArrow from '../../data-presentation/FlowArrow';
+import GraphTabs from '../GraphTabs';
+import StatisticalSummaryTable from '../../StatisticalSummaryTable';
+
+
+export default class FloodDataController extends React.Component {
+  static propTypes = {
+    model_id: PropTypes.string,
+    variable_id: PropTypes.string,
+    experiment: PropTypes.string,
+    area: PropTypes.string,
+    meta: PropTypes.array,
+    contextMeta: PropTypes.array,
+    ensemble_name: PropTypes.string,  // TODO: Why is this declared? Remove?
+  };
+
+  // TODO: Is this necessary?
+  shouldComponentUpdate(nextProps, nextState) {
+    // This guards against re-rendering before calls to the data sever alter the
+    // state
+    // TODO: Consider making shallow comparisons. Deep ones are expensive.
+    // If immutable data objects are used (or functionally equivalently,
+    // new data objects each time), then shallow comparison works.
+    return !(
+      _.isEqual(nextProps.meta, this.props.meta) &&
+      _.isEqual(nextProps.area, this.props.area)
+     );
+  }
+
+  // Spec for generating tabs containing various graphs.
+  // Property names indicate whether the dataset is a multi-year mean or not.
+  // TODO: Pull this out into new component SingleVariableGraphs
+  static graphTabsSpecs = {
+    mym: [
+      { title: singleLtaTabLabel, graph: SingleLongTermAveragesGraph },
+    ],
+  };
+
+  render() {
+    // TODO: Improve returned item
+    if (!_.allDefined(this.props, 'model_id', 'experiment', 'variable_id')) {
+      return 'Readying...';
+    }
+
+    return (
+      // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/246
+      <div>
+        <Panel>
+          <Panel.Heading>
+            <Panel.Title>
+              <Row>
+                <Col lg={4}>
+                  {graphsPanelLabel}
+                </Col>
+                <Col lg={8}>
+                  <MEVSummary
+                    className={styles.mevSummary} {...this.props}
+                  />
+                </Col>
+              </Row>
+            </Panel.Title>
+          </Panel.Heading>
+          <Panel.Body className={styles.data_panel}>
+            <GraphTabs
+              {...this.props}
+              specs={FloodDataController.graphTabsSpecs}
+            />
+          </Panel.Body>
+        </Panel>
+
+        <FlowArrow>filtered datasets</FlowArrow>
+
+        <StatisticalSummaryTable {...this.props} />
+
+      </div>
+    );
+  }
+}

--- a/src/components/map-controllers/DualMapController/DualMapController.js
+++ b/src/components/map-controllers/DualMapController/DualMapController.js
@@ -304,6 +304,7 @@ export default class DualMapController extends React.Component {
 
                 onSetArea={this.props.onSetArea}
                 area={this.props.area}
+                pointSelect={false}
               >
 
                 <StaticControl position='topright'>

--- a/src/components/map-controllers/PrecipMapController/PrecipMapController.js
+++ b/src/components/map-controllers/PrecipMapController/PrecipMapController.js
@@ -279,6 +279,7 @@ export default class PrecipMapController extends React.Component {
 
                 onSetArea={this.props.onSetArea}
                 area={this.props.area}
+                pointSelect={false}
               >
 
                 <StaticControl position='topright'>

--- a/src/components/map-controllers/SingleMapController/SingleMapController.js
+++ b/src/components/map-controllers/SingleMapController/SingleMapController.js
@@ -56,6 +56,7 @@ export default class SingleMapController extends React.Component {
     meta: PropTypes.array.isRequired,
     area: PropTypes.object,
     onSetArea: PropTypes.func.isRequired,
+    pointSelect: PropTypes.bool.isRequired
   };
 
   constructor(props) {
@@ -236,6 +237,7 @@ export default class SingleMapController extends React.Component {
 
                 onSetArea={this.props.onSetArea}
                 area={this.props.area}
+                pointSelect={this.props.pointSelect}
               >
 
                 <StaticControl position='topright'>


### PR DESCRIPTION
Creates a new portal for hydrological flood frequency data.

The new portal has: 
* an app controller, `FloodAppController`, that is extremely similar to `SingleAppController`, differing only in its name and its child components
* a data controller, `FloodDataController`. This controller has only one graph (long term average) and the statistical table, because this data is so simple there's only one way to "slice" it. There's only a single model (ensemble of models, actually) so we don't need the Context Graph or Snapshot graph, and all data is annual-only, so we don't need the annual cycle graph or the annual anomaly graph. Only the Long Term Average graph is present. The next PR will supplement the Long Term Average with additional series that show the ensemble percentiles.
* a map controller. It is using `SingleMapController`, but a new boolean `prop` has been added, `selectPoint`. When `selectPoint` is `true`, users will indicate an area of interest by selecting a single point, as is appropriate for hydrology data. When `selectPoint` is `false`, users will indicate an area of interest by drawing a rectangle or polygon, the current behaviour, which will be preserved in all other portals.

[Demo](http://docker-dev01.pcic.uvic.ca:30400/pcex/app/#/data/flood/upper_fraser)

Resolves #391 