### PR TITLE
I457 mapproxy

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-REACT_APP_TILECACHE_URL=https://tiles.pacificclimate.org/tilecache/tilecache.py
+REACT_APP_TILECACHE_URL=https://services.pacificclimate.org/dev/mapproxy/service
 REACT_APP_NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30778/ncWMS/wms
 REACT_APP_CE_ENSEMBLE_NAME=ce_files
 REACT_APP_MAP_LAYER_ID_TYPE=dynamic

--- a/src/components/CanadaBaseMap/CanadaBaseMap.css
+++ b/src/components/CanadaBaseMap/CanadaBaseMap.css
@@ -1,0 +1,3 @@
+.leaftlet-container {
+    background-color: #aad3df;
+}

--- a/src/components/CanadaBaseMap/CanadaBaseMap.css
+++ b/src/components/CanadaBaseMap/CanadaBaseMap.css
@@ -1,3 +1,3 @@
-.leaftlet-container {
+.leaflet-container {
     background-color: #aad3df;
 }

--- a/src/components/CanadaBaseMap/CanadaBaseMap.js
+++ b/src/components/CanadaBaseMap/CanadaBaseMap.js
@@ -66,12 +66,15 @@ class CanadaBaseMap extends React.Component {
           maxBounds={L.latLngBounds([[40, -150], [90, -50]])}
           ref={this.props.mapRef}
         >
-          <TileLayer
+          <WMSTileLayer
             attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-            url={process.env.REACT_APP_TILECACHE_URL + '/1.0.0/na_4326_osm/{z}/{x}/{y}.png'}
-            subdomains={'abc'}
-            noWrap
-            maxZoom={12}
+            url={process.env.REACT_APP_TILECACHE_URL}
+            layers={'osm'}
+            format={'image/png'}
+            transparent={true}
+            version={'1.3.0'}
+            crs={L.CRS.EPSG4326}
+
           />
           { this.props.children }
         </Map>


### PR DESCRIPTION
This PR resolves #457, which is to replace `tilecache` with `mapproxy` in order to request basemap tiles.

Demo available at https://services.pacificclimate.org/dev/pcex/app/#/data/climo/ce_files.