### PR TITLE
Revert JSZip version to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
     "filesaver.js": "^0.2.0",
-    "jszip": "^3.2.1",
+    "jszip": "2.5.0",
     "leaflet": "^1.3.4",
     "leaflet-draw": "^1.0.4",
     "leaflet-image": "^0.4.0",

--- a/src/core/geo.js
+++ b/src/core/geo.js
@@ -30,7 +30,7 @@ function createZippedShapefile(gj, options) {
 
   [geojson.point(gj), geojson.line(gj), geojson.polygon(gj)]
   .forEach(function(l) {
-    if (l.geometries.length) {
+    if (_.flattenDeep(l.geometries).length > 0) {
       write(
         // field definitions
         l.properties,


### PR DESCRIPTION
JSZip was [refactored](https://stuk.github.io/jszip/documentation/upgrade_guide.html) between version 2.x, which we were previously using, and version 3.x. Some of the functions we were using, like `zip.generate()` are not present in 3.x, which made it impossible to download a shape drawn on the map as a shapefile.

This PR pins JSZip to 2.5 and fixes a too-narrow check for empty coordinates that would treat coordinates consisting of a list of empty lists as if they were were defined coordinates to be written to the shapefile, leading to an error.

[Demo](http://docker-dev01.pcic.uvic.ca:30066/pcex/app/#/data/climo/ce_files)

Resolves #361 