### PR TITLE
Add data series for percentiles to LTA graph for streamflow

### DIFF
--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -682,6 +682,47 @@ help:
 
           50-year annual minimum daily minimum temperature
           
+          
+        ### Annual maximum streamflow quantiles
+
+        The streamflow quantiles describe extreme streamflow events
+        that would be expected to occur once during a specified 
+        "return period," for example once every 20 years. 
+        These datasets are calculated empirically from VIC-GL
+        simulated streamflow driven with the CanESM2 large ensemble,
+        which is forced by the RCP8.5 concentration pathway scenario. 
+        This data is available for six thirty year climatological periods
+        from 1961 to 2099, namely 1961-1990, 1971-2000, 1981-2010, 
+        2010-2039, 2040-2069, and 2070-2099. 
+        This data is available for a region of the Fraser River upstream 
+        of Shelley, British Columbia. Each quantile estimate is also
+        provided with the 95% sampling interval provided as the
+        2.5th and 97.5th percentiles.
+
+        
+        * **`rp2streamflow`**
+
+          2-year annual maximum one day streamflow
+          
+        * **`rp5streamflow`**
+
+          5-year annual maximum one day streamflow
+        
+        * **`rp20streamflow`**
+
+          20-year annual maximum one day streamflow
+          
+        * **`rp50streamflow`**
+
+          50-year annual maximum one day streamflow
+          
+        * **`rp100streamflow`**
+
+          100-year annual maximum one day streamflow
+          
+        * **`rp200streamflow`**
+
+          200-year annual maximum one day streamflow
 
       - |
         ## Models (GCMs)

--- a/src/HOCs/withAsyncPercentileMetadata.js
+++ b/src/HOCs/withAsyncPercentileMetadata.js
@@ -1,0 +1,5 @@
+// This HOC injects asynchronously fetched metadata describing percentile datasets
+import withAsyncData from './withAsyncData';
+import { getPercentileMetadata } from '../data-services/ce-backend';
+
+export default withAsyncData(getPercentileMetadata, 'ensemble_name', 'percentileMeta');

--- a/src/components/data-controllers/FloodDataController/FloodDataController.js
+++ b/src/components/data-controllers/FloodDataController/FloodDataController.js
@@ -31,7 +31,7 @@ import _ from 'lodash';
 import SingleTimeSeriesGraph from '../../graphs/SingleTimeSeriesGraph';
 import PercentileLongTermAveragesGraph from '../../graphs/PercentileLongTermAveragesGraph';
 import {
-    singleLtaTabLabel, graphsPanelLabel, timeSeriesTabLabel,
+    percentileLtaTabLabel, graphsPanelLabel, timeSeriesTabLabel,
     } from '../../guidance-content/info/InformationItems';
 
 import styles from '../DataController.module.css';
@@ -68,7 +68,7 @@ export default class FloodDataController extends React.Component {
   // TODO: Pull this out into new component SingleVariableGraphs
   static graphTabsSpecs = {
     mym: [
-      { title: singleLtaTabLabel, graph: PercentileLongTermAveragesGraph },
+      { title: percentileLtaTabLabel, graph: PercentileLongTermAveragesGraph },
     ],
     notMym: [
       { title: timeSeriesTabLabel, graph: SingleTimeSeriesGraph },

--- a/src/components/data-controllers/FloodDataController/FloodDataController.js
+++ b/src/components/data-controllers/FloodDataController/FloodDataController.js
@@ -1,13 +1,14 @@
 /*******************************************************************
  * FloodDataController.js - controller for numerical visualization of
  * flood frequency data.
- * This data is very simple - there is only one "model" (actually an 
- * ensemble mean) and all data is annual. 
+ * The flood frequency data itself is very simple - there is only one
+ * "model" (an ensemble mean) and all data is annual.
  * So it doesn't display a time slice graph or a context graph - these
  * are used to compare models. It also doesn't display a timeseries
  * graph or anomaly annual cycle graph - these show monthly and
  * seasonal changes. In fact, there is only one graph, a long term 
- * average graph.
+ * average graph. This graph displays both ensemble means and any
+ * available ensemble percentiles.
  * 
  * Receives a model, an experiment, and a variable from its parent,
  * FloodAppController. Manages viewer components that display data as
@@ -28,7 +29,7 @@ import { Row, Col, Panel } from 'react-bootstrap';
 import _ from 'lodash';
 
 import SingleTimeSeriesGraph from '../../graphs/SingleTimeSeriesGraph';
-import SingleLongTermAveragesGraph from '../../graphs/SingleLongTermAveragesGraph';
+import PercentileLongTermAveragesGraph from '../../graphs/PercentileLongTermAveragesGraph';
 import {
     singleLtaTabLabel, graphsPanelLabel, timeSeriesTabLabel,
     } from '../../guidance-content/info/InformationItems';
@@ -37,8 +38,6 @@ import styles from '../DataController.module.css';
 import { MEVSummary } from '../../data-presentation/MEVSummary';
 import FlowArrow from '../../data-presentation/FlowArrow';
 import GraphTabs from '../GraphTabs';
-import StatisticalSummaryTable from '../../StatisticalSummaryTable';
-
 
 export default class FloodDataController extends React.Component {
   static propTypes = {
@@ -47,7 +46,7 @@ export default class FloodDataController extends React.Component {
     experiment: PropTypes.string,
     area: PropTypes.string,
     meta: PropTypes.array,
-    contextMeta: PropTypes.array,
+    percentileMeta: PropTypes.array,
     ensemble_name: PropTypes.string,  // TODO: Why is this declared? Remove?
   };
 
@@ -69,7 +68,7 @@ export default class FloodDataController extends React.Component {
   // TODO: Pull this out into new component SingleVariableGraphs
   static graphTabsSpecs = {
     mym: [
-      { title: singleLtaTabLabel, graph: SingleLongTermAveragesGraph },
+      { title: singleLtaTabLabel, graph: PercentileLongTermAveragesGraph },
     ],
     notMym: [
       { title: timeSeriesTabLabel, graph: SingleTimeSeriesGraph },
@@ -107,10 +106,6 @@ export default class FloodDataController extends React.Component {
             />
           </Panel.Body>
         </Panel>
-
-        <FlowArrow>filtered datasets</FlowArrow>
-
-        <StatisticalSummaryTable {...this.props} />
 
       </div>
     );

--- a/src/components/graphs/PercentileLongTermAveragesGraph.js
+++ b/src/components/graphs/PercentileLongTermAveragesGraph.js
@@ -1,0 +1,77 @@
+/***********************************************************
+* PercentileLongTermAverageGraph.js
+* 
+* Displays long term change of a mean and percentiles for an
+* ensemble of models.
+************************************************************/
+import React from 'react';
+
+import _ from 'lodash';
+
+import { dataToLongTermAverageGraph } from '../../core/chart-generators';
+import { timeKeyToResolutionIndex } from '../../core/util';
+import LongTermAveragesGraph from './LongTermAveragesGraph';
+
+
+export default function PercentileLongTermAveragesGraph(props) {
+  function getMetadata(timeOfYear) {
+    
+    // get a list of all available percentiles    
+    function parsePercentile(metad) {
+        const clim_stat = metad["climatological_statistic"];
+        if (_.startsWith(clim_stat, 'percentile')) {
+            return parseFloat(_.trim(_.replace(clim_stat, 'percentile', ''), '[]'));
+        }
+        else return null 
+    }
+    const percentiles = _.uniq(_.map(props.percentileMeta, parsePercentile));
+
+    const metadataFromProps = _.pick(props,
+      'ensemble_name', 'model_id', 'variable_id', 'experiment', 'area'
+    );
+    
+    //metadata for the ensemble mean - need to include blank percentile attribute
+    //due to the way that series names are automatically generated on the
+    //graph from the attributes that differ between series. This non-percentile
+    //data series will still have its "percentile" value included in the legend.  
+    let apiCalls = [
+      { ...metadataFromProps, 
+      ...timeKeyToResolutionIndex(timeOfYear), 
+      climatological_statistic: 'mean',
+      percentile: ''},
+    ];
+
+    //Add an additional metadata object for each percentile    
+    if (percentiles.length > 0) {
+        _.forEach(percentiles, function(p) {
+           apiCalls.push(
+            {
+              ...metadataFromProps, 
+              ...timeKeyToResolutionIndex(timeOfYear),
+              climatological_statistic: 'percentile',
+              percentile: p 
+              }
+           ); 
+        });
+    }
+    return apiCalls;
+  }
+
+  function dataToGraphSpec(data, meta) {
+    // Convert `data` (described by `meta`) to a graph specification compatible
+    // with `DataGraph`.
+    return dataToLongTermAverageGraph(data, meta);
+  }
+
+  const graphProps = _.pick(props,
+    'model_id', 'variable_id', 'experiment', 'meta', 'area'
+  );
+
+  return (
+    <LongTermAveragesGraph
+      {...graphProps}
+      getMetadata={getMetadata}
+      dataToGraphSpec={dataToGraphSpec}
+    />
+  );
+}

--- a/src/components/guidance-content/info/InformationItems.js
+++ b/src/components/guidance-content/info/InformationItems.js
@@ -443,6 +443,11 @@ const spatialAveragingDefn = `
   drawn on the map (or over the entire dataset if no polygon is drawn).
 `;
 
+const pointAreaDefn = `
+  Data values shown in each graph are from the single grid square selected
+  on the map (or averaged over the entire dataset if no point is selected).
+`;
+
 const datasetSelectorDefn = `
   Model run and averaging period are selected by the Dataset selector
   in the graph.
@@ -498,6 +503,15 @@ export const singleLtaTabLabel = (
     <p>Long term average graphs for the selected variable.</p>
     <p>{ltaGraphDefn}</p>
     <p>{spatialAveragingDefn}</p>
+    <p>{timeOfYearSelectorDefn}</p>
+  </LabelWithInfo>
+);
+
+export const percentileLtaTabLabel = (
+  <LabelWithInfo label='Long Term Average'>
+    <p>Long term average graphs with percentile range for the selected variable.</p>
+    <p>{ltaGraphDefn}</p>
+    <p>{pointAreaDefn}</p>
     <p>{timeOfYearSelectorDefn}</p>
   </LabelWithInfo>
 );


### PR DESCRIPTION
The primary change in this PR is to add data series representing the ensemble percentiles to the Long Term Average graph.

Some minor UI changes:
* Removed stats table - it was meaningless for this portal, since you can only select a single point at a time - no variation
* Added help text for variable description
* Add in-app guidance text