### PR TITLE
Revert JSZip version to 2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
     "filesaver.js": "^0.2.0",
-    "jszip": "^3.2.1",
+    "jszip": "2.5.0",
     "leaflet": "^1.3.4",
     "leaflet-draw": "^1.0.4",
     "leaflet-image": "^0.4.0",

--- a/src/core/geo.js
+++ b/src/core/geo.js
@@ -30,7 +30,7 @@ function createZippedShapefile(gj, options) {
 
   [geojson.point(gj), geojson.line(gj), geojson.polygon(gj)]
   .forEach(function(l) {
-    if (l.geometries.length) {
+    if(_.flattenDeep(l.geometries).length > 0){
       write(
         // field definitions
         l.properties,


### PR DESCRIPTION
JSZip was [pretty thoroughly rewritten in the shift to 3.0](https://stuk.github.io/jszip/documentation/upgrade_guide.html), and some  functions we were using were obsoleted. This PR pins JSZip at 2.5.

Resolves #361 