### PR TITLE
Implement UI changes/fixes requested by RCI

### DIFF
--- a/src/components/DataSpecSelector/DataSpecSelector.js
+++ b/src/components/DataSpecSelector/DataSpecSelector.js
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import Selector from "../Selector/Selector";
 import _ from "lodash";
 import { datasetSelectorLabel } from "../guidance-content/info/InformationItems";
+import { hasMultiRuns } from "../map-controllers/map-helpers";
+
 /******************************************************************
  * DataSpecSelector.js - Data Specification selecting widget
  *
@@ -49,7 +51,7 @@ export default class DataSpecSelector extends React.Component {
       _.sortBy(ids, (item) => item[1]),
       (item) => item[1],
     );
-    if (ids[0][1].split(" ")[0] == ids[ids.length - 1][1].split(" ")[0]) {
+    if (!hasMultiRuns(this.props.meta)) {
       // Only one run id for this model. Remove from labels.
       ids.forEach((item) => {
         item[1] = item[1].split(" ")[1];

--- a/src/components/DataSpecSelector/DataSpecSelector.js
+++ b/src/components/DataSpecSelector/DataSpecSelector.js
@@ -49,6 +49,16 @@ export default class DataSpecSelector extends React.Component {
       _.sortBy(ids, (item) => item[1]),
       (item) => item[1],
     );
+    ids = _.sortedUniqBy(
+      _.sortBy(ids, (item) => item[1]),
+      (item) => item[1],
+    );
+    if (ids[0][1].split(" ")[0] == ids[ids.length - 1][1].split(" ")[0]) {
+      // Only one run id for this model. Remove from labels.
+      ids.forEach((item) => {
+        item[1] = item[1].split(" ")[1];
+      });
+    }
     return ids;
   }
 

--- a/src/components/DataSpecSelector/DataSpecSelector.js
+++ b/src/components/DataSpecSelector/DataSpecSelector.js
@@ -49,10 +49,6 @@ export default class DataSpecSelector extends React.Component {
       _.sortBy(ids, (item) => item[1]),
       (item) => item[1],
     );
-    ids = _.sortedUniqBy(
-      _.sortBy(ids, (item) => item[1]),
-      (item) => item[1],
-    );
     if (ids[0][1].split(" ")[0] == ids[ids.length - 1][1].split(" ")[0]) {
       // Only one run id for this model. Remove from labels.
       ids.forEach((item) => {

--- a/src/components/data-controllers/SingleDataController/SingleDataController.js
+++ b/src/components/data-controllers/SingleDataController/SingleDataController.js
@@ -41,13 +41,11 @@ import SingleLongTermAveragesGraph from "../../graphs/SingleLongTermAveragesGrap
 import SingleContextGraph from "../../graphs/SingleContextGraph";
 import SingleTimeSeriesGraph from "../../graphs/SingleTimeSeriesGraph";
 import AnomalyAnnualCycleGraph from "../../graphs/AnomalyAnnualCycleGraph";
-import SingleTimeSliceGraph from "../../graphs/SingleTimeSliceGraph";
 import {
   singleAnnualCycleTabLabel,
   changeFromBaselineTabLabel,
   singleLtaTabLabel,
   modelContextTabLabel,
-  snapshotTabLabel,
   timeSeriesTabLabel,
   graphsPanelLabel,
 } from "../../guidance-content/info/InformationItems";
@@ -91,7 +89,6 @@ export default class SingleDataController extends React.Component {
       { title: singleLtaTabLabel, graph: SingleLongTermAveragesGraph },
       { title: modelContextTabLabel, graph: SingleContextGraph },
       { title: changeFromBaselineTabLabel, graph: AnomalyAnnualCycleGraph },
-      { title: snapshotTabLabel, graph: SingleTimeSliceGraph },
     ],
     notMym: [{ title: timeSeriesTabLabel, graph: SingleTimeSeriesGraph }],
   };

--- a/src/components/data-presentation/FilteredDatasetsSummary/FilteredDatasetsSummary.js
+++ b/src/components/data-presentation/FilteredDatasetsSummary/FilteredDatasetsSummary.js
@@ -25,6 +25,13 @@ export default class FilteredDatasetsSummary extends React.Component {
     dual: false,
   };
 
+  removeSingleRun = (keyedData, meta) => {
+    // Remove ensemble member from keyedData if there is only one run in the metadata
+    if (keyedData && meta.length && !hasMultiRuns(meta)) {
+      keyedData.forEach((el) => (el.key = el.key.split(" ")[1]));
+    }
+  };
+
   render() {
     const metaToKeyedData = (m) => ({
       key: `${m.ensemble_member} ${m.start_date}-${m.end_date}`,
@@ -46,20 +53,11 @@ export default class FilteredDatasetsSummary extends React.Component {
     };
 
     const keyedData = this.props.meta.map(metaToKeyedData);
-    if (this.props.meta.length && !hasMultiRuns(this.props.meta)) {
-      // Remove run in cases where there is only one run
-      keyedData.forEach((el) => (el.key = el.key.split(" ")[1]));
-    }
+    this.removeSingleRun(keyedData, this.props.meta);
 
     const keyedComparandData =
       this.props.comparandMeta && this.props.comparandMeta.map(metaToKeyedData);
-    if (
-      keyedComparandData &&
-      this.props.comparandMeta.length &&
-      !hasMultiRuns(this.props.comparandMeta)
-    ) {
-      keyedComparandData.forEach((el) => (el.key = el.key.split(" ")[1]));
-    }
+    this.removeSingleRun(keyedComparandData, this.props.comparandMeta);
 
     const dataGroupedByKey = _.groupBy(keyedData, "key");
     const comparandDataGroupedByKey =

--- a/src/components/data-presentation/FilteredDatasetsSummary/FilteredDatasetsSummary.js
+++ b/src/components/data-presentation/FilteredDatasetsSummary/FilteredDatasetsSummary.js
@@ -5,6 +5,7 @@ import Accordion from "../../guidance-tools/Accordion";
 import { BootstrapTable, TableHeaderColumn } from "react-bootstrap-table";
 import { MEVSummary } from "../MEVSummary/MEVSummary";
 import { filteredDatasetSummaryPanelLabel } from "../../guidance-content/info/InformationItems";
+import { hasMultiRuns } from "../../map-controllers/map-helpers";
 
 import _ from "lodash";
 import { HalfWidthCol } from "../../layout/rb-derived-components";
@@ -45,8 +46,20 @@ export default class FilteredDatasetsSummary extends React.Component {
     };
 
     const keyedData = this.props.meta.map(metaToKeyedData);
+    if (this.props.meta.length && !hasMultiRuns(this.props.meta)) {
+      // Remove run in cases where there is only one run
+      keyedData.forEach((el) => (el.key = el.key.split(" ")[1]));
+    }
+
     const keyedComparandData =
       this.props.comparandMeta && this.props.comparandMeta.map(metaToKeyedData);
+    if (
+      keyedComparandData &&
+      this.props.comparandMeta.length &&
+      !hasMultiRuns(this.props.comparandMeta)
+    ) {
+      keyedComparandData.forEach((el) => (el.key = el.key.split(" ")[1]));
+    }
 
     const dataGroupedByKey = _.groupBy(keyedData, "key");
     const comparandDataGroupedByKey =
@@ -72,7 +85,7 @@ export default class FilteredDatasetsSummary extends React.Component {
           End Date
         </TableHeaderColumn>
         <TableHeaderColumn dataField="yearly" width={"10%"}>
-          Yearly?
+          Annual?
         </TableHeaderColumn>
         <TableHeaderColumn dataField="seasonal" width={"10%"}>
           Seasonal?

--- a/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
+++ b/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
@@ -16,7 +16,10 @@ import {
   loadingDataGraphSpec,
 } from "../graph-helpers";
 import { datasetSelectorLabel } from "../../guidance-content/info/InformationItems";
-import { representativeValue } from "../../../core/selectors";
+import {
+  representativeValue,
+  findStartEndDates,
+} from "../../../core/selectors";
 import { setNamedState } from "../../../core/react-component-utils";
 import styles from "./AnnualCycleGraph.module.css";
 
@@ -51,6 +54,10 @@ export default class AnnualCycleGraph extends React.Component {
     // to a graph spec.
     // A different function is passed by different clients to specialize
     // this general component to particular cases (single vs. dual controller).
+    isAnomalyAnnualCycle: PropTypes.bool,
+    // `isAnomalyAnnualCycle` states if a particular AnnualCycleGraph is an
+    // AnomalyAnnualCycleGraph. If so, the default selected dataspec is the one
+    // for 1981-2010 (request from RCI).
   };
 
   // Lifecycle hooks
@@ -164,6 +171,9 @@ export default class AnnualCycleGraph extends React.Component {
   // User event handlers
 
   handleChangeDataSpec = setNamedState(this, "dataSpec");
+  replaceInvalidDataSpec = this.props.isAnomalyAnnualCycle
+    ? findStartEndDates("1981", "2010")
+    : undefined;
 
   exportData(format) {
     exportDataToWorksheet(
@@ -217,6 +227,7 @@ export default class AnnualCycleGraph extends React.Component {
               value={this.state.dataSpec}
               onChange={this.handleChangeDataSpec}
               className={styles.selector}
+              replaceInvalidValue={this.replaceInvalidDataSpec}
             />
           </Col>
           <Col lg={6} md={6} sm={6}>

--- a/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
+++ b/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.js
@@ -15,7 +15,10 @@ import {
   errorMessage,
   loadingDataGraphSpec,
 } from "../graph-helpers";
-import { datasetSelectorLabel } from "../../guidance-content/info/InformationItems";
+import {
+  datasetSelectorLabel,
+  baselineSelectorLabel,
+} from "../../guidance-content/info/InformationItems";
 import {
   representativeValue,
   findStartEndDates,
@@ -174,6 +177,9 @@ export default class AnnualCycleGraph extends React.Component {
   replaceInvalidDataSpec = this.props.isAnomalyAnnualCycle
     ? findStartEndDates("1981", "2010")
     : undefined;
+  selectorLabel = this.props.isAnomalyAnnualCycle
+    ? baselineSelectorLabel
+    : datasetSelectorLabel;
 
   exportData(format) {
     exportDataToWorksheet(
@@ -220,7 +226,7 @@ export default class AnnualCycleGraph extends React.Component {
         <Row>
           <Col lg={6} md={6} sm={6}>
             <ControlLabel className={styles.selector_label}>
-              {datasetSelectorLabel}
+              {this.selectorLabel}
             </ControlLabel>
             <DataspecSelector
               bases={this.props.meta}

--- a/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.module.css
+++ b/src/components/graphs/AnnualCycleGraph/AnnualCycleGraph.module.css
@@ -4,5 +4,5 @@
 
 .selector {
   display: inline-block;
-  width: 80%;
+  width: 75%;
 }

--- a/src/components/graphs/AnomalyAnnualCycleGraph.js
+++ b/src/components/graphs/AnomalyAnnualCycleGraph.js
@@ -48,7 +48,9 @@ export default function AnomalyAnnualCycleGraph(props) {
     //used (usually 1981 - 2010). if there are two equally recent datasets
     //(such as 1971-2000 and 1981-2000) for some reason, one will be arbitrarily selected.
     let historicalMetadatas = getDateRangeMetadatas(undefined, currentYear());
-    const end_date = _.maxBy(_.map(historicalMetadatas, "end_date"), (v) => +v);
+    const end_date = _.isUndefined(dataSpec)
+      ? _.maxBy(_.map(historicalMetadatas, "end_date"), (v) => +v)
+      : dataSpec.end_date;
     historicalMetadatas = _.filter(historicalMetadatas, { end_date });
 
     //pick the highest-resolution dataset available for that climatology
@@ -57,14 +59,11 @@ export default function AnomalyAnnualCycleGraph(props) {
       _.find(historicalMetadatas, { timescale: "seasonal" }) ||
       _.find(historicalMetadatas, { timescale: "yearly" });
 
-    //return the baseline dataset and every same-resolution dataset that starts after it.
+    //return the baseline dataset and every same-resolution dataset that starts after it starting from 2010.
     if (_.isUndefined(baselineMetadata)) {
       return [];
     } else {
-      let anomalyMetadatas = getDateRangeMetadatas(
-        baselineMetadata.start_date,
-        undefined,
-      );
+      let anomalyMetadatas = getDateRangeMetadatas(2009, undefined);
       anomalyMetadatas = _.filter(anomalyMetadatas, {
         timescale: baselineMetadata.timescale,
       });
@@ -98,6 +97,7 @@ export default function AnomalyAnnualCycleGraph(props) {
       meta={getDateRangeMetadatas(undefined, currentYear())}
       getMetadata={getMetadata}
       dataToGraphSpec={dataToGraphSpec}
+      isAnomalyAnnualCycle={true}
     />
   );
 }

--- a/src/components/graphs/SingleAnnualCycleGraph.js
+++ b/src/components/graphs/SingleAnnualCycleGraph.js
@@ -45,7 +45,7 @@ export default function SingleAnnualCycleGraph(props) {
 
     // arrange the graph so that the highest-resolution data is most visible.
     function rankByTimeResolution(series) {
-      var resolutions = ["Yearly", "Seasonal", "Monthly"];
+      var resolutions = ["Annual", "Seasonal", "Monthly"];
       for (let i = 0; i < 3; i++) {
         if (series[0].search(resolutions[i]) !== -1) {
           return i;

--- a/src/components/graphs/SingleContextGraph.js
+++ b/src/components/graphs/SingleContextGraph.js
@@ -58,9 +58,8 @@ export default function SingleContextGraph(props) {
     let graph = dataToLongTermAverageGraph(data, meta);
     graph = emphasizeSeries(graph, selectedModelId);
 
-    //simplify graph by turning off tooltip and missing data gaps
+    // Simplify graph by connecting missing data gaps
     graph.line.connectNull = true;
-    graph.tooltip = { show: false };
     return graph;
   }
 

--- a/src/components/graphs/graph-helpers.js
+++ b/src/components/graphs/graph-helpers.js
@@ -4,6 +4,7 @@ import {
   fadeSeriesByRank,
   hideSeriesInLegend,
   sortSeriesByRank,
+  hideSeriesInTooltip,
 } from "../../core/chart-formatters";
 import { caseInsensitiveStringSearch } from "../../core/util";
 
@@ -177,6 +178,7 @@ function emphasizeSeries(graph, seriesName) {
   graph = assignColoursByGroup(graph, makeSegmentor(1, 0));
   graph = fadeSeriesByRank(graph, makeSegmentor(1, 0.35));
   graph = hideSeriesInLegend(graph, makeSegmentor(false, true));
+  graph = hideSeriesInTooltip(graph, makeSegmentor(false, true));
   graph = sortSeriesByRank(graph, makeSegmentor(1, 0));
 
   return graph;

--- a/src/components/guidance-content/info/InformationItems.js
+++ b/src/components/guidance-content/info/InformationItems.js
@@ -492,6 +492,25 @@ export const datasetSelectorLabel = (
   </LabelWithInfo>
 );
 
+export const baselineSelectorLabel = (
+  <LabelWithInfo label="Baseline">
+    <p>
+      Select a single baseline dataset to display from all of those that match
+      the Model, Emissions Scenario, Variable, and historical averaging period
+      selected.
+    </p>
+    <p>
+      On the graph, the datasets with the same Model, Emissions Scenario, and
+      Variable for all available future periods will be compared with this
+      selected baseline.
+    </p>
+    <p>
+      Datasets are identified by a combination of model run id (e.g.,{" "}
+      <code>r1i1p1</code>) and averaging period (e.g., <code>1961-1990</code>).
+    </p>
+  </LabelWithInfo>
+);
+
 export const timeOfYearSelectorLabel = (
   <LabelWithInfo label="Time of Year">
     <p>

--- a/src/components/guidance-content/info/InformationItems.js
+++ b/src/components/guidance-content/info/InformationItems.js
@@ -457,7 +457,7 @@ export const filteredDatasetSummaryPanelLabel = (
       comprising multiple runs are denoted rX.
     </p>
     <p>
-      The "Yearly", "Seasonal", and "Monthly" columns indicate whether a dataset
+      The "Annual", "Seasonal", and "Monthly" columns indicate whether a dataset
       with that timescale (averaging period) is available in the group.
     </p>
   </LabelWithInfo>
@@ -590,7 +590,7 @@ export const watershedGraphsPanelLabel = (
 export const singleAnnualCycleTabLabel = (
   <LabelWithInfo label="Annual Cycle">
     <p>
-      Annual cycle graph showing the yearly, seasonal, and monthly mean values
+      Annual cycle graph showing the annual, seasonal, and monthly mean values
       of the selected variable.
     </p>
     <p>{annualCycleGraphDefn}</p>
@@ -601,7 +601,7 @@ export const singleAnnualCycleTabLabel = (
 
 export const dualAnnualCycleTabLabel = (
   <LabelWithInfo label="Annual Cycle">
-    Annual cycle graphs showing the yearly, seasonal, and monthly mean values of
+    Annual cycle graphs showing the annual, seasonal, and monthly mean values of
     the two selected variables (if different).
     <p>{annualCycleGraphDefn}</p>
     <p>{spatialAveragingDefn}</p>

--- a/src/components/map-controllers/DualMapController/DualMapController.js
+++ b/src/components/map-controllers/DualMapController/DualMapController.js
@@ -44,6 +44,7 @@ import {
   updateLayerSimpleState,
   updateLayerTime,
   getDatasetIdentifiers,
+  hasMultiRuns,
 } from "../map-helpers.js";
 
 import styles from "../MapController.module.css";
@@ -69,6 +70,7 @@ export default class DualMapController extends React.Component {
       run: undefined,
       start_date: undefined,
       end_date: undefined,
+      has_multi_runs: false,
 
       raster: {
         variableId: undefined, // formerly 'variable'
@@ -128,6 +130,7 @@ export default class DualMapController extends React.Component {
     // (aside from variable_id) display the same dataspec.
 
     const { start_date, end_date, ensemble_member } = dataSpec;
+    const has_multi_runs = hasMultiRuns(props.meta);
 
     const rasterScalarParams = scalarParams.bind(null, props.variable_id);
     const rasterParamsPromise = getTimeParametersPromise(dataSpec, props.meta)
@@ -173,6 +176,7 @@ export default class DualMapController extends React.Component {
         run: ensemble_member,
         start_date,
         end_date,
+        has_multi_runs,
         raster: rasterParams,
         isoline: isolineParams,
       }));

--- a/src/components/map-controllers/PrecipMapController/PrecipMapController.js
+++ b/src/components/map-controllers/PrecipMapController/PrecipMapController.js
@@ -45,6 +45,7 @@ import {
   scalarParams,
   selectRasterPalette,
   getTimeParametersPromise,
+  hasMultiRuns,
 } from "../map-helpers.js";
 
 import styles from "../MapController.module.css";
@@ -70,6 +71,7 @@ export default class PrecipMapController extends React.Component {
       run: undefined,
       start_date: undefined,
       end_date: undefined,
+      has_multi_runs: false,
 
       raster: {
         variableId: undefined, // formerly 'variable'
@@ -114,6 +116,7 @@ export default class PrecipMapController extends React.Component {
     // timestamp is determined at render time and passed to the viewer component.
 
     const { start_date, end_date, ensemble_member } = dataSpec;
+    const has_multi_runs = hasMultiRuns(props.meta);
 
     const rasterScalarParams = scalarParams.bind(null, props.variable_id);
     const rasterParamsPromise = getTimeParametersPromise(dataSpec, props.meta)
@@ -147,6 +150,7 @@ export default class PrecipMapController extends React.Component {
           run: ensemble_member,
           start_date,
           end_date,
+          has_multi_runs,
           raster: rasterParams,
           annotated: annotatedParams,
         }));

--- a/src/components/map-controllers/SingleMapController/SingleMapController.js
+++ b/src/components/map-controllers/SingleMapController/SingleMapController.js
@@ -45,6 +45,7 @@ import {
   getTimeParametersPromise,
   scalarParams,
   getDatasetIdentifiers,
+  hasMultiRuns,
 } from "../map-helpers.js";
 
 import styles from "../MapController.module.css";
@@ -73,6 +74,7 @@ export default class SingleMapController extends React.Component {
       run: undefined,
       start_date: undefined,
       end_date: undefined,
+      has_multi_runs: false,
 
       raster: {
         variableId: undefined, // formerly 'variable'
@@ -102,6 +104,7 @@ export default class SingleMapController extends React.Component {
     // is passed to the viewer component.
 
     const { start_date, end_date, ensemble_member } = dataSpec;
+    const has_multi_runs = hasMultiRuns(props.meta);
 
     const rasterScalarParams = scalarParams.bind(null, props.variable_id);
     const rasterParamsPromise = getTimeParametersPromise(dataSpec, props.meta)
@@ -120,6 +123,7 @@ export default class SingleMapController extends React.Component {
         run: ensemble_member,
         start_date,
         end_date,
+        has_multi_runs,
         raster: params,
       }));
     });

--- a/src/components/map-controllers/map-helpers.js
+++ b/src/components/map-controllers/map-helpers.js
@@ -195,7 +195,9 @@ export function hasMultiRuns(meta) {
     (item) => item,
   );
   // Check if first run is the same as last run
-  return ids[0].split(" ")[0] != ids[ids.length - 1].split(" ")[0];
+  const first_run_id = ids[0].split(" ")[0];
+  const last_run_id = ids[ids.length - 1].split(" ")[0];
+  return first_run_id !== last_run_id;
 }
 
 export function updateLayerSimpleState(layerType, name, value) {

--- a/src/components/map-controllers/map-helpers.js
+++ b/src/components/map-controllers/map-helpers.js
@@ -176,9 +176,26 @@ export function selectIsolinePalette(params) {
  **************************************************************************/
 
 // TODO: https://github.com/pacificclimate/climate-explorer-frontend/issues/118
-export function currentDataSpec({ run, start_date, end_date }) {
-  // Return encoding of currently selected dataspec
-  return `${run} ${start_date}-${end_date}`;
+export function currentDataSpec({ run, start_date, end_date, has_multi_runs }) {
+  // Return encoding of currently selected dataspec.
+  // If the model that this dataspec comes from only has one run, then only the start_date-end_date
+  // portion is displayed in labels
+  return has_multi_runs
+    ? `${run} ${start_date}-${end_date}`
+    : `${start_date}-${end_date}`;
+}
+
+export function hasMultiRuns(meta) {
+  // Check if there are multiple runs making up the datasets for the given model (e.g. CMIP5 MIROC5 has r1i1p1 and r3i1p1).
+  let ids = meta.map(
+    (el) => `${el.ensemble_member} ${el.start_date}-${el.end_date}`,
+  );
+  ids = _.sortedUniqBy(
+    _.sortBy(ids, (item) => item),
+    (item) => item,
+  );
+  // Check if first run is the same as last run
+  return ids[0].split(" ")[0] != ids[ids.length - 1].split(" ")[0];
 }
 
 export function updateLayerSimpleState(layerType, name, value) {

--- a/src/core/__tests__/chart-formatter-tests.js
+++ b/src/core/__tests__/chart-formatter-tests.js
@@ -123,7 +123,7 @@ describe("sortSeriesByRank", function () {
     mockAPI.annualTasmaxTimeseries,
   );
   const rankByTimeResolution = function (series) {
-    const resolutions = ["Yearly", "Seasonal", "Monthly"];
+    const resolutions = ["Annual", "Seasonal", "Monthly"];
     for (let i = 0; i < 3; i++) {
       if (series[0].search(resolutions[i]) != -1) {
         return i;
@@ -132,7 +132,7 @@ describe("sortSeriesByRank", function () {
   };
   it("orders series by ranking", function () {
     const ranked = cf.sortSeriesByRank(graph, rankByTimeResolution);
-    expect(ranked.data.columns[0][0]).toBe("Yearly Mean");
+    expect(ranked.data.columns[0][0]).toBe("Annual Mean");
     expect(ranked.data.columns[1][0]).toBe("Seasonal Mean");
     expect(ranked.data.columns[2][0]).toBe("Monthly Mean");
   });
@@ -153,7 +153,7 @@ describe("hideSeriesInToolTip", function () {
     };
     graph = cf.hideSeriesInTooltip(graph, hideAll);
     formatFunction = graph.tooltip.format.value;
-    expect(formatFunction(10, 19, "Yearly Mean")).toBeUndefined();
+    expect(formatFunction(10, 19, "Annual Mean")).toBeUndefined();
   });
   it("retains data series in the tooltip", function () {
     const showAll = function (series) {

--- a/src/core/__tests__/chart-generator-tests.js
+++ b/src/core/__tests__/chart-generator-tests.js
@@ -248,7 +248,7 @@ describe("shortestUniqueTimeseriesNamingFunction", function () {
     ]);
     expect(nameFunction(metadata[0])).toEqual("Monthly Mean");
     expect(nameFunction(metadata[1])).toEqual("Seasonal Mean");
-    expect(nameFunction(metadata[2])).toEqual("Yearly Mean");
+    expect(nameFunction(metadata[2])).toEqual("Annual Mean");
   });
   it("names series by variable", function () {
     const nameFunction = shortestUniqueTimeseriesNamingFunction(metadata, [

--- a/src/core/__tests__/chart-transformer-tests.js
+++ b/src/core/__tests__/chart-transformer-tests.js
@@ -177,7 +177,7 @@ describe("makeTimeSliceGraph", function () {
   });
   it("generates a yearly timeslice", function () {
     let graph = cg.dataToLongTermAverageGraph([mockAPI.tasmaxData]);
-    const timeSliceGraph = ct.makeTimeSliceGraph("1997-01-15", graph);
+    const timeSliceGraph = ct.makeTimeSliceGraph("1990-01-01", graph);
     for (let c of timeSliceGraph.data.columns) {
       expect(c.length).toBe(2);
     }

--- a/src/core/__tests__/export-test.js
+++ b/src/core/__tests__/export-test.js
@@ -134,7 +134,7 @@ describe("generateDataCellsFromC3Graph", function () {
     expect(validate.isRectangularArray(cells, 4, 14)).toBe(true);
     expect(cells[1][0]).toBe("Monthly Mean");
     expect(cells[2][0]).toBe("Seasonal Mean");
-    expect(cells[3][0]).toBe("Yearly Mean");
+    expect(cells[3][0]).toBe("Annual Mean");
     //spot check a couple representative values
     expect(cells[3][6]).toBe("-2.67");
     expect(cells[2][10]).toBe("-1.36");

--- a/src/core/chart-formatters.js
+++ b/src/core/chart-formatters.js
@@ -98,7 +98,11 @@ function assignColoursByGroup(
         }
         index = categories.length - 1;
       }
-      colors[seriesName] = colourList[index];
+      if (seriesName.includes("PCIC12")) {
+        colors[seriesName] = "#000000";
+      } else {
+        colors[seriesName] = colourList[index];
+      }
     }
   }
   graph.data.colors = colors;
@@ -130,7 +134,11 @@ function fadeSeriesByRank(graph, ranker) {
   for (let column of graph.data.columns) {
     const seriesName = column[0];
     if (seriesName !== "x") {
-      rankDictionary[seriesName] = ranker(column);
+      if (seriesName.includes("PCIC12")) {
+        rankDictionary[seriesName] = 1;
+      } else {
+        rankDictionary[seriesName] = ranker(column);
+      }
     }
   }
 
@@ -168,7 +176,11 @@ function hideSeriesInLegend(graph, predicate) {
 
   _.each(graph.data.columns, (column) => {
     const seriesName = column[0];
-    if (seriesName !== "x" && predicate(column)) {
+    if (
+      seriesName !== "x" &&
+      !seriesName.includes("PCIC12") &&
+      predicate(column)
+    ) {
       hiddenSeries.push(seriesName);
     }
   });

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -24,7 +24,7 @@ import _ from "lodash";
 import {
   capitalizeWords,
   caseInsensitiveStringSearch,
-  extendedDateToBasicDate,
+  dateToPeriod,
   getDataUnits,
   getVariableOptions,
   nestedAttributeIsDefined,
@@ -606,12 +606,12 @@ const missingVariableName = "defaultVariable";
 
 /*
  * Helper constant for dataToLongTermAverageGraph: Format object
- * for a timeseries X axis.
+ * for a timeseries X axis labelled by the decadal period.
  */
-const timeseriesXAxis = {
+const periodXAxis = {
   type: "timeseries",
   tick: {
-    format: "%Y-%m-%d",
+    format: "%Ys",
   },
 };
 
@@ -775,7 +775,7 @@ function dataToLongTermAverageGraph(data, contexts = []) {
   // get the list of all timestamps and add them to the chart
   // (C3 requires x-axis timestamps be added as a data column)
   const timestamps = getAllTimestamps(data);
-  c3Data.columns.push(["x"].concat(_.map(timestamps, extendedDateToBasicDate)));
+  c3Data.columns.push(["x"].concat(_.map(timestamps, dateToPeriod)));
   c3Data.x = "x";
 
   // add each API call to the chart
@@ -812,7 +812,7 @@ function dataToLongTermAverageGraph(data, contexts = []) {
 
   // whole-graph display options: axis formatting and tooltip behaviour
   let c3Axis = {};
-  c3Axis.x = timeseriesXAxis;
+  c3Axis.x = periodXAxis;
 
   // The long term average graph doesn't require every series to have the exact
   // same timestamps, since it's comparing long term trends anyway. Allow C3
@@ -901,7 +901,7 @@ function timeseriesToTimeseriesGraph(metadata, ...data) {
 
   // get list of all timestamps
   const timestamps = getAllTimestamps(data);
-  c3Data.columns.push(["x"].concat(_.map(timestamps, extendedDateToBasicDate)));
+  c3Data.columns.push(["x"].concat(_.map(timestamps, dateToPeriod)));
   c3Data.x = "x";
 
   // Add each timeseries to the graph
@@ -935,7 +935,7 @@ function timeseriesToTimeseriesGraph(metadata, ...data) {
 
   // whole-graph display options: axis formatting and tooltip behaviour
   let c3Axis = {};
-  c3Axis.x = timeseriesXAxis;
+  c3Axis.x = periodXAxis;
   const c3Subchart = { show: true, size: { height: 20 } };
 
   // instructs c3 to connect series across gaps where a timeseries is missing

--- a/src/core/chart-generators.js
+++ b/src/core/chart-generators.js
@@ -436,7 +436,9 @@ function shortestUniqueTimeseriesNamingFunction(metadata, data) {
   // only one timeseries being graphed, simple label.
   if (data.length === 1) {
     return function (m) {
-      return capitalizeWords(`${m.timescale} mean`);
+      return m.timescale === "yearly"
+        ? "Annual Mean"
+        : capitalizeWords(`${m.timescale} mean`);
     };
   }
 
@@ -493,7 +495,7 @@ function shortestUniqueTimeseriesNamingFunction(metadata, data) {
       name = name.concat(`${m[v]} `);
     }
     name = name.concat(basenameByVariable[m.variable_id]);
-    return capitalizeWords(name);
+    return capitalizeWords(name.replace("yearly", "annual"));
   };
 }
 

--- a/src/core/chart-transformers.js
+++ b/src/core/chart-transformers.js
@@ -432,7 +432,6 @@ function makeTimeSliceGraph(timestamp, graph) {
     categories: [date.getFullYear()],
   };
   graph.data.x = undefined;
-  graph.tooltip = { show: false };
 
   return graph;
 }

--- a/src/core/selectors.js
+++ b/src/core/selectors.js
@@ -46,6 +46,10 @@ export const findVariableMatching = (match) => (options) => {
   );
 };
 
+export const findStartEndDates = (start_date, end_date) => (options) =>
+  find({ value: { representative: { start_date, end_date } } })(options) ||
+  fallback(options);
+
 // Extract a value from the representative for a named option in source.
 export const representativeValue = (optionName, valueName) =>
   get(compact([optionName, "value", "representative", valueName]));

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -461,6 +461,17 @@ export function extendedDateToBasicDate(timestamp) {
 }
 
 /*
+ * Returns the 30-year decadal period from the timestamp (e.g. "1997-07-02" and "1996-07-02"
+ * return "1990-01-01". This prevents the x-axis dates where models differ by one year from overlapping.
+ * The extra "-01-01" is used so that c3 can parse it as a date and the x-axis can properly format the label.
+ */
+export function dateToPeriod(timestamp) {
+  const year = new Date(timestamp).getFullYear();
+  const period = (Math.floor(year / 10) * 10).toString();
+  return period + "-01-01";
+}
+
+/*
  * Produces a human-readable string describing the time of year of displayed data.
  * Used by MapController, since ncWMS doesn't provide any human-friendly time info.
  */


### PR DESCRIPTION
This PR contains the UI changes/fixes RCI requested while experimenting with the MBCn climatologies page. These are the changes:

- Replaces instances of `Yearly` with `Annual`
- Represents the `PCIC12` dataset with a thick black line in the `Model Context` graph regardless of the selected model
- Shows the graph tooltip for the selected model in the `Model Context` graph.
- Instead of using exact dates in the x-axis labels of the `Long Term Average` and `Model Context` graphs, they use decadal periods (e.g. `2020s` instead of `2025-07-02`). This is because for some periods (like 1981-2010), some models have `1996-07-02` as their middle date while others have `1997-07-02`, causing the dates to overlap in the `Model Context` graph. This change ensures that the label is the same for all models in each period.
- Removes `Snapshot` graph since the information is already in the `Model Context` graph
- In the `Filtered Datasets Summary` and `Data Map`, only includes the `run_id` if the selected model has multiple runs (e.g. MIROC5 has `r1i1p1` and `r3i1p1`)
- Enables the historical baseline in the `Change from Baseline` graph to be selectable by the dropdown, using 1981-2010 as the default (also resolves #343)

Demo available at https://services.pacificclimate.org/dev/pcex/app/#/data/climo/ce_files