### PR TITLE
Fix bug in generating percentile queries

### DIFF
--- a/src/data-services/ce-backend.js
+++ b/src/data-services/ce-backend.js
@@ -126,7 +126,7 @@ function getData(
     };
 
   // if the caller has passed optional parameters, add them to the call.
-  if (climatological_statistic == 'percentile' & percentile) {
+  if (climatological_statistic == 'percentile' && percentile) {
     query_params['climatological_statistic'] = climatological_statistic;
     query_params['percentile'] = percentile;
   }


### PR DESCRIPTION
Fixes a bug in how queries to the `data` backend are handled.

If the `climatological_statistic` parameter has a value of `percentile` and the `percentile` parameter is not `null` or the empty string, then both parameters are included in the call to the backend. Previously, these two conditions were compared with bitwise and (`&`) instead of logical and (`&&`), which gave incorrect results when the `percentile` parameter's integer portion was divisible by two. This bug wasn't obvious with the original data collection - 5th and 95th percentile dataset -  but became apparent with the inclusion of the 2.5th percentile data, as `true & 2.5` is falsey.

```javascript
>> true & 95
1
>> true & 5
1
>> true & 97.5
1
>> true & 2.5
0
```
