### PR TITLE
Updates to extreme streamflow portal help

### DIFF
--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -702,19 +702,20 @@ help:
           
         ### Annual maximum streamflow quantiles
 
-        The streamflow quantiles describe extreme streamflow events
+        The streamflow quantiles describe daily extreme streamflow events
         that would be expected to occur once during a specified 
         "return period," for example once every 20 years. 
         These datasets are calculated empirically from VIC-GL
         simulated streamflow driven with the CanESM2 large ensemble,
         which is forced by the RCP8.5 concentration pathway scenario. 
-        This data is available for six thirty year climatological periods
-        from 1961 to 2099, namely 1961-1990, 1971-2000, 1981-2010, 
-        2010-2039, 2040-2069, and 2070-2099. 
-        This data is available for a region of the Fraser River upstream 
-        of Shelley, British Columbia. Each quantile estimate is also
-        provided with the 95% sampling interval provided as the
-        2.5th and 97.5th percentiles.
+        The data is available for the period 1951 to 2100 and is divided
+        into a baseline period of 1951-2001 and eight overlapping
+        thirty-year periods of 2001-2031, 2011-2041, 2021-2051,
+        2031-2061, 2041-2071, 2051-2081, 2061-2091 and 2071-2100.
+        This data is available for the Fraser River basin above
+        tidewater and the Peace River basin above Peace River,
+        Alberta. Each quantile estimate is also provided with the 95%
+        sampling interval provided as the 2.5th and 97.5th percentiles.
 
         
         * **`rp2streamflow`**
@@ -724,7 +725,11 @@ help:
         * **`rp5streamflow`**
 
           5-year annual maximum one day streamflow
-        
+
+        * **`rp10streamflow`**
+
+          10-year annual maximum one day streamflow
+
         * **`rp20streamflow`**
 
           20-year annual maximum one day streamflow
@@ -740,6 +745,50 @@ help:
         * **`rp200streamflow`**
 
           200-year annual maximum one day streamflow
+
+        ### Change factors for annual maximum atreamflow quantiles
+
+        Change factors for the streamflow quantiles describe the change
+        in daily extreme streamflow events for a specified return period
+        and are estimated as the ratio of future to baseline (1951-2000)
+        design flow value. Change factors are available for eight
+        overlapping thirty-year periods of 2001-2031, 2011-2041,
+        2021-2051, 2031-2061, 2041-2071, 2051-2081, 2061-2091 and
+        2071-2100. This data is available for the Fraser River basin
+        above tidewater and the Peace River basin above the town of Peace
+        River, Alberta. Each change factor estimate is also provided with
+        the 95% sampling interval provided as the 2.5th and 97.5th
+        percentiles.
+
+
+        * **`cfrp2streamflow`**
+
+          change factor for 2-year annual maximum one day streamflow
+
+        * **`cfrp5streamflow`**
+
+          change factor for 5-year annual maximum one day streamflow
+
+        * **`cfrp10streamflow`**
+
+          change factor for 10-year annual maximum one day streamflow
+
+        * **`cfrp20streamflow`**
+
+          change factor for 20-year annual maximum one day streamflow
+
+        * **`cfrp50streamflow`**
+
+          change factor for 250-year annual maximum one day streamflow
+
+        * **`cfrp100streamflow`**
+
+          change factor for 100-year annual maximum one day streamflow
+
+        * **`cfrp200streamflow`**
+
+          change factor for 200-year annual maximum one day streamflow
+
 
       - |
         ## Models (GCMs)

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -29,7 +29,7 @@ components:
     GCMs are the most advanced tools currently available for simulating the
     response of the global climate system to increasing greenhouse gas
     concentrations.
-  monthlyAnnualVarNameAmbiguityCaution:
+  monthlyAnnualVarNameAmbiguityCaution: |
     Unlike most Climdex variable names used in PCEX,
     this variable name can refer to either an annual version
     (calculation spanning a calendar year) or to the standard

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -369,7 +369,7 @@ class DataMap extends React.Component {
         />
 
         {
-          allowGeometryDraw &&
+          allowGeometryDraw && !this.props.pointSelect &&
           <StaticControl position='topleft'>
               <GeoLoader
                 onLoadArea={this.handleUploadArea}
@@ -385,7 +385,10 @@ class DataMap extends React.Component {
             position='topleft'
             draw={{
               marker: false,
-              circlemarker: allowGeometryDraw && this.props.pointSelect,
+              circlemarker: allowGeometryDraw && this.props.pointSelect && {
+                  title: 'Select an outlet point',
+                  text: 'Select an outlet point'
+              },
               circle: false,
               polyline: false,
               polygon: allowGeometryDraw && !this.props.pointSelect && {

--- a/src/components/DataTool.js
+++ b/src/components/DataTool.js
@@ -50,7 +50,7 @@ const navSpec = {
     },
     {
       label: 'Extreme Streamflow',
-      info: 'View flood frequency data for the Upper Fraser',
+      info: 'View streamflow design values for the Fraser and Peace River basins based on the CanESM2 large ensemble.',
       subpath: 'flood/:ensemble_name(fraser)',
       navSubpath: 'flood/fraser',
       render: (props) => <FloodAppController {...props} />,

--- a/src/components/WatershedSummaryTable/WatershedSummaryTable.js
+++ b/src/components/WatershedSummaryTable/WatershedSummaryTable.js
@@ -126,7 +126,7 @@ export default class WatershedSummaryTable extends React.Component {
 
     // Waiting for data
     if (this.state.fetchingData || this.state.data === null) {
-      return { noDataText: 'Select a point on the map with the circle marker tool to see watershed information' };
+      return { noDataText: 'Select am outlet point on the map to see watershed information' };
     }
 
     // We can haz data

--- a/src/components/data-controllers/FloodDataController/FloodDataController.js
+++ b/src/components/data-controllers/FloodDataController/FloodDataController.js
@@ -31,7 +31,7 @@ import _ from 'lodash';
 import SingleTimeSeriesGraph from '../../graphs/SingleTimeSeriesGraph';
 import PercentileLongTermAveragesGraph from '../../graphs/PercentileLongTermAveragesGraph';
 import {
-    percentileLtaTabLabel, graphsPanelLabel, timeSeriesTabLabel,
+    percentileLtaTabLabel, watershedGraphsPanelLabel, timeSeriesTabLabel,
     } from '../../guidance-content/info/InformationItems';
 
 import styles from '../DataController.module.css';
@@ -90,7 +90,7 @@ export default class FloodDataController extends React.Component {
             <Panel.Title>
               <Row>
                 <Col lg={4}>
-                  {graphsPanelLabel}
+                  {watershedGraphsPanelLabel}
                 </Col>
                 <Col lg={8}>
                   <MEVSummary

--- a/src/components/guidance-content/info/InformationItems.js
+++ b/src/components/guidance-content/info/InformationItems.js
@@ -309,7 +309,7 @@ const isolinesVariable = `
 
 export const variableSelectorLabel = (
   <LabelWithInfo label='Variable'>
-    <p>Variable to view on the map and in the graphs.</p>
+    <p>Variable to view on the map and in the graphs. For variable details, see <Link to='/help/general'>Help</Link>.</p>
     <p>{colourBlocksVariable}</p>
   </LabelWithInfo>
 );
@@ -659,7 +659,8 @@ export const watershedTableLabel = (
   <LabelWithInfo label='Watershed Upstream Of Selected Point'>
     <p>
       This table presents information about the selected grid and its upstream area
-      or watershed.
+      or watershed. The table is only populated if an outlet location has been
+      selected on the map.
     </p>
     <p>
       The Outlet Latitude and Longitude describe the point selected on the map,

--- a/src/components/guidance-content/info/InformationItems.js
+++ b/src/components/guidance-content/info/InformationItems.js
@@ -421,7 +421,8 @@ export const filteredDatasetSummaryPanelLabel = (
       Each row of the table represents a group of up to 3 datasets.
       We group datasets by Model Run, Start Date and End Date,
       and each such group is labelled accordingly as shown in the
-      "Label in selectors" column.
+      "Label in selectors" column. Datasets comprising multiple runs are
+      denoted rX.
     </p>
     <p>
       The "Yearly", "Seasonal", and "Monthly" columns indicate whether a

--- a/src/components/guidance-content/info/InformationItems.js
+++ b/src/components/guidance-content/info/InformationItems.js
@@ -76,6 +76,42 @@ const mapPolygonDrawControls = (
   </span>
 );
 
+const mapCircleMarkerControl = (
+  <span>
+    <LeafletControlContainer>
+      <div className='leaflet-draw leaflet-control'>
+        <div className='leaflet-draw-section'>
+          <div className='leaflet-draw-toolbar leaflet-bar leaflet-draw-toolbar-top'>
+            <a className='leaflet-draw-draw-circlemarker' href='#' title='Draw a circlemarker'>
+              <span className='sr-only'>Draw a circlemarker</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </LeafletControlContainer>
+    {' '}
+    (Add Outlet)
+  </span>
+);
+
+const mapDeleteControl = (
+  <span>
+    <LeafletControlContainer>
+      <div className='leaflet-draw leaflet-control'>
+        <div className='leaflet-draw-section'>
+          <div className='leaflet-draw-toolbar leaflet-bar leaflet-draw-toolbar-top'>
+            <a className='leaflet-draw-edit-remove' href='#' title='Delete layers'>
+              <span className='sr-only'>Delete layers</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </LeafletControlContainer>
+    {' '}
+    (Delete Outlet)
+  </span>
+);
+
 const mapPolygonEditControls = (
   <span>
     <LeafletControlContainer>
@@ -148,6 +184,42 @@ export const mapPanelLabel = (
         {mapPolygonImportExportControls}: Import and export polygons on the map.
         Polygons determine the extents over which spatial data averaging is
         performed.
+      </li>
+      <li>
+        {mapSettingsControl}: Select which dataset(s) are displayed and how.
+      </li>
+      <li>
+        {mapColourScaleControls}: Displays data value ⇄ colour mapping.
+      </li>
+      <li>
+        {mapAutoScaleControl}: Sets bounds of data value ⇄ colour mapping to
+        current range of data.
+      </li>
+    </ul>
+  </LabelWithInfo>
+);
+
+export const floodMapPanelLabel = (
+  <LabelWithInfo label='Data Map'>
+    <p>
+      Map displaying data selected by
+      Model, Emissions scenario, and Variable(s).
+    </p>
+    <p>
+      Summary of map tools and other controls.
+      (For details, see <Link to='/help/general'>Help</Link>.)
+    </p>
+    <ul className={css.controlsList}>
+      <li>
+        {mapZoomControls}: Zoom map in and out.
+      </li>
+      <li>
+        {mapCircleMarkerControl}: Add outlet location to map. When an outlet
+        location is added to the map a polygon will be rendered that shows
+        the upstream area contributing streamflow to the selected location.
+      </li>
+      <li>
+        {mapDeleteControl}: Remove outlet location from map.
       </li>
       <li>
         {mapSettingsControl}: Select which dataset(s) are displayed and how.

--- a/src/components/guidance-content/info/InformationItems.js
+++ b/src/components/guidance-content/info/InformationItems.js
@@ -443,6 +443,12 @@ const spatialAveragingDefn = `
   drawn on the map (or over the entire dataset if no polygon is drawn).
 `;
 
+const watershedDefn = `
+  When no outlet is selected, the data values shown are spatially
+  averaged over the domain. When an outlet is selected, data values
+  are displayed for the specified outlet location.
+`;
+
 const pointAreaDefn = `
   Data values shown in each graph are from the single grid square selected
   on the map (or averaged over the entire dataset if no point is selected).
@@ -465,6 +471,16 @@ export const graphsPanelLabel = (
       selected by Model, Emissions scenario, and Variable(s).
     </p>
     <p>{spatialAveragingDefn}</p>
+  </LabelWithInfo>
+);
+
+export const watershedGraphsPanelLabel = (
+  <LabelWithInfo label='Data Graphs'>
+    <p>
+      Graphs showing various slices and views of the dataset(s)
+      selected by Model, Emissions scenario, and Variable(s).
+    </p>
+    <p>{watershedDefn}</p>
   </LabelWithInfo>
 );
 
@@ -498,19 +514,29 @@ const ltaGraphDefn = `
   Horizontal axis indicates midpoint of multi-decade averaging period.
 `;
 
+const designValueGraphDefn = `
+  The design value graph presents values of the selected variable (design
+  flow or change factor) as estimated for each multi-decade period. There
+  is one data point per multi-decade period and the horizontal axis
+  indicates the midpoint of each period. Each data point provides the best
+  estimate and the corresponding 2.5% to 97.5% confidence interval derived
+  from bootstrap resampling.
+`;
+
 export const singleLtaTabLabel = (
   <LabelWithInfo label='Long Term Average'>
     <p>Long term average graphs for the selected variable.</p>
     <p>{ltaGraphDefn}</p>
-    <p>{spatialAveragingDefn}</p>
-    <p>{timeOfYearSelectorDefn}</p>
+    <p>{watershedDefn}</p>
+    <p>The Time of Year selector only allows Annual values (i.e. all
+    values represent the annual maximum design flow event).</p>
   </LabelWithInfo>
 );
 
 export const percentileLtaTabLabel = (
-  <LabelWithInfo label='Long Term Average'>
-    <p>Long term average graphs with percentile range for the selected variable.</p>
-    <p>{ltaGraphDefn}</p>
+  <LabelWithInfo label='Design Values'>
+    <p>Design value graphs with percentile range for the selected variable.</p>
+    <p>{designValueGraphDefn}</p>
     <p>{pointAreaDefn}</p>
     <p>{timeOfYearSelectorDefn}</p>
   </LabelWithInfo>

--- a/src/components/map-controllers/SingleMapController/SingleMapController.js
+++ b/src/components/map-controllers/SingleMapController/SingleMapController.js
@@ -49,7 +49,11 @@ import {
 } from '../map-helpers.js';
 
 import styles from '../MapController.module.css';
-import { mapPanelLabel } from '../../guidance-content/info/InformationItems';
+import { 
+  mapPanelLabel,
+  floodMapPanelLabel
+} from '../../guidance-content/info/InformationItems';
+
 import { MEVSummary } from '../../data-presentation/MEVSummary';
 
 
@@ -220,7 +224,7 @@ export default class SingleMapController extends React.Component {
           <Panel.Title>
             <Row>
               <Col lg={2}>
-                {mapPanelLabel}
+                {this.props.pointSelect ? floodMapPanelLabel : mapPanelLabel}
               </Col>
               <Col lg={10}>
                 {mapLegend}


### PR DESCRIPTION
Updates to help text for the Extreme Streamflow Portal. Resolves #448 , makes progress on #447

Have not yet completed requested updates to the Filtered Datasets Summary, Data Map, and Time of Year Selector due to these components being shared across multiple portals with different desired help texts. The way forward on this is probably to pass a string to each component telling it which portal it is being used by so it can load appropriate help. (Though completely removing the Time Of Year selector would be even better - this portal uses only annual data).