### PR TITLE
pin serve to 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #
 # docker build --build-arg REACT_APP_CE_CURRENT_VERSION="$(./generate-commitish.sh)" -t <tag> .
 
-FROM node:10-alpine
+FROM node:12-alpine
 
 ADD . /app
 WORKDIR /app
@@ -16,7 +16,7 @@ COPY package.json /app/package.json
 
 RUN apk add --no-cache git bash && \
     npm install --quiet && \
-    npm install -g serve && \
+    npm install -g serve@13 &&\
     npm audit fix --quiet
 
 EXPOSE 8080

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "leaflet-draw": "^1.0.4",
     "leaflet-image": "^0.4.0",
     "lodash": "^4.17.21",
-    "moment": "^2.10.6",
+    "moment": "^2.29.4",
     "pcic-react-components": "git+https://git@github.com/pacificclimate/pcic-react-components.git#3.1.1",
     "pcic-react-external-text": "git+https://git@github.com/pacificclimate/pcic-react-external-text.git#1.0.0",
     "proj4": "^2.4.4",


### PR DESCRIPTION
I was unable to deploy the docker image of the main branch. The issue turned out to be an overzealous automatic update of the `serve` package. This branch pins `serve` in the `Dockerfile`.

Also include a security update recommended by `npm audit`.