### PR TITLE
Display selected watershed on map

### DIFF
--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -397,6 +397,8 @@ class DataMap extends React.Component {
                 showLength: false,
               },
             }}
+            //don't allow editing watershed boundary polygon
+            edit={this.displayWatershedBoundary() ? {edit: false} : {}} 
             onCreated={this.handleAreaCreated}
             onEdited={this.handleAreaEdited}
             onDeleted={this.handleAreaDeleted}

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -116,7 +116,7 @@ class DataMap extends React.Component {
   static defaultProps = {
     activeGeometryStyle: { color: '#3388ff' },
     inactiveGeometryStyle: { color: '#777777' },
-    watershedGeometryStyle: {colour: '#336699' },
+    watershedGeometryStyle: {color: '#000000' },
     pointSelect: false,
   };
 

--- a/src/components/DataTool.js
+++ b/src/components/DataTool.js
@@ -51,8 +51,8 @@ const navSpec = {
     {
       label: 'Extreme Streamflow',
       info: 'View flood frequency data for the Upper Fraser',
-      subpath: 'flood/:ensemble_name(upper_fraser)',
-      navSubpath: 'flood/upper_fraser',
+      subpath: 'flood/:ensemble_name(fraser)',
+      navSubpath: 'flood/fraser',
       render: (props) => <FloodAppController {...props} />,
     },
   ],

--- a/src/components/app-controllers/FloodAppController/FloodAppController.js
+++ b/src/components/app-controllers/FloodAppController/FloodAppController.js
@@ -189,6 +189,7 @@ class FloodAppControllerDisplay extends React.Component {
               area={this.props.area}
               onSetArea={this.props.onChangeArea}
               pointSelect={true}
+              watershedEnsemble={this.props.ensemble_name}
             />
           </HalfWidthCol>
           <HalfWidthCol>

--- a/src/components/map-controllers/SingleMapController/SingleMapController.js
+++ b/src/components/map-controllers/SingleMapController/SingleMapController.js
@@ -4,6 +4,12 @@
  * This controller coordinates a map displaying data extracted from
  * netCDF files as a colour-coded raster, as well as a menu of 
  * viewing settings for the raster.
+ *
+ * It allows the user to select an area of interest by interacting
+ * with the map. This area can either be a polygon or a point, which is
+ * controlled by the pointSelect prop. If the selection area is a point,
+ * the watershed of which that point is the mouth will be displayed on
+ * the map if the watershedEnsemble prop has a non-null value.
  * 
  * It is also responsible for passing user-drawn areas up to its 
  * parent.
@@ -56,7 +62,8 @@ export default class SingleMapController extends React.Component {
     meta: PropTypes.array.isRequired,
     area: PropTypes.object,
     onSetArea: PropTypes.func.isRequired,
-    pointSelect: PropTypes.bool.isRequired
+    pointSelect: PropTypes.bool.isRequired,
+    watershedEnsemble: PropTypes.string
   };
 
   constructor(props) {
@@ -238,6 +245,7 @@ export default class SingleMapController extends React.Component {
                 onSetArea={this.props.onSetArea}
                 area={this.props.area}
                 pointSelect={this.props.pointSelect}
+                watershedEnsemble={this.props.watershedEnsemble}
               >
 
                 <StaticControl position='topright'>

--- a/src/data-services/ce-backend.js
+++ b/src/data-services/ce-backend.js
@@ -205,7 +205,8 @@ function guessExperimentFormatFromVariable(variable, experiment) {
 function getWatershedGeographyName(ensemble){
     return {
         "bc_moti": "peace_watershed",
-        "upper_fraser": "upper_fraser_watershed"
+        "upper_fraser": "upper_fraser_watershed",
+        "fraser": "fraser_watershed",
         }[ensemble];
 }
 


### PR DESCRIPTION
This PR does the following:

* when a user selects the outlet of a watershed on the map, make a call to the watershed API and display the outline of the watershed on the map
* switch from the Upper Fraser dataset to the entire Fraser dataset (different data ensembles in the base URL)

Demo here: https://services.pacificclimate.org/dev/pcex/app/#/data/flood/fraser